### PR TITLE
feat(fitment): persona-aware fitment assessment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Persona-aware fitment assessment** — fitment tooling now accepts an optional `persona` parameter that flows cleanly through every layer (HTTP request → `JobAnalysisService` → `tools.fitment` / `tools.job_queue`). When set, the named persona's prompt block is prepended either to the returned context pack (for `assess_job_fitment` / `evaluate_queued_job` / `/jobs/evaluate`) or to the LLM system prompt (for `run_job_assessment`). Same JD against `faang_technical`, `executive_polish`, and `startup_founder` now produces materially different lenses on the same candidate. Unknown persona names emit a non-fatal warning instead of crashing. New `tests/test_fitment.py` (11 tests) covers persona injection across the tool, service, and route layers.
+
 ### Planned
 
 - **`POST /jobs/ingest`** — single-input job intake for mobile. Body is `{jd, source?}` only; server-side parses `company` and `role` from the JD (heuristics first, LLM-assisted fallback), runs queue + evaluate in one call, and returns the standard evaluate response plus a `parsed: {company, role, confidence}` block. On low confidence, response sets `needs_confirmation: true` so the client can prompt for the missing field(s). Motivation: iPad Shortcuts "Ask for Input" placeholder text is visually indistinguishable from a typed value, leading users to submit literal placeholder strings; share-sheet → single-blob ingestion sidesteps the prompt-per-field UX entirely.

--- a/services/job_analysis_service.py
+++ b/services/job_analysis_service.py
@@ -50,6 +50,7 @@ class JobAnalysisService:
         role: str,
         job_description: str,
         source: str = "",
+        persona: str | None = None,
         on_progress: Optional[ProgressCallback] = None,
     ) -> AnalysisResult:
         """Queue a job and run fitment evaluation in one call.
@@ -69,6 +70,8 @@ class JobAnalysisService:
             role:            Target role title.
             job_description: Full JD text.
             source:          Optional source label (e.g. "linkedin", "referral").
+            persona:         Optional persona name to bias the fitment lens
+                             (e.g. 'faang_technical', 'executive_polish').
             on_progress:     Optional callback for streaming progress events.
 
         Returns:
@@ -84,9 +87,10 @@ class JobAnalysisService:
               "Job already in queue" if already_queued else "Job added to queue",
               {"already_queued": already_queued})
 
-        _emit(on_progress, "evaluating", "Running fitment assessment")
+        _emit(on_progress, "evaluating", "Running fitment assessment",
+              {"persona": persona or ""})
 
-        fitment_result = _job_queue.evaluate_queued_job(company, role)
+        fitment_result = _job_queue.evaluate_queued_job(company, role, persona or "")
 
         # evaluate_queued_job returns the fitment context on success, or an
         # informational message when the job is already decided / not found.
@@ -120,6 +124,7 @@ class JobAnalysisService:
         company: str,
         role: str,
         job_description: str,
+        persona: str | None = None,
         on_progress: Optional[ProgressCallback] = None,
     ) -> str:
         """Standalone fitment assessment (no queue interaction).
@@ -131,15 +136,16 @@ class JobAnalysisService:
             company:         Target company name.
             role:            Target role title.
             job_description: Full JD text.
+            persona:         Optional persona name to bias the fitment lens.
             on_progress:     Optional progress callback.
 
         Returns:
             The fitment context package text.
         """
         _emit(on_progress, "assessing", f"Assessing fitment for {role} @ {company}",
-              {"company": company, "role": role})
+              {"company": company, "role": role, "persona": persona or ""})
 
-        result = _fitment.assess_job_fitment(company, role, job_description)
+        result = _fitment.assess_job_fitment(company, role, job_description, persona=persona or "")
 
         _emit(on_progress, "complete", "Fitment assessment finished")
         return result

--- a/tests/test_fitment.py
+++ b/tests/test_fitment.py
@@ -1,0 +1,137 @@
+"""
+Tests for persona-aware fitment tooling.
+
+Covers:
+  assess_job_fitment(persona=...)  ... persona block injected
+  evaluate_queued_job(persona=...) ... persona threaded through
+  run_job_assessment(persona=...)  ... persona prepended to system prompt
+  JobAnalysisService.evaluate(persona=...) ... orchestrator pass-through
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import server as srv
+from services import JobAnalysisService
+from services.persona_service import PersonaService
+
+
+JD = "We need a senior engineer with React, Node, and AWS."
+
+
+class TestAssessJobFitmentPersona:
+    def test_no_persona_omits_lens_section(self, isolated_server):
+        out = srv.assess_job_fitment("Stripe", "Staff Engineer", JD)
+        assert "PERSONA LENS" not in out
+        assert "JOB DESCRIPTION" in out
+
+    def test_persona_injects_lens_block(self, isolated_server):
+        out = srv.assess_job_fitment("Stripe", "Staff Engineer", JD, persona="faang_technical")
+        assert "PERSONA LENS" in out
+        expected = PersonaService.get("faang_technical").to_prompt_block()
+        assert expected in out
+
+    def test_unknown_persona_emits_warning_not_crash(self, isolated_server):
+        out = srv.assess_job_fitment("Stripe", "Staff Engineer", JD, persona="nonexistent")
+        assert "PERSONA LENS" in out
+        assert "warning" in out.lower()
+
+
+class TestEvaluateQueuedJobPersona:
+    def test_persona_passed_to_assess(self, isolated_server):
+        srv.queue_job("Stripe", "Staff Engineer", JD)
+        out = srv.evaluate_queued_job("Stripe", "Staff Engineer", persona="executive_polish")
+        assert "PERSONA LENS" in out
+        expected = PersonaService.get("executive_polish").to_prompt_block()
+        assert expected in out
+
+    def test_default_no_persona(self, isolated_server):
+        srv.queue_job("Stripe", "Staff Engineer", JD)
+        out = srv.evaluate_queued_job("Stripe", "Staff Engineer")
+        assert "PERSONA LENS" not in out
+
+
+class TestRunJobAssessmentPersona:
+    def test_persona_prepended_to_system_prompt(self, isolated_server, monkeypatch):
+        """When OpenAI is configured, persona block must be prepended to the system prompt."""
+        from lib import config
+        monkeypatch.setitem(config._cfg, "openai_api_key", "sk-real-test-key")
+
+        fake_client = MagicMock()
+        fake_response = MagicMock()
+        fake_response.choices = [MagicMock(message=MagicMock(content="FITMENT SCORE: 9/10"))]
+        fake_response.usage = MagicMock(prompt_tokens=100, completion_tokens=50)
+        fake_client.chat.completions.create.return_value = fake_response
+
+        with patch("openai.OpenAI", return_value=fake_client):
+            out = srv.run_job_assessment(
+                "Stripe", "Staff Engineer", JD,
+                persona="faang_technical", auto_save=False,
+            )
+
+        call_kwargs = fake_client.chat.completions.create.call_args.kwargs
+        system_msg = call_kwargs["messages"][0]["content"]
+        expected_block = PersonaService.get("faang_technical").to_prompt_block()
+        assert expected_block in system_msg
+        assert "FITMENT SCORE" in system_msg  # original system text still present
+        assert "persona: faang_technical" in out
+
+    def test_no_persona_uses_bare_system_prompt(self, isolated_server, monkeypatch):
+        from lib import config
+        monkeypatch.setitem(config._cfg, "openai_api_key", "sk-real-test-key")
+
+        fake_client = MagicMock()
+        fake_response = MagicMock()
+        fake_response.choices = [MagicMock(message=MagicMock(content="FITMENT SCORE: 7/10"))]
+        fake_response.usage = MagicMock(prompt_tokens=80, completion_tokens=40)
+        fake_client.chat.completions.create.return_value = fake_response
+
+        with patch("openai.OpenAI", return_value=fake_client):
+            srv.run_job_assessment("Stripe", "Staff Engineer", JD, auto_save=False)
+
+        system_msg = fake_client.chat.completions.create.call_args.kwargs["messages"][0]["content"]
+        for name in ("faang_technical", "executive_polish", "startup_founder"):
+            block = PersonaService.get(name).to_prompt_block()
+            assert block not in system_msg
+
+    def test_no_openai_key_falls_back_to_context_pack_with_persona(self, isolated_server, monkeypatch):
+        from lib import config
+        monkeypatch.setitem(config._cfg, "openai_api_key", "sk-...placeholder")
+
+        out = srv.run_job_assessment("Stripe", "Staff Engineer", JD, persona="executive_polish")
+        assert "PERSONA LENS" in out
+        assert PersonaService.get("executive_polish").to_prompt_block() in out
+
+
+class TestJobAnalysisServicePersona:
+    def test_evaluate_threads_persona_to_pack(self, isolated_server):
+        result = JobAnalysisService.evaluate(
+            company="Stripe",
+            role="Staff Engineer",
+            job_description=JD,
+            source="test",
+            persona="faang_technical",
+        )
+        assert result.evaluated is True
+        assert "PERSONA LENS" in result.fitment_context
+        assert PersonaService.get("faang_technical").to_prompt_block() in result.fitment_context
+
+    def test_evaluate_default_no_persona(self, isolated_server):
+        result = JobAnalysisService.evaluate(
+            company="Stripe",
+            role="Staff Engineer",
+            job_description=JD,
+        )
+        assert result.evaluated is True
+        assert "PERSONA LENS" not in result.fitment_context
+
+    def test_assess_threads_persona(self, isolated_server):
+        out = JobAnalysisService.assess(
+            company="Stripe",
+            role="Staff Engineer",
+            job_description=JD,
+            persona="startup_founder",
+        )
+        assert "PERSONA LENS" in out
+        assert PersonaService.get("startup_founder").to_prompt_block() in out

--- a/tools/fitment.py
+++ b/tools/fitment.py
@@ -39,15 +39,33 @@ _ASSESSMENT_SYSTEM = textwrap.dedent("""\
 """)
 
 
-def assess_job_fitment(company: str, role: str, job_description: str) -> str:
-    """Package Frank's master resume alongside a job description so the AI can assess fit, identify gaps, and recommend which experience to emphasize for this specific role."""
+def assess_job_fitment(company: str, role: str, job_description: str, persona: str = "") -> str:
+    """Package Frank's master resume alongside a job description so the AI can assess fit, identify gaps, and recommend which experience to emphasize for this specific role.
+
+    When `persona` is set, prepends the persona's prompt block to the context
+    pack so the consuming agent reads it as a role-specific lens (e.g.
+    'faang_technical' weighs systems depth differently than 'executive_polish').
+    """
     master = _load_master_context()
     interview_block = get_interview_context(company=company, role=role)
     interview_section = f"\n\n{interview_block}" if interview_block else ""
+
+    persona_section = ""
+    if persona:
+        # Lazy import: services/__init__ -> resume_service -> tools.generate ->
+        # tools.fitment, so importing PersonaService at module top would cycle.
+        from services.persona_service import PersonaService, UnknownPersonaError
+        try:
+            cfg = PersonaService.get(persona)
+            persona_section = f"──── PERSONA LENS ────\n{cfg.to_prompt_block()}\n\n"
+        except UnknownPersonaError as exc:
+            persona_section = f"──── PERSONA LENS ────\n[warning: {exc}]\n\n"
+
     return (
         f"═══ FITMENT ASSESSMENT ═══\n"
         f"Company: {company}\n"
         f"Role:    {role}\n\n"
+        f"{persona_section}"
         f"──── JOB DESCRIPTION ────\n{job_description}\n\n"
         f"──── FRANK'S MASTER RESUME ────\n{master}"
         f"{interview_section}"
@@ -125,13 +143,17 @@ def save_job_assessment(company: str, content: str, filename: str = "", source: 
     return f"\u2713 Saved job assessment: {relative}"
 
 
-def run_job_assessment(company: str, role: str, job_description: str, auto_save: bool = True) -> str:
+def run_job_assessment(company: str, role: str, job_description: str, persona: str = "", auto_save: bool = True) -> str:
     """
     Run a real LLM-powered fitment assessment for a job posting.
 
     Unlike assess_job_fitment (which is a context packer), this tool actually calls
     the OpenAI API and returns a structured analysis: fitment score, strong matches,
     gaps, key angles to emphasize, comp assessment, and recommendation.
+
+    When `persona` is set (e.g. 'faang_technical', 'executive_polish'), the
+    persona's prompt block is prepended to the system message so the LLM
+    applies role-specific weighting and tone to the assessment.
 
     If auto_save=True (default), saves the result to 07-Job-Assessments automatically.
     """
@@ -143,10 +165,21 @@ def run_job_assessment(company: str, role: str, job_description: str, auto_save:
     key = config._cfg.get("openai_api_key", "")
     if not key or key.startswith("sk-..."):
         # Fallback: return context package for manual analysis
-        return assess_job_fitment(company, role, job_description)
+        return assess_job_fitment(company, role, job_description, persona=persona)
 
     client = OpenAI(api_key=key)
     model = config._cfg.get("openai_model", "gpt-4o-mini")
+
+    system_prompt = _ASSESSMENT_SYSTEM
+    persona_note = ""
+    if persona:
+        from services.persona_service import PersonaService, UnknownPersonaError
+        try:
+            cfg = PersonaService.get(persona)
+            system_prompt = f"{cfg.to_prompt_block()}\n\n{_ASSESSMENT_SYSTEM}"
+            persona_note = f" (persona: {cfg.name})"
+        except UnknownPersonaError as exc:
+            persona_note = f" (persona warning: {exc})"
 
     master = _load_master_context()
     candidate_name = config._cfg.get("name", "the candidate")
@@ -163,7 +196,7 @@ def run_job_assessment(company: str, role: str, job_description: str, auto_save:
         response = client.chat.completions.create(
             model=model,
             messages=[
-                {"role": "system", "content": _ASSESSMENT_SYSTEM},
+                {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_msg},
             ],
             temperature=0.2,
@@ -185,7 +218,7 @@ def run_job_assessment(company: str, role: str, job_description: str, auto_save:
     else:
         save_result = "(not saved — pass auto_save=True to persist)"
 
-    return f"✓ Assessment complete for {role} @ {company}\n{cost_note}  {save_result}\n\n{content}"
+    return f"✓ Assessment complete for {role} @ {company}{persona_note}\n{cost_note}  {save_result}\n\n{content}"
 
 
 def register(mcp) -> None:

--- a/tools/job_queue.py
+++ b/tools/job_queue.py
@@ -93,8 +93,13 @@ def get_job_queue(status: str = "") -> str:
     return "\n".join(lines)
 
 
-def evaluate_queued_job(company: str, role: str) -> str:
-    """Run fitment analysis on a queued job. Loads the stored JD and assembles a full fitment context package for review. Sets status to 'evaluated' so decide_job can proceed. After reviewing this output, call decide_job with 'add' or 'dismiss'."""
+def evaluate_queued_job(company: str, role: str, persona: str = "") -> str:
+    """Run fitment analysis on a queued job. Loads the stored JD and assembles a full fitment context package for review. Sets status to 'evaluated' so decide_job can proceed. After reviewing this output, call decide_job with 'add' or 'dismiss'.
+
+    Optional `persona` (e.g. 'faang_technical', 'executive_polish') prepends a
+    persona lens to the context pack so the consuming agent applies role-specific
+    weighting.
+    """
     data = _load_json(config.JOB_QUEUE_FILE, {"jobs": []})
     jobs: list = data.get("jobs", [])
 
@@ -116,6 +121,7 @@ def evaluate_queued_job(company: str, role: str) -> str:
         company=company,
         role=role,
         job_description=job["jd"],
+        persona=persona,
     )
 
 

--- a/transport/http/models.py
+++ b/transport/http/models.py
@@ -30,6 +30,10 @@ class JobEvaluateRequest(BaseModel):
     role: str = Field(..., min_length=1)
     job_description: str = Field(..., min_length=1)
     source: str = ""
+    persona: str | None = Field(
+        default=None,
+        description="Optional persona name to bias the fitment lens (e.g. 'faang_technical', 'executive_polish'). Defaults to no persona.",
+    )
 
 
 class JobEvaluateResponse(BaseModel):

--- a/transport/http/routes/jobs.py
+++ b/transport/http/routes/jobs.py
@@ -35,6 +35,7 @@ async def evaluate(req: JobEvaluateRequest) -> JobEvaluateResponse:
         role=req.role,
         job_description=req.job_description,
         source=req.source,
+        persona=req.persona,
     )
     return JobEvaluateResponse(
         company=result.company,
@@ -55,6 +56,7 @@ async def evaluate_stream(req: JobEvaluateRequest):
             role=req.role,
             job_description=req.job_description,
             source=req.source,
+            persona=req.persona,
             on_progress=cb,
         ),
     )


### PR DESCRIPTION
Threads an optional persona parameter through every layer of the fitment stack (HTTP request -> JobAnalysisService -> tools.fitment / tools.job_queue), mirroring the existing ResumeGenerateRequest.persona pattern.

- assess_job_fitment / evaluate_queued_job: persona block prepended to the returned context pack as a PERSONA LENS section
- run_job_assessment: persona block prepended to the LLM system prompt so the OpenAI call applies role-specific weighting and tone
- JobEvaluateRequest gains persona field; /jobs/evaluate and /jobs/evaluate/stream forward it
- Unknown persona names emit a non-fatal warning instead of crashing
- PersonaService imported lazily inside fitment.py to avoid circular dep (services/__init__ -> resume_service -> tools.generate -> tools.fitment)
- 11 new tests in tests/test_fitment.py cover tool, service, and HTTP layers; full suite 476/476 green