### PR TITLE
feat(mcp): expose export_cover_letter_latex as an MCP tool

### DIFF
--- a/server.py
+++ b/server.py
@@ -229,6 +229,7 @@ draft_outreach_message = outreach.draft_outreach_message
 
 export_resume_pdf = export.export_resume_pdf
 export_cover_letter_pdf = export.export_cover_letter_pdf
+export_cover_letter_latex = export.export_cover_letter_latex
 
 generate_resume = generate.generate_resume
 generate_cover_letter = generate.generate_cover_letter

--- a/tests/test_latex_export.py
+++ b/tests/test_latex_export.py
@@ -1,6 +1,8 @@
+from pathlib import Path
 from types import SimpleNamespace
 
 from tools import latex_export
+from tools import export
 
 
 def test_latex_cover_letter_template_owns_date_and_signature():
@@ -100,3 +102,41 @@ def test_latex_cover_letter_uses_bundled_support_files_when_workspace_missing(mo
 
     assert out.parent.name == "09-Cover-Letter-PDFs"
     assert out.exists()
+
+def test_export_cover_letter_latex_tool_extracts_body_from_full_letter(monkeypatch):
+    """The MCP tool accepts a pasted full letter and passes only the prose body
+    to the LaTeX pipeline (salutation, leading header, and sign-off stripped)."""
+    captured = {}
+
+    def fake_generate(*, body, company, role, role_title, letter_date):
+        captured.update(body=body, company=company, role=role, role_title=role_title)
+        return Path("/tmp/09-Cover-Letter-PDFs/cover_letter_Equifax.pdf")
+
+    monkeypatch.setattr(latex_export, "generate_cover_letter_latex", fake_generate)
+
+    full_letter = (
+        "FRANK VLADMIR MACBRIDE III\n"
+        "Email: frankvmacbride@gmail.com\n\n"
+        "Dear Hiring Manager,\n\n"
+        "I keep the systems boring in production.\n\n"
+        "I own the whole stack end to end.\n\n"
+        "Kindest Regards,\nFrank Vladmir MacBride III"
+    )
+
+    result = export.export_cover_letter_latex(
+        company="Equifax", role="Senior Applied AI Engineer",
+        body=full_letter, role_title="Senior Applied AI Engineer",
+    )
+
+    assert "PDF exported (LaTeX)" in result
+    assert captured["role_title"] == "Senior Applied AI Engineer"
+    # Body must be the prose only — no salutation, header email, or sign-off.
+    assert "boring in production" in captured["body"]
+    assert "Dear Hiring Manager" not in captured["body"]
+    assert "frankvmacbride@gmail.com" not in captured["body"]
+    assert "Kindest Regards" not in captured["body"]
+
+
+def test_export_cover_letter_latex_tool_requires_body_or_filename():
+    msg = export.export_cover_letter_latex(company="Acme", role="SWE")
+    assert msg.startswith("Error:")

--- a/tools.json
+++ b/tools.json
@@ -56,6 +56,17 @@
     ]
   },
   {
+    "name": "export_cover_letter_latex",
+    "parameters": [
+      "company",
+      "role",
+      "body",
+      "filename",
+      "role_title",
+      "letter_date"
+    ]
+  },
+  {
     "name": "export_resume_pdf",
     "parameters": [
       "filename",

--- a/tools/export.py
+++ b/tools/export.py
@@ -235,6 +235,84 @@ def export_cover_letter_pdf(
     return f"✓ PDF exported: {out}"
 
 
+def export_cover_letter_latex(
+    company: str,
+    role: str,
+    body: str = "",
+    filename: str = "",
+    role_title: str = "Full Stack Software Engineer",
+    letter_date: str = "",
+) -> str:
+    """Pipeline A — LaTeX cover letter export (tectonic, with pdflatex fallback).
+
+    Compiles a cover letter to PDF using the TLCresume LaTeX template, producing
+    output identical to the manually-compiled frank-resume-latex versions. This
+    is the PRIMARY cover-letter pipeline; export_cover_letter_pdf is the
+    HTML/weasyprint fallback for environments without a LaTeX engine.
+
+    Provide the letter text one of two ways:
+      - body:     Paste the cover-letter text directly. The template supplies its
+                  own salutation ("Dear Hiring Manager,") and sign-off, so a full
+                  letter is fine — the prose body is extracted automatically (any
+                  leading contact header, "Dear ..." line, and closing block are
+                  stripped). Takes precedence over filename.
+      - filename: Name of a saved .txt in the active cover-letters folder (with
+                  or without .txt). Used when body is empty.
+
+    Args:
+        company:     Target company (used in the letter and output filename).
+        role:        Target role (used in the output filename).
+        body:        Cover-letter text. Takes precedence over filename.
+        filename:    Saved .txt to read when body is empty.
+        role_title:  Title printed under the name in the letterhead
+                     (e.g. "Senior Applied AI Engineer"). Default: Full Stack
+                     Software Engineer.
+        letter_date: Right-aligned date under the letterhead. Defaults to today.
+
+    Returns:
+        Path to the generated PDF, or an error string.
+    """
+    from tools.latex_export import generate_cover_letter_latex
+    from tools.generate import _extract_cover_letter_body
+
+    raw = body
+    if not raw.strip():
+        if not filename:
+            return "Error: provide either body text or a filename from the cover-letters folder."
+        cl_dir = config.get_active_cover_letters_dir()
+        if not filename.endswith(".txt"):
+            filename += ".txt"
+        source = cl_dir / filename
+        if not source.exists():
+            matches = list(cl_dir.glob(f"*{pathlib.Path(filename).stem}*"))
+            if not matches:
+                return f"Error: file not found — {filename}"
+            source = matches[0]
+        try:
+            raw = source.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            raw = source.read_text(encoding="latin-1")
+
+    # Strip salutation/header/sign-off so they aren't duplicated by the template.
+    # Fall back to the raw text if the draft is already just the body paragraphs.
+    letter_body = _extract_cover_letter_body(raw) or raw.strip()
+    if not letter_body.strip():
+        return "Error: could not extract a cover-letter body from the provided text."
+
+    try:
+        pdf = generate_cover_letter_latex(
+            body=letter_body,
+            company=company,
+            role=role,
+            role_title=role_title,
+            letter_date=letter_date,
+        )
+    except Exception as exc:  # noqa: BLE001 — surface the compile error to the caller
+        return f"⚠ LaTeX export failed: {exc}"
+    return f"✓ PDF exported (LaTeX): {pdf}"
+
+
 def register(mcp) -> None:
     mcp.tool()(export_resume_pdf)
     mcp.tool()(export_cover_letter_pdf)
+    mcp.tool()(export_cover_letter_latex)


### PR DESCRIPTION
## Summary

Exposes the LaTeX cover-letter pipeline as a first-class **MCP tool** so connector clients (Claude Desktop, etc.) can invoke it directly. Previously `tools/latex_export.generate_cover_letter_latex` was only reachable internally (via `generate_cover_letter` with a config flag) or through the HTTP dashboard — so from a connector's perspective the LaTeX pipeline effectively didn't exist.

## What's added

- **`export_cover_letter_latex`** MCP tool (`tools/export.py`, registered in `register()`):
  - Required: `company`, `role`. Optional: `body`, `filename`, `role_title`, `letter_date`.
  - **`body`** — paste a full letter; the prose body is extracted automatically (leading contact header, `Dear …` salutation, and sign-off stripped, since the template supplies those). Takes precedence over `filename`.
  - **`filename`** — read a saved `.txt` from the active cover-letters folder when `body` is empty.
  - Compiles via the existing tectonic → pdflatex pipeline and returns the PDF path.
- Server alias in `server.py` and a `tools.json` manifest entry, mirroring `export_cover_letter_pdf`.

## Tests

- Body extraction from a pasted full letter (salutation/header/sign-off stripped).
- Missing-input guard returns a clear error.

## Verification

- ✅ Registers with FastMCP — appears in `list_tools()` with the correct schema (required: `company`, `role`).
- ✅ End-to-end: pasted full letter → body extracted → PDF produced (exercised the pdflatex fallback).
- ✅ Both new tests pass.

## Note

Goes live for connector clients only after merge + MCP server redeploy and a connector tool-list refresh. Complements `generate_cover_letter` (which routes to LaTeX when configured); this is the explicit "I have the text, just compile it" path — no OpenAI key or config flag required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMpLGJ1dQkQQAs44xEDqVT

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMpLGJ1dQkQQAs44xEDqVT)_