### PR TITLE
feat(mcp): expose export_resume_latex as an MCP tool

### DIFF
--- a/server.py
+++ b/server.py
@@ -230,6 +230,7 @@ draft_outreach_message = outreach.draft_outreach_message
 export_resume_pdf = export.export_resume_pdf
 export_cover_letter_pdf = export.export_cover_letter_pdf
 export_cover_letter_latex = export.export_cover_letter_latex
+export_resume_latex = export.export_resume_latex
 
 generate_resume = generate.generate_resume
 generate_cover_letter = generate.generate_cover_letter

--- a/tests/test_latex_export.py
+++ b/tests/test_latex_export.py
@@ -140,3 +140,31 @@ def test_export_cover_letter_latex_tool_extracts_body_from_full_letter(monkeypat
 def test_export_cover_letter_latex_tool_requires_body_or_filename():
     msg = export.export_cover_letter_latex(company="Acme", role="SWE")
     assert msg.startswith("Error:")
+
+
+def test_export_resume_latex_tool_success(monkeypatch):
+    """The resume MCP tool returns the compiled PDF path on success."""
+    def fake_generate(*, resume_text, company, role, role_title, output_filename):
+        assert company == "Equifax" and role == "Senior Applied AI Engineer"
+        return Path("/tmp/03-Resume-PDFs/resume_Equifax.pdf")
+
+    monkeypatch.setattr(latex_export, "generate_resume_latex", fake_generate)
+
+    result = export.export_resume_latex(
+        company="Equifax", role="Senior Applied AI Engineer",
+    )
+    assert "PDF exported (LaTeX)" in result
+    assert "resume_Equifax.pdf" in result
+
+
+def test_export_resume_latex_tool_surfaces_unconfigured_dir(monkeypatch):
+    """When latex_resume_dir / resume.tex is missing, the tool returns a clear
+    error string rather than raising."""
+    def fake_generate(**kwargs):
+        raise FileNotFoundError("latex_resume_dir is not set or does not exist in config.json.")
+
+    monkeypatch.setattr(latex_export, "generate_resume_latex", fake_generate)
+
+    msg = export.export_resume_latex(company="Acme", role="SWE")
+    assert msg.startswith("Error:")
+    assert "latex_resume_dir" in msg

--- a/tools.json
+++ b/tools.json
@@ -75,6 +75,16 @@
     ]
   },
   {
+    "name": "export_resume_latex",
+    "parameters": [
+      "company",
+      "role",
+      "resume_text",
+      "output_filename",
+      "role_title"
+    ]
+  },
+  {
     "name": "generate_cover_letter",
     "parameters": [
       "company",

--- a/tools/export.py
+++ b/tools/export.py
@@ -312,7 +312,55 @@ def export_cover_letter_latex(
     return f"✓ PDF exported (LaTeX): {pdf}"
 
 
+def export_resume_latex(
+    company: str,
+    role: str,
+    resume_text: str = "",
+    output_filename: str = "",
+    role_title: str = "Full Stack Software Engineer",
+) -> str:
+    """Pipeline A — LaTeX resume export (tectonic).
+
+    Compiles a ``resume.tex`` from the configured ``latex_resume_dir`` as-is
+    ("compile what's there") and copies the PDF to the workspace resume folder.
+
+    NOTE: unlike export_cover_letter_latex, this pipeline does NOT inject text
+    and has NO bundled-asset fallback. It requires ``latex_resume_dir`` to be
+    set in config and to contain a ``resume.tex`` source file; otherwise it
+    returns an error string. The legacy/portable path is export_resume_pdf
+    (HTML/weasyprint), which works without a LaTeX engine or .tex source.
+
+    Args:
+        company:         Target company (used in the output filename).
+        role:            Target role (used in the output filename).
+        resume_text:     Reserved — not injected by this pipeline (the .tex
+                         source governs layout). Accepted for API symmetry.
+        output_filename: Override the output PDF filename. Defaults to
+                         resume_{company}_{role}_{YYYYMMDD}.pdf.
+        role_title:      Reserved for a future \\def\\role injection.
+
+    Returns:
+        Path to the generated PDF, or an error string.
+    """
+    from tools.latex_export import generate_resume_latex
+
+    try:
+        pdf = generate_resume_latex(
+            resume_text=resume_text,
+            company=company,
+            role=role,
+            role_title=role_title,
+            output_filename=output_filename,
+        )
+    except FileNotFoundError as exc:
+        return f"Error: {exc}"
+    except Exception as exc:  # noqa: BLE001 — surface the compile error to the caller
+        return f"⚠ LaTeX resume export failed: {exc}"
+    return f"✓ PDF exported (LaTeX): {pdf}"
+
+
 def register(mcp) -> None:
     mcp.tool()(export_resume_pdf)
     mcp.tool()(export_cover_letter_pdf)
     mcp.tool()(export_cover_letter_latex)
+    mcp.tool()(export_resume_latex)


### PR DESCRIPTION
## Summary

Mirrors #49 for the resume LaTeX pipeline: exposes `tools.latex_export.generate_resume_latex` as a first-class **MCP tool** (`export_resume_latex`) so connector clients can invoke it directly.

## Important behavioral difference vs. the cover-letter tool

Unlike `export_cover_letter_latex`, this pipeline **compiles an existing `resume.tex`** from `latex_resume_dir` as-is — it does **not** inject text and has **no bundled-asset fallback**. Consequently:

- It requires `latex_resume_dir` to be set in config and to contain a `resume.tex` source.
- When that's missing (e.g. a default AKS deployment), the tool returns a **clear error string** instead of raising — telling the caller to configure `latex_resume_dir` or use the portable `export_resume_pdf` (HTML/weasyprint) path.

The `resume_text` param is accepted for API symmetry but is currently not injected (the `.tex` source governs layout), matching the underlying function's documented contract.

## Changes

- `export_resume_latex` tool in `tools/export.py` + `register()`.
- Server alias in `server.py`; `tools.json` manifest entry.
- Tests for the success path and the unconfigured-`latex_resume_dir` error path.

## Verification

- ✅ Registers with FastMCP — appears in `list_tools()` (required: `company`, `role`).
- ✅ Success path returns the PDF path; unconfigured path returns `Error: …latex_resume_dir…`.
- ✅ All four export-tool tests pass.

Merging to `qa` triggers the Build & Deploy to AKS workflow, after which connector clients will see `export_resume_latex` once their tool list refreshes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMpLGJ1dQkQQAs44xEDqVT

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMpLGJ1dQkQQAs44xEDqVT)_