### PR TITLE
test: cover reindex_stories + lib/rag.py, refresh README stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/version-1.1.1-blue" alt="Version 1.1.1"/>
-  <img src="https://img.shields.io/badge/tests-924%20passing-brightgreen" alt="924 tests passing"/>
-  <img src="https://img.shields.io/badge/coverage-77.41%25-brightgreen" alt="77.41% coverage"/>
-  <img src="https://img.shields.io/badge/tools-78-informational" alt="78 MCP tools"/>
+  <img src="https://img.shields.io/badge/tests-931%20passing-brightgreen" alt="931 tests passing"/>
+  <img src="https://img.shields.io/badge/coverage-82.43%25-brightgreen" alt="82.43% coverage"/>
+  <img src="https://img.shields.io/badge/tools-80-informational" alt="80 MCP tools"/>
   <img src="https://img.shields.io/badge/license-MIT-lightgrey" alt="MIT License"/>
 </p>
 <p align="center">
@@ -19,7 +19,7 @@ A personal [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) serv
 
 Built in Python using [FastMCP](https://github.com/jlowin/fastmcp), FastAPI, SQLite (with dual-write JSON fallback), optional OpenAI/Azure AI Foundry/Ollama generation, WeasyPrint PDF export, a mobile-friendly dashboard, and a Kubernetes deployment on AKS with workload identity and Azure Blob Storage workspace seeding.
 
-> **The agent is optional.** MCP servers are protocol-driven capability layers — any client that speaks the protocol can call them. jobContextMCP ships with a CLI (`cli.py`) that invokes all 77 tools directly from the terminal, no AI client required. Automation scripts, CI pipelines, cron/launchd jobs, the web dashboard, and scheduled tasks can consume the same underlying capabilities as Claude or Copilot. The AI is one type of client, not the only one.
+> **The agent is optional.** MCP servers are protocol-driven capability layers — any client that speaks the protocol can call them. jobContextMCP ships with a CLI (`cli.py`) that invokes all 80 tools directly from the terminal, no AI client required. Automation scripts, CI pipelines, cron/launchd jobs, the web dashboard, and scheduled tasks can consume the same underlying capabilities as Claude or Copilot. The AI is one type of client, not the only one.
 
 ---
 
@@ -33,8 +33,8 @@ Available as a local MCP server, local dashboard, or cloud-hosted multi-user dep
 
 | | |
 |---|---|
-| 78 MCP tools | Resume + cover letter generation |
-| 924 passing tests | Job fitment analysis with persona lenses |
+| 80 MCP tools | Resume + cover letter generation |
+| 931 passing tests | Job fitment analysis with persona lenses |
 | SQLite persistence + JSON fallback | Interview prep + debrief logging |
 | Local RAG semantic search | Outreach + relationship tracking |
 | Azure AKS deployment | Microsoft Entra ID authentication |
@@ -168,7 +168,7 @@ graph TB
     PROV["User provisioning\nauto-create on first Entra login"]
   end
 
-  subgraph TOOLS["77 MCP / CLI tools"]
+  subgraph TOOLS["80 MCP / CLI tools"]
     CTX["Context + identity"]
     PIPE["Pipeline + queue + compensation"]
     DOCS["Resume + cover letter generation"]
@@ -603,7 +603,7 @@ brew install python@3.12
 
 # Smoke test: confirm the server imports cleanly and registers all tools
 .venv/bin/python3 -c "import server; print('OK,', len(server.mcp._tool_manager.list_tools()), 'tools')"
-# Expected: OK, 77 tools
+# Expected: OK, 80 tools
 ```
 
 > ⚠️ **macOS venv gotcha:** if you accidentally run `python3 -m venv .venv` with the system 3.9 first, the resulting `.venv/bin/python3` symlink points at the system 3.9 binary. A follow-up `python3.12 -m venv .venv` call will NOT replace it — the broken symlink survives. Symptom: `ModuleNotFoundError: No module named 'mcp'` even though `pip list` shows it installed. Fix: `rm -rf .venv` and recreate with the explicit `/opt/homebrew/opt/python@3.12/bin/python3.12 -m venv .venv` command above.
@@ -687,7 +687,7 @@ The server speaks MCP — it works with any compatible client. You don't need an
 
 #### Terminal (no AI client required)
 
-`cli.py` is a first-class client. Invoke any of the 77 tools directly:
+`cli.py` is a first-class client. Invoke any of the 80 tools directly:
 
 ```bash
 # List all tools
@@ -946,7 +946,7 @@ In `.env`:
 MCP_MODE=local
 ```
 
-Then **Command Palette → MCP: List Servers → restart jobContextMCP**. The startup logs should no longer mention `Container … Creating` / `Container … Created`. You'll see `Discovered 77 tools` (or whatever your current count is) within ~0.5s instead of ~1.5s.
+Then **Command Palette → MCP: List Servers → restart jobContextMCP**. The startup logs should no longer mention `Container … Creating` / `Container … Created`. You'll see `Discovered 80 tools` (or whatever your current count is) within ~0.5s instead of ~1.5s.
 
 #### What's live vs. baked-in
 

--- a/lib/rag.py
+++ b/lib/rag.py
@@ -275,7 +275,7 @@ def format_results(hits: list[dict], header: str = "Search Results") -> str:
 
 # ─── CLI ──────────────────────────────────────────────────────────────────────
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     import sys
     if len(sys.argv) > 1 and sys.argv[1] == "search":
         query = " ".join(sys.argv[2:])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,6 @@ omit    = ["tests/*", ".venv/*"]
 [tool.coverage.report]
 show_missing   = true
 skip_covered   = false
-# Raise incrementally as test_job_hunt, test_resume, test_mental_health are added.
-# Current: 43% (helpers + personal_context + star_context covered)
-fail_under     = 50
+# Current: 80% total. Biggest remaining gap is lib/rag.py (0% — no offline tests).
+# Add tests there for durable headroom before raising this gate further.
+fail_under     = 80

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,6 @@ omit    = ["tests/*", ".venv/*"]
 [tool.coverage.report]
 show_missing   = true
 skip_covered   = false
-# Current: 80% total. Biggest remaining gap is lib/rag.py (0% — no offline tests).
-# Add tests there for durable headroom before raising this gate further.
+# Current: ~82% total. Next-largest gaps: tools/latex_export.py (~48%),
+# tools/health.py (~49%), tools/resume.py (~55%). Raise this gate as they land.
 fail_under     = 80

--- a/tests/test_rag_lib_coverage.py
+++ b/tests/test_rag_lib_coverage.py
@@ -1,0 +1,256 @@
+"""
+tests/test_rag_lib_coverage.py
+
+Offline coverage for lib/rag.py — the local-numpy RAG index/search layer.
+All OpenAI calls are mocked; no network or real API key is required.
+"""
+
+import json
+import types
+
+import numpy as np
+import pytest
+
+from lib import rag
+
+
+# ── Pure helpers: _chunk_text ────────────────────────────────────────────────
+
+def test_chunk_text_single_short_paragraph():
+    text = "This is a single paragraph that comfortably exceeds the fifty character minimum."
+    chunks = rag._chunk_text(text)
+    assert len(chunks) == 1
+    assert chunks[0].startswith("This is a single paragraph")
+
+
+def test_chunk_text_drops_sub_threshold_chunks():
+    # Whole text is under the 50-char floor → filtered out entirely.
+    assert rag._chunk_text("too short") == []
+
+
+def test_chunk_text_splits_long_paragraph_by_sentences():
+    sentence = "Alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu. "
+    text = sentence * 20  # one giant paragraph, well over max_chars
+    chunks = rag._chunk_text(text, max_chars=200, overlap=20)
+    assert len(chunks) > 1
+    assert all(len(c) > 50 for c in chunks)
+
+
+def test_chunk_text_merges_multiple_paragraphs():
+    paras = "\n\n".join(f"Paragraph number {i} with enough text to clear the floor easily." for i in range(6))
+    chunks = rag._chunk_text(paras, max_chars=120, overlap=20)
+    assert len(chunks) >= 2
+
+
+# ── Pure helpers: format_results ─────────────────────────────────────────────
+
+def test_format_results_empty():
+    assert rag.format_results([]) == "No relevant results found."
+
+
+def test_format_results_populated():
+    hits = [
+        {"text": "chunk one", "source": "resume.txt", "score": 0.91, "category": "resume"},
+        {"text": "chunk two", "source": "prep.txt", "score": 0.77, "category": "interview_prep"},
+    ]
+    out = rag.format_results(hits, header="My Results")
+    assert "═══ My Results ═══" in out
+    assert "[1] resume.txt (score: 0.91, category: resume)" in out
+    assert "[2] prep.txt (score: 0.77, category: interview_prep)" in out
+    assert "chunk one" in out and "chunk two" in out
+
+
+# ── Path helpers ─────────────────────────────────────────────────────────────
+
+def test_path_helpers(monkeypatch, tmp_path):
+    monkeypatch.setattr(rag._cfg_module, "get_active_data_folder", lambda: tmp_path)
+    assert rag._data_dir() == tmp_path
+    assert rag._index_file() == tmp_path / "rag_index.json"
+    assert rag._embed_file() == tmp_path / "rag_embeddings.npy"
+
+
+# ── _openai_client ───────────────────────────────────────────────────────────
+
+def test_openai_client_missing_key(monkeypatch):
+    monkeypatch.setattr(rag._cfg_module, "get_config_value", lambda *_a, **_k: "")
+    with pytest.raises(ValueError, match="openai_api_key not set"):
+        rag._openai_client()
+
+
+def test_openai_client_with_key(monkeypatch):
+    monkeypatch.setattr(rag._cfg_module, "get_config_value", lambda *_a, **_k: "sk-test")
+    client = rag._openai_client()
+    assert client is not None  # constructed without a network call
+
+
+# ── _embed ───────────────────────────────────────────────────────────────────
+
+def test_embed_returns_vectors_from_client():
+    fake_client = types.SimpleNamespace(
+        embeddings=types.SimpleNamespace(
+            create=lambda model, input: types.SimpleNamespace(
+                data=[types.SimpleNamespace(embedding=[float(len(t)), 1.0]) for t in input]
+            )
+        )
+    )
+    vecs = rag._embed(["aa", "bbbb"], fake_client)
+    assert vecs == [[2.0, 1.0], [4.0, 1.0]]
+
+
+# ── search ───────────────────────────────────────────────────────────────────
+
+def _seed_index(data_dir, chunks, metadata, embeddings):
+    (data_dir / "rag_index.json").write_text(
+        json.dumps({"chunks": chunks, "metadata": metadata}), encoding="utf-8"
+    )
+    np.save(str(data_dir / "rag_embeddings.npy"), np.array(embeddings, dtype=np.float32))
+
+
+def test_search_missing_index_raises(monkeypatch, tmp_path):
+    monkeypatch.setattr(rag._cfg_module, "get_active_data_folder", lambda: tmp_path)
+    with pytest.raises(FileNotFoundError, match="RAG index not found"):
+        rag.search("anything")
+
+
+def test_search_category_filter_no_match_returns_empty(monkeypatch, tmp_path):
+    monkeypatch.setattr(rag._cfg_module, "get_active_data_folder", lambda: tmp_path)
+    _seed_index(
+        tmp_path,
+        chunks=["resume chunk"],
+        metadata=[{"source": "r.txt", "category": "resume"}],
+        embeddings=[[1.0, 0.0]],
+    )
+    monkeypatch.setattr(rag, "_openai_client", lambda: object())
+    monkeypatch.setattr(rag, "_embed", lambda texts, client: [[1.0, 0.0]])
+    assert rag.search("q", category="nonexistent") == []
+
+
+def test_search_ranks_by_cosine_similarity(monkeypatch, tmp_path):
+    monkeypatch.setattr(rag._cfg_module, "get_active_data_folder", lambda: tmp_path)
+    _seed_index(
+        tmp_path,
+        chunks=["aligned", "orthogonal", "opposite"],
+        metadata=[
+            {"source": "a.txt", "category": "resume"},
+            {"source": "b.txt", "category": "resume"},
+            {"source": "c.txt", "category": "resume"},
+        ],
+        embeddings=[[1.0, 0.0], [0.0, 1.0], [-1.0, 0.0]],
+    )
+    monkeypatch.setattr(rag, "_openai_client", lambda: object())
+    # Query vector points along +x → "aligned" should rank first.
+    monkeypatch.setattr(rag, "_embed", lambda texts, client: [[1.0, 0.0]])
+
+    results = rag.search("query", n_results=3)
+    assert [r["source"] for r in results] == ["a.txt", "b.txt", "c.txt"]
+    assert results[0]["score"] == 1.0
+    assert results[0]["text"] == "aligned"
+
+
+def test_search_category_filter_match(monkeypatch, tmp_path):
+    monkeypatch.setattr(rag._cfg_module, "get_active_data_folder", lambda: tmp_path)
+    _seed_index(
+        tmp_path,
+        chunks=["resume chunk", "prep chunk"],
+        metadata=[
+            {"source": "r.txt", "category": "resume"},
+            {"source": "p.txt", "category": "interview_prep"},
+        ],
+        embeddings=[[1.0, 0.0], [0.0, 1.0]],
+    )
+    monkeypatch.setattr(rag, "_openai_client", lambda: object())
+    monkeypatch.setattr(rag, "_embed", lambda texts, client: [[0.0, 1.0]])
+    results = rag.search("q", category="interview_prep")
+    assert len(results) == 1
+    assert results[0]["source"] == "p.txt"
+
+
+# ── build_index ──────────────────────────────────────────────────────────────
+
+def _wire_build_index(monkeypatch, resume_folder, data_folder, leetcode_folder):
+    monkeypatch.setattr(rag, "_openai_client", lambda: object())
+    monkeypatch.setattr(rag, "_embed", lambda texts, client: [[0.5, 0.5] for _ in texts])
+    monkeypatch.setattr(rag._cfg_module, "get_active_workspace_folder", lambda: resume_folder)
+    monkeypatch.setattr(rag._cfg_module, "get_active_leetcode_folder", lambda: leetcode_folder)
+    monkeypatch.setattr(rag._cfg_module, "get_active_data_folder", lambda: data_folder)
+    monkeypatch.setattr(rag._cfg_module, "get_active_workspace_path", lambda rel: resume_folder / rel)
+    # get_config_value(key, default) → default; leetcode paths default to "" (skipped).
+    monkeypatch.setattr(rag._cfg_module, "get_config_value", lambda key, default="": default)
+
+
+def test_build_index_empty_returns_empty(monkeypatch, tmp_path):
+    resume_folder = tmp_path / "resume"
+    resume_folder.mkdir()
+    data_folder = tmp_path / "data"
+    leetcode_folder = tmp_path / "lc"
+    leetcode_folder.mkdir()
+    _wire_build_index(monkeypatch, resume_folder, data_folder, leetcode_folder)
+    monkeypatch.setattr(rag._cfg_module, "MASTER_RESUME", tmp_path / "nope.txt")
+
+    assert rag.build_index(verbose=False) == {}
+
+
+def test_build_index_with_files_writes_index(monkeypatch, tmp_path):
+    resume_folder = tmp_path / "resume"
+    resume_folder.mkdir()
+    data_folder = tmp_path / "data"
+    leetcode_folder = tmp_path / "lc"
+    leetcode_folder.mkdir()
+    _wire_build_index(monkeypatch, resume_folder, data_folder, leetcode_folder)
+
+    master = tmp_path / "master.txt"
+    master.write_text("Master resume content that is clearly longer than the fifty char floor.", encoding="utf-8")
+    monkeypatch.setattr(rag._cfg_module, "MASTER_RESUME", master)
+    # A prep file in the resume root (matches the 'prep'/'interview' keyword filter).
+    (resume_folder / "interview_prep.txt").write_text(
+        "Interview prep notes with more than enough characters to survive chunking.", encoding="utf-8"
+    )
+
+    counts = rag.build_index(verbose=True)
+    assert counts.get("resume", 0) >= 1
+    assert counts.get("interview_prep", 0) >= 1
+    # Index artifacts written to the data folder.
+    assert (data_folder / "rag_index.json").exists()
+    assert (data_folder / "rag_embeddings.npy").exists()
+    saved = json.loads((data_folder / "rag_index.json").read_text(encoding="utf-8"))
+    assert len(saved["chunks"]) == len(saved["metadata"]) >= 2
+
+
+def test_build_index_covers_all_optional_folders(monkeypatch, tmp_path):
+    resume_folder = tmp_path / "resume"
+    resume_folder.mkdir()
+    data_folder = tmp_path / "data"
+    leetcode_folder = tmp_path / "lc"
+    leetcode_folder.mkdir()
+    _wire_build_index(monkeypatch, resume_folder, data_folder, leetcode_folder)
+    monkeypatch.setattr(rag._cfg_module, "MASTER_RESUME", tmp_path / "absent.txt")
+
+    body = "This file holds well over fifty characters so its chunk survives the floor."
+
+    # Optional workspace sub-folders, each resolved via get_active_workspace_path.
+    for sub in ("01-Current-Optimized", "02-Cover-Letters", "06-Reference-Materials"):
+        d = resume_folder / sub
+        d.mkdir()
+        (d / "doc.txt").write_text(body, encoding="utf-8")
+    # A MASTER file in the optimized dir must be excluded by name.
+    (resume_folder / "01-Current-Optimized" / "MASTER_resume.txt").write_text(body, encoding="utf-8")
+
+    # Prep docs + job assessment folders (relative to the resume root).
+    for sub in ("08-Interview-Prep-Docs", "07-Job-Assessments"):
+        d = resume_folder / sub
+        d.mkdir()
+        (d / "note.md").write_text(body, encoding="utf-8")
+    # Assessment file dropped in the resume root.
+    (resume_folder / "fitment_notes.txt").write_text(body, encoding="utf-8")
+
+    # An unreadable entry (a directory named like a .txt file, matching the
+    # prep keyword filter) exercises the read-failure `continue` branch.
+    (resume_folder / "interview_broken.txt").mkdir()
+
+    counts = rag.build_index(verbose=False)
+    assert counts.get("cover_letters", 0) >= 1
+    assert counts.get("reference", 0) >= 1
+    assert counts.get("job_assessments", 0) >= 1
+    # The MASTER-named optimized resume was filtered out, so resume chunks come
+    # only from the single non-master doc.
+    assert counts.get("resume", 0) >= 1

--- a/tests/test_rag_tools.py
+++ b/tests/test_rag_tools.py
@@ -50,6 +50,57 @@ def test_reindex_materials_success_and_error(monkeypatch):
     out2 = rag.reindex_materials()
     assert "requires an OpenAI API key" in out2
 
+    def _raise_generic(*_a, **_k):
+        raise RuntimeError("chroma unavailable")
+
+    monkeypatch.setitem(sys.modules, "lib.rag", types.SimpleNamespace(build_index=_raise_generic))
+    out3 = rag.reindex_materials()
+    assert out3.startswith("Indexing error:")
+    assert "chroma unavailable" in out3
+
+
+def _fake_story_retrieval(load_fn):
+    return types.SimpleNamespace(clear_cache=lambda: None, _load_semantic_index=load_fn)
+
+
+def test_reindex_stories_success(monkeypatch, tmp_path):
+    path = tmp_path / "personal_context.json"
+    monkeypatch.setitem(sys.modules, "lib.config", types.SimpleNamespace(PERSONAL_CONTEXT_FILE=path))
+    monkeypatch.setitem(
+        sys.modules,
+        "lib.story_retrieval",
+        _fake_story_retrieval(lambda p: (["s1", "s2", "s3"], types.SimpleNamespace(shape=(3, 1536)))),
+    )
+
+    out = rag.reindex_stories()
+    assert "Story semantic index built" in out
+    assert "3 stories embedded" in out
+    assert "1536d vectors" in out
+    assert "Semantic retrieval is now active" in out
+
+
+def test_reindex_stories_missing_api_key(monkeypatch, tmp_path):
+    def _raise_key(_p):
+        raise RuntimeError("openai_api_key not configured")
+
+    monkeypatch.setitem(sys.modules, "lib.config", types.SimpleNamespace(PERSONAL_CONTEXT_FILE=tmp_path / "pc.json"))
+    monkeypatch.setitem(sys.modules, "lib.story_retrieval", _fake_story_retrieval(_raise_key))
+
+    out = rag.reindex_stories()
+    assert "requires an OpenAI API key" in out
+
+
+def test_reindex_stories_generic_error(monkeypatch, tmp_path):
+    def _raise(_p):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setitem(sys.modules, "lib.config", types.SimpleNamespace(PERSONAL_CONTEXT_FILE=tmp_path / "pc.json"))
+    monkeypatch.setitem(sys.modules, "lib.story_retrieval", _fake_story_retrieval(_raise))
+
+    out = rag.reindex_stories()
+    assert out.startswith("Story index error:")
+    assert "disk full" in out
+
 
 def test_register_tools():
     registered = []
@@ -65,3 +116,4 @@ def test_register_tools():
     rag.register(_FakeMCP())
     assert "search_materials" in registered
     assert "reindex_materials" in registered
+    assert "reindex_stories" in registered


### PR DESCRIPTION
## Summary

Adds missing test coverage and brings the README stats up to date.

- **`reindex_stories` tool** (added in `b987682`) had no tests — added success / missing-API-key / generic-error cases, asserted MCP registration, and covered the previously-untested generic-error branch of `reindex_materials`. `tools/rag.py` → **100%**.
- **`lib/rag.py`** (local-numpy RAG index/search) was at **0%** — added a 17-test offline suite (OpenAI fully mocked) covering chunking, result formatting, path helpers, the client guard, embedding, cosine-similarity search (incl. category filters + missing-index error), and `build_index` across all material folders + the read-failure branch. `lib/rag.py` → **100%**.
- **Coverage gate** in `pyproject.toml` raised `50` → `80` (stale `43%` comment fixed).
- **README** badges and current-state stats refreshed (verified against the runtime tool manager); dated changelog entries left untouched.

## Results

| Metric | Before | After |
|---|---|---|
| Total coverage | 79.91% | **82.43%** |
| Passing tests | 911 | **931** |
| `tools/rag.py` | 86% | **100%** |
| `lib/rag.py` | 0% | **100%** |
| Tool count (README) | 77/78 | **80** (real) |

All 931 tests pass; 17 SQLite-migration tests remain skipped (they require a live local DB and pass in the maintainer's dev environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgkYqPTSEs7C8MCokPrDqG)_