### PR TITLE
ci(sonar): stop swallowing SonarCloud scan failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,7 +89,9 @@ jobs:
   sonar:
     needs: test
     runs-on: ubuntu-latest
-    continue-on-error: true
+    # No continue-on-error: surface SonarCloud failures (e.g. rejected
+    # branch analysis, quality-gate errors) instead of silently swallowing
+    # them. Deploy is independent (needs: test), so it still proceeds.
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Removes `continue-on-error: true` from the `sonar` job in `.github/workflows/deploy.yml`.

Until now, the SonarCloud scan step always reported a green check even when the analysis was rejected or failed server-side — which is why a failing/rejected branch analysis went unnoticed. Removing the flag makes those failures visible in CI.

## Why this is safe

The `build-and-deploy` job depends only on `test` (`needs: test`), **not** on `sonar`. So deployments continue exactly as before; only the `sonar` job's true status is now surfaced.

## Context

While investigating why the `qa` branch wasn't appearing in SonarCloud, we confirmed CI-based analysis is the active method (Automatic Analysis is correctly off). The scanner step was reporting success purely because it uploaded its report — the swallowed exit status hid any server-side rejection. This change ensures the next such failure shows up red instead of green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0185ZWPNhAVFUcgoaG9RUWN8)_