### PR TITLE
fix: resolve final SonarCloud issues — duplicate branch, type smells, FastAPI responses

### DIFF
--- a/lib/resume_parser.py
+++ b/lib/resume_parser.py
@@ -260,12 +260,8 @@ def _parse_header(pre_lines: list[str], contact: dict) -> tuple[str, str, str]: 
             or _CLOSING_TAG_RE.match(s)  # </SOFTWARE_ENGINEER> footer tag
         ):
             continue
-        if in_synopsis:
-            if not tagline and _is_tagline(s):
-                tagline = s
-            else:
-                synopsis_lines.append(s)
-        elif not name_lines or (len(s) > 6 and s.isupper() and "," not in s and "@" not in s):
+        if (not in_synopsis and
+                (not name_lines or (len(s) > 6 and s.isupper() and "," not in s and "@" not in s))):
             # FRANK V. MACBRIDE III — is it a name or title?
             if name_lines and re.match(r"^[A-Z ]+$", s) and len(s) > 10:
                 # could be subtitle like "SOFTWARE ENGINEER" — stop here
@@ -273,6 +269,7 @@ def _parse_header(pre_lines: list[str], contact: dict) -> tuple[str, str, str]: 
             else:
                 name_lines.append(s)
         else:
+            # Both in-synopsis and post-name lines accumulate tagline/synopsis the same way
             if not tagline and _is_tagline(s):
                 tagline = s
             else:
@@ -444,7 +441,7 @@ def _parse_experience_section(lines: list[str]) -> dict:  # NOSONAR
                 continue
             current_job = cur  # guarded above: cur is dict
             if not current_job.get("_done", False):
-                _finalize_job(current_job)
+                _finalize_job(current_job)  # NOSONAR — cur is non-None: guarded by `if not cur: continue` above
             flush_group()
             cur_group = {"label": line.rstrip(":"), "bullets": []}
             had_bullets = False
@@ -467,7 +464,7 @@ def _parse_experience_section(lines: list[str]) -> dict:  # NOSONAR
                 # Finalize when last pipe-segment looks like a date range
                 check = line.rsplit(" | ", 1)[-1].strip()
                 if _is_date_part(check):
-                    _finalize_job(current_job)
+                    _finalize_job(current_job)  # NOSONAR — cur is non-None: else branch of `elif after_blank or not cur:`
             else:
                 # Header is done; plain-text lines without bullet chars are
                 # implicit bullets (common in MCP-saved .txt resumes).

--- a/transport/http/routes/dashboard/settings.py
+++ b/transport/http/routes/dashboard/settings.py
@@ -213,7 +213,7 @@ def _build_page(user: User, flash: str = "", flash_type: str = "ok") -> str:
     return html_page("Settings", "settings", "Account and AI preferences", _EXTRA_CSS, body)
 
 
-@router.get("/settings", include_in_schema=False)
+@router.get("/settings", include_in_schema=False, responses={400: {"description": "Invalid config path"}})
 async def settings_page(
     user: Annotated[User, Depends(require_authenticated_user)],
     saved: Annotated[str, Query()] = "",


### PR DESCRIPTION
Resolves all remaining open SonarCloud issues and fixes both quality gate failures.

## Bug / Reliability fix

`lib/resume_parser.py` — NOSONAR on `_finalize_job(current_job)` calls at lines 447 and 470. Both are in branches guarded by `if not cur: continue` (L443) and the `else` of `elif after_blank or not cur:` respectively — cur is guaranteed non-None. Sonar's flow analysis doesn't track across elif chains.

## Code smell fixes

`lib/resume_parser.py:276` — Duplicate branch (S1764): the `if in_synopsis:` and final `else:` blocks had identical bodies after the `_is_tagline()` refactor. Collapsed into a single `else:` block by inverting the condition — logically equivalent, one implementation.

`transport/http/routes/dashboard/settings.py:140` — Added `responses={400: {"description": "Invalid config path"}}` to the `GET /settings` route decorator (S6956). The `_user_config_path()` helper it calls can raise HTTPException 400 — now documented at the route level.

## Tests: 1064 passed, 0 failures