### PR TITLE
test: boost coverage to 86.81% to clear Sonar new-code gate

### DIFF
--- a/tests/test_coverage_extras.py
+++ b/tests/test_coverage_extras.py
@@ -1,0 +1,282 @@
+import datetime as dt
+
+from transport.http.routes.login_page import login_html
+from tools import digest, health, session, tone
+
+
+def test_login_html_urlencodes_next_target():
+    html = login_html("/dashboard/settings?tab=profile&return=/dashboard")
+
+    assert "__NEXT_HREF__" not in html
+    assert "%2Fdashboard%2Fsettings%3Ftab%3Dprofile%26return%3D%2Fdashboard" in html
+
+
+def test_get_session_context_combines_all_sections(monkeypatch):
+    monkeypatch.setattr(session.config, "get_contact_name", lambda default: "Frank")
+    monkeypatch.setattr(session, "_load_master_context", lambda: "MASTER")
+    monkeypatch.setattr(session, "get_tone_profile", lambda: "TONE")
+    monkeypatch.setattr(session, "get_all_star_context", lambda: "STAR")
+    monkeypatch.setattr(session, "get_job_hunt_status", lambda: "STATUS")
+    monkeypatch.setattr(session, "get_people", lambda: "PEOPLE")
+
+    result = session.get_session_context()
+
+    assert "SESSION CONTEXT — Frank" in result
+    assert "MASTER" in result
+    assert "TONE" in result
+    assert "STAR" in result
+    assert "STATUS" in result
+    assert "PEOPLE" in result
+    assert "fully contextualized" in result
+
+
+def test_get_mental_health_log_reports_no_recent_entries(monkeypatch):
+    old_date = (dt.date.today() - dt.timedelta(days=30)).isoformat()
+    monkeypatch.setattr(
+        health,
+        "_load_json",
+        lambda *args, **kwargs: {"entries": [{"date": old_date, "energy": 5, "mood": "steady"}]},
+    )
+
+    result = health.get_mental_health_log(days=7)
+
+    assert result == "No check-ins logged in the past 7 days."
+
+
+def test_get_mental_health_log_formats_entries_and_low_energy_warning(monkeypatch):
+    today = dt.date.today()
+    entries = [
+        {
+            "date": (today - dt.timedelta(days=1)).isoformat(),
+            "energy": 2,
+            "mood": "tired",
+            "productive": False,
+            "notes": "rough day",
+        },
+        {
+            "date": today.isoformat(),
+            "energy": 4,
+            "mood": "steady",
+            "productive": True,
+            "notes": "",
+        },
+    ]
+    monkeypatch.setattr(health, "_load_json", lambda *args, **kwargs: {"entries": entries})
+
+    result = health.get_mental_health_log(days=14)
+
+    assert "═══ MENTAL HEALTH LOG" in result
+    assert "🟥" in result
+    assert "🟨" in result
+    assert "productive: ✓" in result
+    assert "rough day" in result
+    assert "Average energy over 14 days: 3.0/10" in result
+    assert "extended low-energy period" in result
+
+
+def test_get_mental_health_log_reports_high_energy_trend(monkeypatch):
+    today = dt.date.today()
+    entries = [
+        {"date": (today - dt.timedelta(days=1)).isoformat(), "energy": 8, "mood": "great", "productive": True},
+        {"date": today.isoformat(), "energy": 9, "mood": "locked in", "productive": True},
+    ]
+    monkeypatch.setattr(health, "_load_json", lambda *args, **kwargs: {"entries": entries})
+
+    result = health.get_mental_health_log(days=7)
+
+    assert "🟩" in result
+    assert "Average energy over 7 days: 8.5/10" in result
+    assert "strong energy" in result
+
+
+def test_get_tone_profile_renders_context_and_samples(monkeypatch):
+    monkeypatch.setattr(
+        tone,
+        "_load_json",
+        lambda *args, **kwargs: {
+            "samples": [
+                {"id": 1, "source": "cover_letter", "context": "target register", "text": "First sample", "word_count": 2},
+                {"id": 2, "source": "linkedin_post", "context": "", "text": "Second sample", "word_count": 2},
+            ]
+        },
+    )
+
+    result = tone.get_tone_profile()
+
+    assert "═══ TONE PROFILE (2 samples, 4 total words) ═══" in result
+    assert "Context: target register" in result
+    assert "First sample" in result
+    assert "Second sample" in result
+
+
+def test_budgeted_tone_profiles_handle_empty_samples(monkeypatch):
+    monkeypatch.setattr(tone, "_load_json", lambda *args, **kwargs: {"samples": []})
+
+    assert tone.get_tone_profile_budgeted() == tone._NO_TONE_SAMPLES_MESSAGE
+    assert tone.get_cover_letter_tone_profile_budgeted() == tone._NO_TONE_SAMPLES_MESSAGE
+
+
+def test_get_tone_profile_budgeted_selects_diverse_samples_in_order(monkeypatch):
+    samples = [
+        {"id": 1, "source": "cover_letter", "context": "target register", "text": "alpha", "word_count": 120},
+        {"id": 2, "source": "email", "context": "", "text": "beta", "word_count": 100},
+        {"id": 3, "source": "email", "context": "", "text": "gamma", "word_count": 100},
+    ]
+    monkeypatch.setattr(tone, "_load_json", lambda *args, **kwargs: {"samples": samples})
+    monkeypatch.setattr("lib.story_retrieval.estimate_tokens", lambda text: 10)
+
+    result = tone.get_tone_profile_budgeted(token_budget=25, max_samples=2)
+
+    assert "Sample #1" in result
+    assert "Sample #3" in result
+    assert "Sample #2" not in result
+    assert result.index("Sample #1") < result.index("Sample #3")
+
+
+def test_budgeted_tone_profiles_handle_zero_budget_and_oversized_samples(monkeypatch):
+    samples = [{"id": 1, "source": "cover_letter", "context": "", "text": "alpha", "word_count": 120}]
+    monkeypatch.setattr(tone, "_load_json", lambda *args, **kwargs: {"samples": samples})
+    monkeypatch.setattr("lib.story_retrieval.estimate_tokens", lambda text: 5000)
+
+    assert tone.get_tone_profile_budgeted(token_budget=0, max_samples=2) == ""
+    assert tone.get_tone_profile_budgeted(token_budget=100, max_samples=2) == ""
+    assert tone.get_cover_letter_tone_profile_budgeted(token_budget=0, max_samples=2) == ""
+    assert tone.get_cover_letter_tone_profile_budgeted(token_budget=100, max_samples=2) == ""
+
+
+def test_cover_letter_tone_score_rewards_high_signal_samples():
+    strong = {
+        "id": 9,
+        "source": "cover_letter_workday",
+        "context": "Strongest voice sample. Target register. Engineering philosophy.",
+        "text": "jobContextMCP helped the model actually sound like me " * 6,
+        "word_count": 120,
+    }
+    weak = {
+        "id": 3,
+        "source": "short_note",
+        "context": "",
+        "text": "tiny",
+        "word_count": 4,
+    }
+
+    assert tone._cover_letter_tone_score(strong) > tone._cover_letter_tone_score(weak)
+
+
+def test_get_daily_digest_surfaces_actionable_sections(monkeypatch):
+    today = dt.date.today()
+    recent = today.isoformat()
+    stale = (today - dt.timedelta(days=20)).isoformat()
+    closed = (today - dt.timedelta(days=5)).isoformat()
+    apps = [
+        {
+            "company": "WaitCo",
+            "role": "Platform Engineer",
+            "status": "applied",
+            "last_updated": recent,
+            "events": [{"type": "applied", "date": recent, "notes": "Submitted application. Recruiter replied fast."}],
+        },
+        {
+            "company": "ReviewCo",
+            "role": "Backend Engineer",
+            "status": "saved",
+            "last_updated": stale,
+            "events": [],
+        },
+        {
+            "company": "ClosedCo",
+            "role": "Staff Engineer",
+            "status": "rejected",
+            "last_updated": closed,
+            "events": [],
+        },
+    ]
+    queue_jobs = [
+        {"company": "QueueCo", "role": "Platform Engineer", "status": "pending"},
+        {"company": "ScoreCo", "role": "AI Engineer", "status": "evaluated", "fitment_score": "8/10"},
+    ]
+    people = [{"name": "Alex", "company": "WaitCo", "outreach_status": "drafted"}]
+
+    monkeypatch.setattr(digest, "_load_apps", lambda: apps)
+    monkeypatch.setattr(digest, "_load_queue", lambda: queue_jobs)
+    monkeypatch.setattr(digest, "_load_rejections", lambda: [{"company": "ClosedCo"}])
+    monkeypatch.setattr(digest, "_load_people", lambda: people)
+    monkeypatch.setattr(digest, "_load_health", lambda: [])
+    monkeypatch.setattr(
+        digest,
+        "_check_overdue_followups",
+        lambda active: ["[FOLLOW-UP] WaitCo — Platform Engineer: send update"],
+    )
+    monkeypatch.setattr(digest, "get_daily_checkin_nudge", lambda: "NUDGE")
+
+    result = digest.get_daily_digest()
+
+    assert "NEEDS DECISION" in result
+    assert "QueueCo" in result
+    assert "ACTION  —  FOLLOW-UPS DUE" in result
+    assert "ACTION  —  DRAFTED BUT NOT SENT" in result
+    assert "WAITING ON OTHERS" in result
+    assert "NEEDS REVIEW" in result
+    assert "RECENT PROGRESS" in result
+    assert "TOTALS: 3 apps tracked  /  1 rejection logged" in result
+    assert "Follow up: WaitCo" in result
+    assert "NUDGE" in result
+
+
+def test_get_daily_digest_uses_fallback_focus_without_nudge(monkeypatch):
+    today = dt.date.today().isoformat()
+
+    monkeypatch.setattr(digest, "_load_apps", lambda: [])
+    monkeypatch.setattr(digest, "_load_queue", lambda: [])
+    monkeypatch.setattr(digest, "_load_rejections", lambda: [])
+    monkeypatch.setattr(digest, "_load_people", lambda: [])
+    monkeypatch.setattr(digest, "_load_health", lambda: [{"date": today, "energy": 7, "mood": "good"}])
+    monkeypatch.setattr(digest, "_check_overdue_followups", lambda active: [])
+    monkeypatch.setattr(digest, "get_daily_checkin_nudge", lambda: "SHOULD NOT APPEAR")
+
+    result = digest.get_daily_digest()
+
+    assert "Apply to 2-3 new roles" in result
+    assert "Log a check-in after the session" in result
+    assert "SHOULD NOT APPEAR" not in result
+
+
+def test_weekly_summary_reports_contacts_and_low_energy(monkeypatch):
+    recent = (dt.date.today() - dt.timedelta(days=1)).isoformat()
+
+    monkeypatch.setattr(
+        digest,
+        "_load_apps",
+        lambda: [{"company": "Acme", "role": "Backend Engineer", "status": "applied", "applied_date": recent, "last_updated": recent}],
+    )
+    monkeypatch.setattr(digest, "_load_rejections", lambda: [{"date": recent, "stage": "phone"}])
+    monkeypatch.setattr(
+        digest,
+        "_load_people",
+        lambda: [{"name": "Riley", "company": "Acme", "relationship": "recruiter", "added_at": recent}],
+    )
+    monkeypatch.setattr(
+        digest,
+        "_load_health",
+        lambda: [{"date": recent, "energy": 3, "mood": "tired", "productive": False}],
+    )
+
+    result = digest.weekly_summary()
+
+    assert "CONTACTS ADDED: 1" in result
+    assert "Riley (Acme, recruiter)" in result
+    assert "Avg energy: 3.0/10" in result
+    assert "Productive days: 0/1" in result
+    assert "Mood distribution: tired (1x)" in result
+    assert "Low-energy week. Be gentle with yourself." in result
+
+
+def test_weekly_summary_reports_missing_checkins(monkeypatch):
+    monkeypatch.setattr(digest, "_load_apps", lambda: [])
+    monkeypatch.setattr(digest, "_load_rejections", lambda: [])
+    monkeypatch.setattr(digest, "_load_people", lambda: [])
+    monkeypatch.setattr(digest, "_load_health", lambda: [])
+
+    result = digest.weekly_summary()
+
+    assert "No check-ins logged this week." in result

--- a/tests/test_entra_auth.py
+++ b/tests/test_entra_auth.py
@@ -571,6 +571,56 @@ class TestOauthAuthorizeProxy:
         assert "state=mystate" in location
 
 
+class TestOauthTokenProxy:
+    def test_strips_resource_and_preserves_error_response(self, monkeypatch, oauth_client):
+        import httpx
+
+        captured = {}
+
+        class FakeResponse:
+            status_code = 400
+            text = '{"error":"invalid_grant"}'
+            content = b'{"error":"invalid_grant"}'
+            headers = {"Content-Type": "application/json; charset=utf-8"}
+
+        class FakeAsyncClient:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def post(self, url, data, headers, timeout):
+                captured["url"] = url
+                captured["data"] = data
+                captured["headers"] = headers
+                captured["timeout"] = timeout
+                return FakeResponse()
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda: FakeAsyncClient())
+
+        r = oauth_client.post(
+            "/oauth/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": "0123456789abcdef",
+                "client_secret": "super-secret-value",
+                "resource": "https://jobcontext.ai",
+            },
+        )
+
+        assert r.status_code == 400
+        assert r.json() == {"error": "invalid_grant"}
+        assert captured["url"].endswith("/oauth2/v2.0/token")
+        assert captured["data"] == {
+            "grant_type": "authorization_code",
+            "code": "0123456789abcdef",
+            "client_secret": "super-secret-value",
+        }
+        assert captured["headers"]["Content-Type"] == "application/x-www-form-urlencoded"
+        assert captured["timeout"] == 30
+
+
 class TestLogoutEndpoints:
     def test_logout_redirects_to_entra(self, oauth_client):
         r = oauth_client.get("/logout", follow_redirects=False)
@@ -591,6 +641,27 @@ class TestLogoutEndpoints:
     def test_logged_out_page_has_cache_clear_instructions(self, oauth_client):
         r = oauth_client.get("/logged-out")
         assert "mcp-remote" in r.text or "rm -rf" in r.text
+
+
+class TestLogoutPostEndpoints:
+    def test_logout_post_uses_local_redirect_for_api_key_auth(self, http_client_authed):
+        r = http_client_authed.post("/logout", follow_redirects=False)
+
+        assert r.status_code == 303
+        assert r.headers["location"] == "/"
+        assert "jc_session=" in r.headers["set-cookie"]
+
+    def test_logout_post_redirects_to_entra_using_server_base(self, monkeypatch, oauth_client):
+        monkeypatch.setenv("SERVER_BASE_URL", "https://jobs.example.com")
+
+        r = oauth_client.post("/logout", follow_redirects=False)
+
+        assert r.status_code == 303
+        assert (
+            r.headers["location"]
+            == "https://login.microsoftonline.com/test-tenant/oauth2/v2.0/logout?post_logout_redirect_uri=https://jobs.example.com/"
+        )
+        assert "jc_session=" in r.headers["set-cookie"]
 
 
 class _StubAuthProvider:

--- a/tests/test_fitment.py
+++ b/tests/test_fitment.py
@@ -15,6 +15,7 @@ import pytest
 import server as srv
 from services import JobAnalysisService
 from services.persona_service import PersonaService
+from tools import fitment
 
 
 JD = "We need a senior engineer with React, Node, and AWS."
@@ -106,6 +107,59 @@ class TestRunJobAssessmentPersona:
         out = srv.run_job_assessment("Stripe", "Staff Engineer", JD, persona="executive_polish")
         assert PersonaService.get("executive_polish").to_prompt_block() in out
 
+    @pytest.mark.live_llm
+    def test_unknown_persona_warning_and_auto_save(self, isolated_server, monkeypatch):
+        from lib import config
+
+        monkeypatch.setitem(config._cfg, "openai_api_key", "sk-real-test-key")
+
+        fake_client = MagicMock()
+        fake_response = MagicMock()
+        fake_response.choices = [MagicMock(message=MagicMock(content="FITMENT SCORE: 6/10"))]
+        fake_response.usage = MagicMock(prompt_tokens=10, completion_tokens=5)
+        fake_client.chat.completions.create.return_value = fake_response
+
+        with patch("lib.config.get_llm_client", return_value=(fake_client, "gpt-4o")):
+            out = srv.run_job_assessment(
+                "ACME/AI",
+                "AI Platform Engineer",
+                "Build MCP and RAG workflows.",
+                persona="missing_persona",
+            )
+
+        saved = fitment.config.get_active_job_assessments_dir() / "run_job_assessment" / "ACME-AI AI Platform Engineer - Fitment Assessment.md"
+        assert "persona warning:" in out
+        assert "Saved job assessment" in out
+        assert saved.exists()
+        assert saved.read_text(encoding="utf-8") == "FITMENT SCORE: 6/10"
+
+    @pytest.mark.live_llm
+    def test_ai_role_includes_ai_evidence_in_user_message(self, isolated_server, monkeypatch):
+        from lib import config
+
+        monkeypatch.setitem(config._cfg, "openai_api_key", "sk-real-test-key")
+
+        fake_client = MagicMock()
+        fake_response = MagicMock()
+        fake_response.choices = [MagicMock(message=MagicMock(content="FITMENT SCORE: 8/10"))]
+        fake_response.usage = None
+        fake_client.chat.completions.create.return_value = fake_response
+
+        with patch("lib.config.get_llm_client", return_value=(fake_client, "gpt-4o")), patch(
+            "tools.fitment._load_master_context",
+            return_value="Built an MCP server for agent workflows.\nPlain Java service line.",
+        ):
+            srv.run_job_assessment(
+                "Stripe",
+                "AI Platform Engineer",
+                "Build RAG agents and MCP tooling.",
+                auto_save=False,
+            )
+
+        user_msg = fake_client.chat.completions.create.call_args.kwargs["messages"][1]["content"]
+        assert "AI PLATFORM EVIDENCE EXTRACTED FROM MASTER RESUME" in user_msg
+        assert "- Built an MCP server for agent workflows." in user_msg
+
 
 class TestJobAnalysisServicePersona:
     def test_evaluate_threads_persona_to_pack(self, isolated_server):
@@ -140,3 +194,44 @@ class TestJobAnalysisServicePersona:
         )
         assert "PERSONA LENS" in out
         assert PersonaService.get("startup_founder").to_prompt_block() in out
+
+
+class TestFitmentCoverageExtras:
+    def test_extract_ai_platform_evidence_returns_empty_without_matches(self):
+        assert fitment._extract_ai_platform_evidence("Plain Java backend. Spring services only.") == ""
+
+    def test_get_customization_strategy_reports_unknown_role_type(self):
+        out = fitment.get_customization_strategy("mystery_role")
+
+        assert "Unknown role type: 'mystery_role'" in out
+        assert "backend" in out
+        assert "cloud" in out
+
+    def test_save_job_assessment_sanitizes_source_and_extension(self, isolated_server):
+        out = fitment.save_job_assessment(
+            "ACME/AI",
+            "Line one  \nLine two  ",
+            filename="summary",
+            source="Referral\\Team",
+        )
+
+        saved = fitment.config.get_active_job_assessments_dir() / "Referral-Team" / "summary.md"
+        assert "Referral-Team/summary.md" in out
+        assert saved.read_text(encoding="utf-8") == "Line one\nLine two"
+
+    def test_run_job_assessment_handles_llm_client_boot_failure(self, isolated_server):
+        with patch("lib.config.get_llm_client", side_effect=RuntimeError("boom")):
+            out = fitment.run_job_assessment("Stripe", "Staff Engineer", JD)
+
+        assert out == "✗ Failed to load LLM client. Check config.json llm_provider settings."
+
+    def test_run_job_assessment_handles_openai_errors(self, isolated_server):
+        fake_client = object()
+
+        with patch("lib.config.get_llm_client", return_value=(fake_client, "gpt-4o")), patch(
+            "tools.fitment.create_chat_completion",
+            side_effect=RuntimeError("rate limited"),
+        ):
+            out = fitment.run_job_assessment("Stripe", "Staff Engineer", JD, auto_save=False)
+
+        assert out == "✗ OpenAI API error: rate limited"


### PR DESCRIPTION
Pushes total coverage from 83% → 86.81% to clear Sonar's 80% new-code gate (currently failing at 78.93%).

Added targeted tests in `tests/test_coverage_extras.py`, `tests/test_fitment.py`, and `tests/test_entra_auth.py` for the files that were dragging new-code coverage below the threshold.

| File | Before | After |
|---|---|---|
| `transport/http/routes/login_page.py` | 50% | 100% |
| `transport/http/routes/oauth.py` | 70% | 100% |
| `tools/session.py` | 75% | 100% |
| `tools/tone.py` | 76% | 99% |
| `tools/fitment.py` | 72% | 96% |
| `tools/health.py` | 45% | 96% |
| `tools/digest.py` | 75% | 95% |

**Tests: 1088 passed. Total coverage: 86.81%**