### PR TITLE
fix(security): tenant-scope LaTeX section writes (cross-tenant data leak)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ JobContextMCP is now more than a stdio MCP server. The current branch combines:
 
 | Area | Included capabilities |
 |------|----------------------|
-| Authentication + multi-user | Entra ID OAuth2 PKCE browser login for AKS-hosted dashboard; JWT validation (v1/v2 audience); per-user data isolation via `ContextVar` — each guest gets their own SQLite DB, workspace folder, and JSON partition; owner OID routes to full corpus; auto-provisioning with placeholder resume on first login; logout button on all dashboard pages |
+| Authentication + multi-user | Entra ID OAuth2 PKCE browser login for AKS-hosted dashboard; JWT validation (v1/v2 audience); per-user data isolation via `ContextVar` — every authenticated user (owner included) gets their own SQLite DB, workspace folder, and JSON partition under `/app/data/users/{oid}/`; auto-provisioning with placeholder resume on first login; logout button on all dashboard pages |
 | Persistent context | Master resume, STAR stories, tone samples, personal stories, HBDI profile, contacts, interviews, pipeline, rejections, compensation, LinkedIn posts, mental-health logs |
 | Application pipeline | Job queue, duplicate-safe intake, fitment assessment, persona lenses, add/dismiss decisions, immutable application events, compensation comparison, rejection analysis |
 | Dashboard + mobile UI | Local browser dashboard, LAN/phone mode, token login, daily digest (with NEEDS DECISION queue section), pipeline triage, queue assessment, cover-letter edit dialog with draft versioning, resume/cover-letter generation, PDF export, people/outreach/wellbeing views |
@@ -192,8 +192,8 @@ graph TB
   end
 
   subgraph AKS_FILES["Storage (AKS mode)"]
-    AKS_OWNER["Owner corpus — /app/data/\nFull SQLite DB + workspace (ENTRA_OWNER_OID)"]
-    AKS_USERS["Per-user partitions — /app/data/users/{oid}/\nIsolated SQLite + workspace per guest\nAuto-provisioned with placeholder resume"]
+    AKS_GLOBAL["Global root — /app/data/\nShared DB for pre-auth API-key lookups only\nNo tenant request is scoped here"]
+    AKS_USERS["Per-user partitions — /app/data/users/{oid}/\nIsolated SQLite + workspace per user (owner included)\nAuto-provisioned with placeholder resume"]
     BLOB["Azure Blob Storage — jcmcpstore/workspace\nSidecar syncs PVC → blob every 15 min"]
   end
 
@@ -203,10 +203,10 @@ graph TB
   TOOLS --> MATERIALS
   TOOLS --> INDEX
   TOOLS --> PROJECTS
-  TOOLS --> AKS_OWNER
   TOOLS --> AKS_USERS
   ENTRA --> AKS_USERS
-  AKS_OWNER --> BLOB
+  ENTRA --> AKS_GLOBAL
+  AKS_GLOBAL --> BLOB
   AKS_USERS --> BLOB
 ```
 
@@ -246,7 +246,7 @@ sequenceDiagram
     MW->>Store: provision_user_data(oid) — idempotent\ncreate SQLite DB + workspace dirs + placeholder resume
     MW-->>Browser: Set jc_session cookie → redirect /dashboard/
 
-    note over MW,Store: Owner OID → /app/data/ (full corpus)\nAll others → /app/data/users/{oid}/ (isolated)
+    note over MW,Store: Every authenticated user (owner included) → /app/data/users/{oid}/ (isolated)\nGlobal /app/data/ DB is used only for pre-auth API-key lookups
 ```
 
 ### End-to-End: Mobile/Dashboard Pipeline Flow
@@ -260,7 +260,7 @@ sequenceDiagram
     participant LLM as OpenAI, Ollama, or Copilot Fallback
     participant Store as Data Partition (ContextVar-scoped)
 
-    note over API,Store: ContextVar set by UserDataContextMiddleware per request\nOwner → /app/data/  ·  Guest → /app/data/users/{oid}/
+    note over API,Store: ContextVar set by UserDataContextMiddleware per request\nEvery authenticated user (owner included) → /app/data/users/{oid}/
 
     You->>UI: Paste or queue job description
     UI->>API: POST /jobs/queue
@@ -1185,10 +1185,10 @@ The guest must accept the Entra invitation before their first login. After accep
 
 | User | Data path | Rule |
 |---|---|---|
-| Service owner (`ENTRA_OWNER_OID`) | `/app/data/` | Full corpus; all tools, pipeline, and generated materials |
-| Any other authenticated user | `/app/data/users/{entra_oid}/` | Isolated SQLite DB + workspace; placeholder resume seeded on first login |
+| Any authenticated Entra user (owner included) | `/app/data/users/{entra_oid}/` | Isolated SQLite DB + workspace; placeholder resume seeded on first login |
+| Global root | `/app/data/db/` | Not a tenant destination; holds only the shared DB used for pre-auth per-user API-key lookups |
 
-The `UserDataContextMiddleware` handles routing transparently — tools and dashboard routes read and write the caller's partition with no code changes required.
+The `UserDataContextMiddleware` handles routing transparently — tools and dashboard routes read and write the caller's partition with no code changes required. `ENTRA_OWNER_OID` only governs contact-info fallback and owner-only UI flags; it does **not** change storage routing, so the owner is isolated to their own `/app/data/users/{oid}/` partition like everyone else.
 
 
 
@@ -1531,7 +1531,7 @@ PDFs land in `03-Resume-PDFs/` inside your `resume_folder`. Available templates:
 v1.0 completes the transformation from a local stdio context server into a multi-user, cloud-hosted job-search platform:
 
 - **Entra ID browser authentication** — full PKCE OAuth2 login flow for the AKS-hosted dashboard; JWT validation (v1 + v2 audiences); secure `jc_session` cookie; logout from every page.
-- **Per-user data isolation** — each authenticated user (guest or tenant member) gets their own isolated SQLite DB, workspace folder tree, and JSON partition. The service owner routes to the full corpus; everyone else is scoped to `/app/data/users/{oid}/`. Auto-provisioned on first login with a placeholder resume so the setup flow works immediately.
+- **Per-user data isolation** — each authenticated user (owner included) gets their own isolated SQLite DB, workspace folder tree, and JSON partition, scoped to `/app/data/users/{oid}/`. Auto-provisioned on first login with a placeholder resume so the setup flow works immediately.
 - **Root landing page** — browser-friendly `/` with project banner and Sign In CTA, replacing the bare 404.
 - **MCP Streamable HTTP transport (`2025-03-26`)** — VS Code + GitHub Copilot (and any HTTP MCP client) can connect to the live AKS pod over the standard transport via `kubectl port-forward`.
 - **SQLite + dual-write persistence** — all pipeline writes go to both SQLite and JSON; reads come from SQLite when `USE_SQLITE=1`; `SQLITE_ONLY=1` skips JSON for production AKS.

--- a/tests/test_latex_export.py
+++ b/tests/test_latex_export.py
@@ -661,12 +661,13 @@ class TestLatexExportTenantIsolation:
 # ---------------------------------------------------------------------------
 
 def test_read_latex_asset_returns_file_contents(monkeypatch, tmp_path):
-    """read_latex_asset returns the content of an allowlisted file."""
+    """read_latex_asset returns bundled default content when no tenant overlay exists."""
     bundled = tmp_path / "latex_assets"
     bundled.mkdir()
     (bundled / "TLCresume.sty").write_text("\\ProvidesPackage{TLCresume}", encoding="utf-8")
 
     monkeypatch.setattr(latex_export, "_BUNDLED_LATEX_ASSETS_DIR", bundled)
+    monkeypatch.setattr(latex_export, "_tenant_latex_assets_dir", lambda: tmp_path / "tenant")
 
     result = latex_export.read_latex_asset("TLCresume.sty")
     assert "ProvidesPackage" in result
@@ -680,6 +681,7 @@ def test_read_latex_asset_reads_section_file(monkeypatch, tmp_path):
     (sections / "synopsis.tex").write_text("\\noindent My summary.", encoding="utf-8")
 
     monkeypatch.setattr(latex_export, "_BUNDLED_LATEX_ASSETS_DIR", bundled)
+    monkeypatch.setattr(latex_export, "_tenant_latex_assets_dir", lambda: tmp_path / "tenant")
 
     result = latex_export.read_latex_asset("sections/synopsis.tex")
     assert "My summary" in result
@@ -705,6 +707,7 @@ def test_read_latex_asset_raises_if_file_missing(monkeypatch, tmp_path):
     # Don't create TLCresume.sty
 
     monkeypatch.setattr(latex_export, "_BUNDLED_LATEX_ASSETS_DIR", bundled)
+    monkeypatch.setattr(latex_export, "_tenant_latex_assets_dir", lambda: tmp_path / "tenant")
 
     import pytest
     with pytest.raises(FileNotFoundError):
@@ -716,16 +719,13 @@ def test_read_latex_asset_raises_if_file_missing(monkeypatch, tmp_path):
 # ---------------------------------------------------------------------------
 
 def test_write_latex_section_creates_file(monkeypatch, tmp_path):
-    """write_latex_section writes content to sections/ and returns confirmation."""
-    bundled = tmp_path / "latex_assets"
-    sections = bundled / "sections"
-    sections.mkdir(parents=True)
-
-    monkeypatch.setattr(latex_export, "_BUNDLED_LATEX_ASSETS_DIR", bundled)
+    """write_latex_section writes content to the tenant sections/ dir and returns confirmation."""
+    tenant = tmp_path / "tenant"
+    monkeypatch.setattr(latex_export, "_tenant_latex_assets_dir", lambda: tenant)
 
     result = latex_export.write_latex_section("synopsis.tex", "\\noindent Tailored summary.")
 
-    target = sections / "synopsis.tex"
+    target = tenant / "sections" / "synopsis.tex"
     assert target.exists()
     assert target.read_text(encoding="utf-8") == "\\noindent Tailored summary."
     assert "✓" in result
@@ -734,16 +734,15 @@ def test_write_latex_section_creates_file(monkeypatch, tmp_path):
 
 def test_write_latex_section_overwrites_existing_content(monkeypatch, tmp_path):
     """write_latex_section replaces existing file content."""
-    bundled = tmp_path / "latex_assets"
-    sections = bundled / "sections"
-    sections.mkdir(parents=True)
-    (sections / "synopsis.tex").write_text("old content", encoding="utf-8")
+    tenant = tmp_path / "tenant"
+    (tenant / "sections").mkdir(parents=True)
+    (tenant / "sections" / "synopsis.tex").write_text("old content", encoding="utf-8")
 
-    monkeypatch.setattr(latex_export, "_BUNDLED_LATEX_ASSETS_DIR", bundled)
+    monkeypatch.setattr(latex_export, "_tenant_latex_assets_dir", lambda: tenant)
 
     latex_export.write_latex_section("synopsis.tex", "new content")
 
-    assert (sections / "synopsis.tex").read_text(encoding="utf-8") == "new content"
+    assert (tenant / "sections" / "synopsis.tex").read_text(encoding="utf-8") == "new content"
 
 
 def test_write_latex_section_rejects_unlisted_file(monkeypatch, tmp_path):
@@ -773,15 +772,106 @@ def test_write_latex_section_rejects_path_traversal(monkeypatch, tmp_path):
 
 def test_read_write_roundtrip(monkeypatch, tmp_path):
     """Write a section then read it back — content must survive the roundtrip."""
+    tenant = tmp_path / "tenant"
     bundled = tmp_path / "latex_assets"
     (bundled / "sections").mkdir(parents=True)
 
+    monkeypatch.setattr(latex_export, "_tenant_latex_assets_dir", lambda: tenant)
     monkeypatch.setattr(latex_export, "_BUNDLED_LATEX_ASSETS_DIR", bundled)
 
     content = "\\begin{zitemize}\n\\item Led migration.\n\\end{zitemize}"
     latex_export.write_latex_section("experience.tex", content)
 
-    # Add to readable allowlist for this test (experience.tex is already there)
     result = latex_export.read_latex_asset("sections/experience.tex")
     assert "Led migration" in result
+
+
+# ---------------------------------------------------------------------------
+# Tenant isolation regression tests (cross-tenant leak guard)
+# ---------------------------------------------------------------------------
+
+def test_write_latex_section_writes_to_tenant_not_bundled(monkeypatch, tmp_path):
+    """Section writes must land in the per-tenant overlay, never the shared
+    bundled template dir that every tenant compiles from."""
+    tenant = tmp_path / "tenant"
+    bundled = tmp_path / "latex_assets"
+    (bundled / "sections").mkdir(parents=True)
+
+    monkeypatch.setattr(latex_export, "_tenant_latex_assets_dir", lambda: tenant)
+    monkeypatch.setattr(latex_export, "_BUNDLED_LATEX_ASSETS_DIR", bundled)
+
+    latex_export.write_latex_section("experience.tex", "TENANT PRIVATE CONTENT")
+
+    assert (tenant / "sections" / "experience.tex").read_text(encoding="utf-8") == "TENANT PRIVATE CONTENT"
+    # The shared bundled template must be left untouched.
+    assert not (bundled / "sections" / "experience.tex").exists()
+
+
+def test_read_latex_asset_prefers_tenant_overlay(monkeypatch, tmp_path):
+    """A tenant's own overlay copy wins over the bundled default."""
+    tenant = tmp_path / "tenant"
+    bundled = tmp_path / "latex_assets"
+    (tenant / "sections").mkdir(parents=True)
+    (bundled / "sections").mkdir(parents=True)
+    (tenant / "sections" / "synopsis.tex").write_text("TENANT VERSION", encoding="utf-8")
+    (bundled / "sections" / "synopsis.tex").write_text("BUNDLED DEFAULT", encoding="utf-8")
+
+    monkeypatch.setattr(latex_export, "_tenant_latex_assets_dir", lambda: tenant)
+    monkeypatch.setattr(latex_export, "_BUNDLED_LATEX_ASSETS_DIR", bundled)
+
+    assert latex_export.read_latex_asset("sections/synopsis.tex") == "TENANT VERSION"
+
+
+def test_read_latex_asset_falls_back_to_bundled_default(monkeypatch, tmp_path):
+    """With no tenant overlay, read returns the bundled read-only default."""
+    tenant = tmp_path / "tenant"  # never created
+    bundled = tmp_path / "latex_assets"
+    (bundled / "sections").mkdir(parents=True)
+    (bundled / "sections" / "synopsis.tex").write_text("BUNDLED DEFAULT", encoding="utf-8")
+
+    monkeypatch.setattr(latex_export, "_tenant_latex_assets_dir", lambda: tenant)
+    monkeypatch.setattr(latex_export, "_BUNDLED_LATEX_ASSETS_DIR", bundled)
+
+    assert latex_export.read_latex_asset("sections/synopsis.tex") == "BUNDLED DEFAULT"
+
+
+def test_latex_section_writes_are_tenant_isolated(monkeypatch, tmp_path):
+    """End-to-end isolation: content written under tenant A's data-folder context
+    must be invisible to tenant B (who sees the bundled default instead).
+    Exercises the real ContextVar resolver via set_data_folder."""
+    from lib import user_context
+
+    bundled = tmp_path / "latex_assets"
+    (bundled / "sections").mkdir(parents=True)
+    (bundled / "sections" / "experience.tex").write_text(
+        "BUNDLED DEFAULT EXPERIENCE", encoding="utf-8"
+    )
+    monkeypatch.setattr(latex_export, "_BUNDLED_LATEX_ASSETS_DIR", bundled)
+
+    tenant_a = tmp_path / "users" / "oid-a"
+    tenant_b = tmp_path / "users" / "oid-b"
+
+    # Tenant A writes private content.
+    tok_a = user_context.set_data_folder(tenant_a)
+    try:
+        latex_export.write_latex_section("experience.tex", "TENANT A PRIVATE RESUME")
+    finally:
+        user_context.reset_data_folder(tok_a)
+
+    # Tenant B reads the same logical asset — must NOT see A's content.
+    tok_b = user_context.set_data_folder(tenant_b)
+    try:
+        b_view = latex_export.read_latex_asset("sections/experience.tex")
+    finally:
+        user_context.reset_data_folder(tok_b)
+    assert "TENANT A PRIVATE RESUME" not in b_view
+    assert "BUNDLED DEFAULT EXPERIENCE" in b_view
+
+    # And A can still read back their own content.
+    tok_a2 = user_context.set_data_folder(tenant_a)
+    try:
+        a_view = latex_export.read_latex_asset("sections/experience.tex")
+    finally:
+        user_context.reset_data_folder(tok_a2)
+    assert "TENANT A PRIVATE RESUME" in a_view
 

--- a/tools/latex_export.py
+++ b/tools/latex_export.py
@@ -111,6 +111,20 @@ def _latex_dir() -> Path | None:
     return d
 
 
+def _tenant_latex_assets_dir() -> Path:
+    """Return the per-request writable LaTeX assets overlay directory.
+
+    Resolves through the tenant-aware workspace resolver
+    (``cfg.get_active_workspace_folder``), so an authenticated guest gets
+    ``data/users/{oid}/workspace/latex_assets`` and the owner / local dev gets
+    their own workspace copy. The bundled ``templates/latex_assets`` dir is a
+    shared, READ-ONLY source of defaults only: user-supplied section content
+    must never be written there or it would leak across tenants (every tenant
+    compiles from the same bundled path).
+    """
+    return cfg.get_active_workspace_folder() / "latex_assets"
+
+
 def _user_identity() -> dict[str, str]:
     """Read contact info from the active user's config.json at call time.
 
@@ -565,6 +579,15 @@ def generate_resume_latex(
         # the temp workspace so \input{sections/skills} and friends resolve.
         shutil.copytree(str(latex_src), str(tmp_path), dirs_exist_ok=True)
 
+        # Overlay the caller's per-tenant LaTeX assets (sections they tailored
+        # via write_latex_section) on top of the shared source so their edits
+        # win at compile time — and so no other tenant's sections can ever bleed
+        # into this compile. Tenant assets live under the request-scoped
+        # workspace, resolved by _tenant_latex_assets_dir().
+        tenant_assets = _tenant_latex_assets_dir()
+        if tenant_assets.exists():
+            shutil.copytree(str(tenant_assets), str(tmp_path), dirs_exist_ok=True)
+
         # Override the header identity + role on the temp copy only, so the
         # source resume.tex on disk is never mutated AND a shared template
         # (e.g. the bundled assets used on AKS) can never emit another user's
@@ -635,13 +658,19 @@ _WRITABLE_LATEX_SECTIONS: set[str] = {
 
 
 def read_latex_asset(filename: str) -> str:
-    """Read a file from the bundled LaTeX resume assets.
+    """Read a LaTeX resume asset, tenant overlay first, bundled default second.
 
     Allows the AI to inspect TLCresume.sty, resume.tex, _header.tex, and any
     section file so it understands the available macros before writing content.
 
+    Resolution order (tenant isolation): the requesting user's own overlay copy
+    under ``_tenant_latex_assets_dir()`` is preferred; if they have not written
+    that file yet, the shared read-only bundled default is returned. A user
+    therefore only ever sees their own edits or the pristine template — never
+    another tenant's content.
+
     Args:
-        filename: Relative path within templates/latex_assets/, e.g.
+        filename: Relative path within the assets tree, e.g.
                   ``"TLCresume.sty"`` or ``"sections/experience.tex"``.
 
     Returns:
@@ -649,26 +678,40 @@ def read_latex_asset(filename: str) -> str:
 
     Raises:
         PermissionError: If the filename is not in the readable allowlist.
-        FileNotFoundError: If the file does not exist.
+        FileNotFoundError: If neither the tenant overlay nor a bundled default
+            exists for the file.
     """
     if filename not in _READABLE_LATEX_ASSETS:
         raise PermissionError(
             f"'{filename}' is not in the readable LaTeX asset allowlist. "
             f"Allowed files: {sorted(_READABLE_LATEX_ASSETS)}"
         )
-    target = _BUNDLED_LATEX_ASSETS_DIR / filename
-    if not target.exists():
-        raise FileNotFoundError(f"LaTeX asset not found: {target}")
-    return target.read_text(encoding="utf-8")
+    tenant_target = _tenant_latex_assets_dir() / filename
+    if tenant_target.exists():
+        return tenant_target.read_text(encoding="utf-8")
+    bundled = _BUNDLED_LATEX_ASSETS_DIR / filename
+    if bundled.exists():
+        return bundled.read_text(encoding="utf-8")
+    raise FileNotFoundError(
+        f"LaTeX asset not found: {filename} "
+        "(checked the tenant overlay and the bundled defaults)."
+    )
 
 
 def write_latex_section(section_filename: str, content: str) -> str:
-    """Overwrite a section file in the bundled LaTeX resume assets.
+    """Write a tailored resume section into the caller's per-tenant overlay.
 
     Use this to inject tailored content (summary, experience, skills) into the
-    resume before calling ``export_resume_latex``.  Only files in
-    ``templates/latex_assets/sections/`` are writable.  The base template files
+    resume before calling ``export_resume_latex``.  Only the section files in
+    the writable allowlist may be written; the base template files
     (``TLCresume.sty``, ``resume.tex``, ``_header.tex``) are read-only.
+
+    Tenant isolation: content is written under ``_tenant_latex_assets_dir()``
+    (the request-scoped workspace, e.g. ``data/users/{oid}/workspace/
+    latex_assets/sections/``), NEVER the shared bundled template dir. One
+    tenant's section content can therefore never be read back or compiled by
+    another tenant.  ``read_latex_asset`` and ``export_resume_latex`` both
+    prefer this overlay over the bundled defaults.
 
     Workflow::
 
@@ -697,7 +740,11 @@ def write_latex_section(section_filename: str, content: str) -> str:
             f"'{section_filename}' is not in the writable sections allowlist. "
             f"Writable: {sorted(_WRITABLE_LATEX_SECTIONS)}"
         )
-    target = _BUNDLED_LATEX_ASSETS_DIR / "sections" / section_filename
+    # Write into the per-tenant overlay, NEVER the shared bundled template dir.
+    # _tenant_latex_assets_dir() resolves through the request-scoped ContextVar
+    # (get_active_workspace_folder), so each user's sections stay in their own
+    # data partition and can never leak into another tenant's read or compile.
+    target = _tenant_latex_assets_dir() / "sections" / section_filename
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(content, encoding="utf-8")
     return f"✓ Written: {target} ({len(content)} chars)"


### PR DESCRIPTION
## Severity: High — cross-tenant data leak

`write_latex_section` and `read_latex_asset` are per-tenant MCP tools (callable by any authenticated user via chat), but they wrote to / read from the **shared bundled template dir** (`templates/latex_assets`) that every tenant compiles from. The write bypassed the `ContextVar` tenant resolver with a direct path write.

**Leak path:** Tenant A calls `write_latex_section("experience.tex", "<A's real resume>")` → shared file on the pod. Tenant B (same pod) calls `read_latex_asset("sections/experience.tex")` — the documented step 2 of the workflow — and reads A's private content, or it bleeds into B's next compiled PDF. This is the same leak class the contextvars work closed, resurfacing through the LaTeX asset path.

## Fix (mirrors the `_save_job_queue()` tenant-resolution pattern)

- **New `_tenant_latex_assets_dir()`** resolves through `cfg.get_active_workspace_folder()`, so assets live under the request-scoped `data/users/{oid}/workspace/latex_assets`. The bundled dir becomes read-only defaults.
- **`write_latex_section`** writes to the per-tenant overlay, never the bundled dir.
- **`read_latex_asset`** reads the tenant overlay first, falling back to the bundled read-only default (a user sees only their own edits or the pristine template).
- **`generate_resume_latex`** overlays the tenant's assets into the temp compile dir so their sections win and no other tenant's sections can bleed in.

## Tests

- Updated the read/write suite for the overlay model.
- Added `test_latex_section_writes_are_tenant_isolated` — a real end-to-end isolation test using `user_context.set_data_folder` that proves tenant B cannot see tenant A's write (B gets the bundled default; A reads their own content back).
- Plus overlay-precedence and bundled-fallback tests.
- Full suite: **1267 passing** (latex module 48 → 52).

## Docs

Corrected the README isolation model (architecture diagram, login + pipeline flow notes, isolation table, v1.0 notes). `UserDataContextMiddleware` routes **every** authenticated Entra user (owner included) to `/app/data/users/{oid}/`; the prior "owner OID → /app/data/ full corpus" claim never matched the code. `ENTRA_OWNER_OID` only governs contact-info fallback and owner-only UI flags, not storage routing.

## Note

Separate from #69 (already merged). This is an independent, higher-severity fix with its own auditable history.