### PR TITLE
QA → main: consolidated MCP tool surface (85 → 11 domain tools)

### DIFF
--- a/.github/workflows/desktop-backend.yml
+++ b/.github/workflows/desktop-backend.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - feat/desktop-app
+      - feat/desktop-*
     paths:
       - desktop_main.py
       - packaging/**

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -40,6 +40,10 @@ jobs:
       APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
       APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
       APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+      # Tauri updater artifact signing (all platforms). Empty on forks —
+      # updater artifacts are simply skipped without it.
+      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
     strategy:
       fail-fast: false
       matrix:
@@ -50,6 +54,8 @@ jobs:
             bundles: dmg
             installer_glob: |
               desktop/src-tauri/target/release/bundle/dmg/*.dmg
+              desktop/src-tauri/target/release/bundle/macos/*.app.tar.gz
+              desktop/src-tauri/target/release/bundle/macos/*.app.tar.gz.sig
           # macos-13 was retired 2025-12-08; macos-15-intel is the last Intel
           # image (until Fall 2027). Plan to go arm64-only when it sunsets.
           - os: macos-15-intel
@@ -58,12 +64,15 @@ jobs:
             bundles: dmg
             installer_glob: |
               desktop/src-tauri/target/release/bundle/dmg/*.dmg
+              desktop/src-tauri/target/release/bundle/macos/*.app.tar.gz
+              desktop/src-tauri/target/release/bundle/macos/*.app.tar.gz.sig
           - os: windows-latest
             label: windows-x64
             binary: dist/jobcontext-backend/jobcontext-backend.exe
             bundles: nsis,msi
             installer_glob: |
               desktop/src-tauri/target/release/bundle/nsis/*.exe
+              desktop/src-tauri/target/release/bundle/nsis/*.sig
               desktop/src-tauri/target/release/bundle/msi/*.msi
           - os: ubuntu-22.04    # oldest supported glibc for AppImage compatibility
             label: linux-x64
@@ -71,6 +80,7 @@ jobs:
             bundles: appimage,deb
             installer_glob: |
               desktop/src-tauri/target/release/bundle/appimage/*.AppImage
+              desktop/src-tauri/target/release/bundle/appimage/*.sig
               desktop/src-tauri/target/release/bundle/deb/*.deb
 
     steps:
@@ -279,14 +289,24 @@ jobs:
             BUNDLES="$(printf '%s' "$BUNDLES" | tr ',' '\n' | grep -vx msi | paste -sd, -)"
             echo "pre-release version ${VERSION} — Windows bundles: ${BUNDLES} (msi dropped)"
           fi
-          # One merged --config overlay: release version stamp and/or the
-          # Windows signCommand.
+          # One merged --config overlay: release version stamp, the Windows
+          # signCommand, and updater artifacts (.sig files via the
+          # TAURI_SIGNING_* secrets). macOS skips createUpdaterArtifacts —
+          # Tauri would tar the .app BEFORE rcodesign signs it, so the mac
+          # signing step builds the updater archive itself from the signed app.
           OVERLAY=""
+          BUNDLE_OVERLAY=""
           if [ -n "${VERSION:-}" ]; then
             OVERLAY+="\"version\":\"${VERSION}\","
           fi
           if [ "$RUNNER_OS" = "Windows" ] && [ -n "$AZURE_CLIENT_ID" ]; then
-            OVERLAY+="\"bundle\":{\"windows\":{\"signCommand\":\"trusted-signing-cli -e https://eus.codesigning.azure.net -a jobContext -c jobcontext-public %1\"}},"
+            BUNDLE_OVERLAY+="\"windows\":{\"signCommand\":\"trusted-signing-cli -e https://eus.codesigning.azure.net -a jobContext -c jobcontext-public %1\"},"
+          fi
+          if [ "$RUNNER_OS" != "macOS" ] && [ -n "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
+            BUNDLE_OVERLAY+="\"createUpdaterArtifacts\":true,"
+          fi
+          if [ -n "$BUNDLE_OVERLAY" ]; then
+            OVERLAY+="\"bundle\":{${BUNDLE_OVERLAY%,}},"
           fi
           EXTRA=()
           if [ -n "$OVERLAY" ]; then
@@ -356,6 +376,24 @@ jobs:
             --p12-password-file "$RUNNER_TEMP/cert.pass" "$DMG"
           rm -f "$RUNNER_TEMP/cert.p12" "$RUNNER_TEMP/cert.pass"
           echo "signed dmg: $DMG"
+
+          # Updater artifact: tar of the SIGNED .app + minisign signature.
+          # (Tauri's own createUpdaterArtifacts would archive the pre-signing
+          # app, so it's disabled on macOS and built here instead.)
+          if [ -n "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
+            MAC_DIR="desktop/src-tauri/target/release/bundle/macos"
+            rm -f "$MAC_DIR"/*.app.tar.gz "$MAC_DIR"/*.app.tar.gz.sig
+            UPDATER_TAR="$MAC_DIR/jobContext_${DMG_VERSION}_${DMG_ARCH}.app.tar.gz"
+            tar -czf "$UPDATER_TAR" -C "$MAC_DIR" jobContext.app
+            printf '%s' "$TAURI_SIGNING_PRIVATE_KEY" > "$RUNNER_TEMP/updater.key"
+            (cd desktop && npx tauri signer sign \
+              --private-key-path "$RUNNER_TEMP/updater.key" \
+              --password "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" \
+              "$GITHUB_WORKSPACE/$UPDATER_TAR")
+            rm -f "$RUNNER_TEMP/updater.key"
+            test -s "$UPDATER_TAR.sig"
+            echo "updater artifact: $UPDATER_TAR"
+          fi
 
       # Notarize the signed dmg ourselves so the submission log is visible.
       # The Notary log lists every issue (unsigned/unhardened Mach-O, bad

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -385,12 +385,9 @@ jobs:
             rm -f "$MAC_DIR"/*.app.tar.gz "$MAC_DIR"/*.app.tar.gz.sig
             UPDATER_TAR="$MAC_DIR/jobContext_${DMG_VERSION}_${DMG_ARCH}.app.tar.gz"
             tar -czf "$UPDATER_TAR" -C "$MAC_DIR" jobContext.app
-            printf '%s' "$TAURI_SIGNING_PRIVATE_KEY" > "$RUNNER_TEMP/updater.key"
-            (cd desktop && npx tauri signer sign \
-              --private-key-path "$RUNNER_TEMP/updater.key" \
-              --password "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" \
-              "$GITHUB_WORKSPACE/$UPDATER_TAR")
-            rm -f "$RUNNER_TEMP/updater.key"
+            # The tauri CLI reads TAURI_SIGNING_PRIVATE_KEY(_PASSWORD) from
+            # the environment; passing key flags as well is a CLI conflict.
+            (cd desktop && npx tauri signer sign "$GITHUB_WORKSPACE/$UPDATER_TAR")
             test -s "$UPDATER_TAR.sig"
             echo "updater artifact: $UPDATER_TAR"
           fi

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -43,8 +43,56 @@ jobs:
         run: |
           shopt -s globstar nullglob
           files=(installers/**/*.dmg installers/**/*.exe installers/**/*.msi
-                 installers/**/*.AppImage installers/**/*.deb)
-          echo "attaching ${#files[@]} installers"
+                 installers/**/*.AppImage installers/**/*.deb
+                 installers/**/*.app.tar.gz installers/**/*.sig)
+          echo "attaching ${#files[@]} installers + updater artifacts"
+
+          # Updater manifest: version + per-platform artifact URL/signature,
+          # consumed by tauri-plugin-updater in the installed apps. Attached
+          # to this release AND clobbered onto the rolling `desktop-latest`
+          # release (the fixed endpoint apps poll — /releases/latest can't be
+          # used because desktop releases are pre-releases in a shared repo).
+          python3 - "$GITHUB_REF_NAME" <<'PYEOF'
+          import datetime, json, os, pathlib, sys
+
+          tag = sys.argv[1]
+          version = tag.removeprefix("desktop-v")
+          repo = os.environ["GITHUB_REPOSITORY"]
+          base = f"https://github.com/{repo}/releases/download/{tag}"
+          arts = {p.name: p for p in pathlib.Path("installers").rglob("*") if p.is_file()}
+
+          def entry(name):
+              sig = arts.get(name + ".sig")
+              if name not in arts or sig is None:
+                  return None
+              return {"signature": sig.read_text().strip(), "url": f"{base}/{name}"}
+
+          platforms = {}
+          for key, name in [
+              ("darwin-aarch64", f"jobContext_{version}_aarch64.app.tar.gz"),
+              ("darwin-x86_64",  f"jobContext_{version}_x64.app.tar.gz"),
+              ("windows-x86_64", f"jobContext_{version}_x64-setup.exe"),
+              ("linux-x86_64",   f"jobContext_{version}_amd64.AppImage"),
+          ]:
+              e = entry(name)
+              if e:
+                  platforms[key] = e
+          if not platforms:
+              print("no signed updater artifacts found — skipping latest.json")
+              raise SystemExit(0)
+          manifest = {
+              "version": version,
+              "notes": f"jobContext Desktop {version}",
+              "pub_date": datetime.datetime.now(datetime.timezone.utc)
+                  .isoformat(timespec="seconds").replace("+00:00", "Z"),
+              "platforms": platforms,
+          }
+          pathlib.Path("latest.json").write_text(json.dumps(manifest, indent=2))
+          print(f"latest.json: {sorted(platforms)}")
+          PYEOF
+          if [ -f latest.json ]; then
+            files+=(latest.json)
+          fi
 
           # Install notes prepended above the auto-generated changelog. These
           # builds aren't Apple-notarized yet (Phase 7), so testers need the
@@ -79,3 +127,17 @@ jobs:
             --notes-file NOTES.md \
             --generate-notes \
             "${files[@]}"
+
+          # Refresh the rolling updater channel: a fixed-tag release whose
+          # only job is hosting the newest latest.json at a stable URL.
+          if [ -f latest.json ]; then
+            if ! gh release view desktop-latest --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+              gh release create desktop-latest \
+                --repo "${GITHUB_REPOSITORY}" \
+                --prerelease \
+                --title "Desktop updater channel" \
+                --notes "Machine-consumed update manifest for jobContext Desktop's auto-updater. Install from the newest desktop-v* release, not from here."
+            fi
+            gh release upload desktop-latest latest.json --clobber --repo "${GITHUB_REPOSITORY}"
+            echo "updater channel now points at ${GITHUB_REF_NAME}"
+          fi

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/version-1.2.0-blue" alt="Version 1.2.0"/>
-  <img src="https://img.shields.io/badge/tests-1313%20passing-brightgreen" alt="1313 tests passing"/>
+  <img src="https://img.shields.io/badge/tests-1328%20passing-brightgreen" alt="1328 tests passing"/>
   <a href="https://sonarcloud.io/component_measures?id=JustLikeFrank3_jobContextMCP&metric=coverage"><img src="https://sonarcloud.io/api/project_badges/measure?project=JustLikeFrank3_jobContextMCP&metric=coverage" alt="Coverage"/></a>
   <img src="https://img.shields.io/badge/tools-11%20domains%20%C2%B7%2085%20actions-informational" alt="11 domain tools, 85 actions"/>
   <img src="https://img.shields.io/badge/license-MIT-lightgrey" alt="MIT License"/>
@@ -35,7 +35,7 @@ Available as a local MCP server, local dashboard, or cloud-hosted multi-user dep
 | | |
 |---|---|
 | 11 domain tools (85 actions) | Resume + cover letter generation |
-| 1313 passing tests | Job fitment analysis with persona lenses |
+| 1328 passing tests | Job fitment analysis with persona lenses |
 | SQLite persistence + JSON fallback | Interview prep + debrief logging |
 | Local RAG semantic search | Outreach + relationship tracking |
 | Azure AKS deployment | Microsoft Entra ID authentication |
@@ -171,7 +171,7 @@ graph TB
     PROV["User provisioning\nauto-create on first Entra login"]
   end
 
-  subgraph TOOLS["85 MCP / CLI tools"]
+  subgraph TOOLS["11 MCP / CLI tools"]
     CTX["Context + identity"]
     PIPE["Pipeline + queue + compensation"]
     DOCS["Resume + cover letter generation"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <img src="https://img.shields.io/badge/version-1.2.0-blue" alt="Version 1.2.0"/>
   <img src="https://img.shields.io/badge/tests-1313%20passing-brightgreen" alt="1313 tests passing"/>
   <a href="https://sonarcloud.io/component_measures?id=JustLikeFrank3_jobContextMCP&metric=coverage"><img src="https://sonarcloud.io/api/project_badges/measure?project=JustLikeFrank3_jobContextMCP&metric=coverage" alt="Coverage"/></a>
-  <img src="https://img.shields.io/badge/tools-85-informational" alt="85 MCP tools"/>
+  <img src="https://img.shields.io/badge/tools-11%20domains%20%C2%B7%2085%20actions-informational" alt="11 domain tools, 85 actions"/>
   <img src="https://img.shields.io/badge/license-MIT-lightgrey" alt="MIT License"/>
   <img src="https://img.shields.io/badge/Works%20with-Oura%20Ring-00B5C8" alt="Works with Oura Ring"/>
 </p>
@@ -20,7 +20,7 @@ A personal [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) serv
 
 Built in Python using [FastMCP](https://github.com/jlowin/fastmcp), FastAPI, SQLite (with dual-write JSON fallback), optional OpenAI/Azure AI Foundry/Ollama generation, WeasyPrint PDF export, a mobile-friendly dashboard, and a Kubernetes deployment on AKS with workload identity and Azure Blob Storage workspace seeding.
 
-> **The agent is optional.** MCP servers are protocol-driven capability layers — any client that speaks the protocol can call them. jobContextMCP ships with a CLI (`cli.py`) that invokes all 85 tools directly from the terminal, no AI client required. Automation scripts, CI pipelines, cron/launchd jobs, the web dashboard, and scheduled tasks can consume the same underlying capabilities as Claude or Copilot. The AI is one type of client, not the only one.
+> **The agent is optional.** MCP servers are protocol-driven capability layers — any client that speaks the protocol can call them. jobContextMCP ships with a CLI (`cli.py`) that invokes every tool action directly from the terminal, no AI client required. Automation scripts, CI pipelines, cron/launchd jobs, the web dashboard, and scheduled tasks can consume the same underlying capabilities as Claude or Copilot. The AI is one type of client, not the only one.
 
 ---
 
@@ -34,7 +34,7 @@ Available as a local MCP server, local dashboard, or cloud-hosted multi-user dep
 
 | | |
 |---|---|
-| 85 MCP tools | Resume + cover letter generation |
+| 11 domain tools (85 actions) | Resume + cover letter generation |
 | 1313 passing tests | Job fitment analysis with persona lenses |
 | SQLite persistence + JSON fallback | Interview prep + debrief logging |
 | Local RAG semantic search | Outreach + relationship tracking |
@@ -646,7 +646,7 @@ brew install python@3.12
 
 # Smoke test: confirm the server imports cleanly and registers all tools
 .venv/bin/python3 -c "import server; print('OK,', len(server.mcp._tool_manager.list_tools()), 'tools')"
-# Expected: OK, 85 tools
+# Expected: OK, 11 tools (85 actions; set JOBCONTEXT_LEGACY_TOOLS=1 for the old per-function surface)
 ```
 
 > ⚠️ **macOS venv gotcha:** if you accidentally run `python3 -m venv .venv` with the system 3.9 first, the resulting `.venv/bin/python3` symlink points at the system 3.9 binary. A follow-up `python3.12 -m venv .venv` call will NOT replace it — the broken symlink survives. Symptom: `ModuleNotFoundError: No module named 'mcp'` even though `pip list` shows it installed. Fix: `rm -rf .venv` and recreate with the explicit `/opt/homebrew/opt/python@3.12/bin/python3.12 -m venv .venv` command above.
@@ -730,7 +730,7 @@ The server speaks MCP — it works with any compatible client. You don't need an
 
 #### Terminal (no AI client required)
 
-`cli.py` is a first-class client. Invoke any of the 85 tools directly:
+`cli.py` is a first-class client. Invoke any tool action directly:
 
 ```bash
 # List all tools
@@ -989,7 +989,7 @@ In `.env`:
 MCP_MODE=local
 ```
 
-Then **Command Palette → MCP: List Servers → restart jobContextMCP**. The startup logs should no longer mention `Container … Creating` / `Container … Created`. You'll see `Discovered 85 tools` (or whatever your current count is) within ~0.5s instead of ~1.5s.
+Then **Command Palette → MCP: List Servers → restart jobContextMCP**. The startup logs should no longer mention `Container … Creating` / `Container … Created`. You'll see `Discovered 11 tools` (or 85 with JOBCONTEXT_LEGACY_TOOLS=1) within ~0.5s instead of ~1.5s.
 
 #### What's live vs. baked-in
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -79,7 +79,7 @@ flowchart TB
         subgraph sidecar["<b>PyInstaller sidecar</b> (frozen CPython)"]
             direction TB
             api["FastAPI + FastMCP<br/>127.0.0.1:PORT (loopback only)"]
-            tools["85 MCP tools<br/>resume · pipeline · interviews · …"]
+            tools["11 domain tools · 85 actions<br/>resume · pipeline · interviews · …"]
             db[("SQLite<br/>per-OS app-data dir")]
             api --> tools --> db
         end
@@ -93,7 +93,7 @@ flowchart TB
     class shell accent
 ```
 
-**Why a sidecar, not a rewrite:** the backend is 85 tools, WeasyPrint PDF
+**Why a sidecar, not a rewrite:** the backend is 85 tool actions, WeasyPrint PDF
 rendering, LangGraph, and 1,300+ tests of Python. Freezing it with
 PyInstaller and shipping it as a managed subprocess reuses all of it verbatim
 — the desktop app and the cloud app run byte-identical server code.

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -54,6 +54,13 @@ reputation, SmartScreen may warn — click **More info → Run anyway**.
 - **AppImage:** `chmod +x jobContext_*_amd64.AppImage && ./jobContext_*_amd64.AppImage`
 - **Debian/Ubuntu:** `sudo dpkg -i jobContext_*_amd64.deb`
 
+### Updating
+
+From `v1.0.0-beta.5` onward the app checks for updates at launch and offers
+**Update & restart** (signed manifest, downloads from GitHub Releases). Older
+builds: download the new installer and install over the existing app — your
+data lives in the per-OS app-data folder and is never touched by upgrades.
+
 ### First run
 
 Open **Settings** to (optionally) add an AI provider key — OpenAI, Anthropic,

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -48,6 +48,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,6 +680,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,6 +972,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1499,6 +1529,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1748,6 +1793,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1779,9 +1854,13 @@ dependencies = [
 name = "jobcontext-desktop"
 version = "0.1.0"
 dependencies = [
+ "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
+ "tauri-plugin-process",
  "tauri-plugin-single-instance",
+ "tauri-plugin-updater",
 ]
 
 [[package]]
@@ -1944,6 +2023,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2177,6 +2262,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2190,6 +2276,18 @@ dependencies = [
  "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2256,6 +2354,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2269,6 +2373,20 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2662,15 +2780,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2680,6 +2803,44 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2711,6 +2872,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2723,6 +2957,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2781,6 +3024,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3003,6 +3269,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3115,6 +3397,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3197,7 +3485,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -3231,6 +3519,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3253,7 +3552,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -3350,6 +3649,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74be5dd4bed9afbd145e5716b5fa2ec28cbc29c34ffa61c258c9273d896c8020"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
 name = "tauri-plugin-single-instance"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3365,6 +3732,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3374,7 +3774,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -3397,7 +3797,7 @@ checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -3593,6 +3993,16 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -3909,6 +4319,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4152,6 +4568,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4379,6 +4804,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4676,7 +5110,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -4721,6 +5155,16 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]
@@ -4829,6 +5273,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4859,6 +5309,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -10,6 +10,10 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-single-instance = "2"
+tauri-plugin-updater = "2"
+tauri-plugin-dialog = "2"
+tauri-plugin-process = "2"
+serde_json = "1"
 
 [profile.release]
 strip = true

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -148,6 +148,64 @@ fn stop_backend(state: &BackendState) {
     }
 }
 
+/// Background update check (shell-side, no SPA involvement): ask the rolling
+/// `desktop-latest` manifest whether a newer build exists; if so, offer a
+/// native dialog and on Yes download + install + relaunch. Any failure is
+/// silent — updates must never break a working app, and the user can always
+/// install a release manually.
+fn check_for_updates(handle: tauri::AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
+        use tauri_plugin_updater::UpdaterExt;
+
+        let updater = match handle.updater() {
+            Ok(u) => u,
+            Err(_) => return,
+        };
+        let update = match updater.check().await {
+            Ok(Some(update)) => update,
+            _ => return,
+        };
+        let version = update.version.clone();
+        let proceed = handle
+            .dialog()
+            .message(format!(
+                "jobContext {version} is available (you have {}).\n\nDownload and install now? \
+                 The app restarts when it finishes.",
+                handle.package_info().version
+            ))
+            .title("Update available")
+            .kind(MessageDialogKind::Info)
+            .buttons(MessageDialogButtons::OkCancelCustom(
+                "Update & restart".into(),
+                "Later".into(),
+            ))
+            .blocking_show();
+        if !proceed {
+            return;
+        }
+        match update.download_and_install(|_, _| {}, || {}).await {
+            Ok(()) => {
+                // The backend must exit cleanly before the new shell spawns
+                // its own (SQLite single-writer). RunEvent::Exit handles it,
+                // and restart() takes the normal exit path.
+                handle.restart();
+            }
+            Err(_) => {
+                handle
+                    .dialog()
+                    .message(
+                        "The update could not be installed. You can download the latest \
+                         version from the jobContext releases page.",
+                    )
+                    .title("Update failed")
+                    .kind(MessageDialogKind::Warning)
+                    .blocking_show();
+            }
+        }
+    });
+}
+
 fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
@@ -156,8 +214,12 @@ fn main() {
                 let _ = window.set_focus();
             }
         }))
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_process::init())
         .manage(BackendState(Mutex::new(None)))
         .setup(|app| {
+            check_for_updates(app.handle().clone());
             let handle = app.handle().clone();
             std::thread::spawn(move || {
                 let result = spawn_backend(&handle).and_then(|backend| {

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -22,8 +22,17 @@
       "csp": null
     }
   },
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEY5QTI5RjIwRjBCMEI1MDUKUldRRnRiRHdJSitpK1pmN0c3QzU3b1pDM0szTWt3OHgxbnI0WUwxSkMrUk50bUtic2tTYkNyVDEK",
+      "endpoints": [
+        "https://github.com/JustLikeFrank3/jobContextMCP/releases/download/desktop-latest/latest.json"
+      ]
+    }
+  },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": ["dmg", "nsis", "msi", "appimage", "deb"],
     "category": "Productivity",
     "shortDescription": "Local-first job search copilot with MCP",

--- a/docs/desktop/ROADMAP.md
+++ b/docs/desktop/ROADMAP.md
@@ -23,7 +23,7 @@ pywebview spike remains a cheap fallback demo if ever needed.
 | 5.5 | Embedded chat panel (agent loop + tool calling in the SPA) | ✅ agent loop + SSE + persistence, chat UI w/ tool chips + model indicator, Anthropic/OpenAI/Ollama BYOK with in-app Settings key entry — all live-verified; deferred polish: markdown rendering, token streaming |
 | 6 | Installers (dmg / NSIS+msi / AppImage+deb) | ✅ all four platforms green in CI (2026-07-06): arm64+Intel dmg, NSIS exe+msi, AppImage+deb — unsigned pending Phase 7 |
 | 7 | Signing & notarization | ✅ (2026-07-06) Windows Authenticode via Azure Trusted Signing (individual validation; org later). macOS Developer ID + notarization green: sign the **final** .app with rcodesign two-pass — Tauri's resource copy dereferences symlinks into duplicate Python Mach-Os that pre-bundle signing can never cover; notarytool crashes on GH runners → rcodesign notary-submit + staple |
-| 8 | Auto-update + GitHub Actions release matrix | ◐ release pipeline done & validated: reusable desktop-build.yml shared by Desktop CI (branch pushes) and Desktop Release (`desktop-v*` tags → version-stamped pre-release with installers; namespace disjoint from cloud `v*`/AKS). Remaining: updater plugin (wants signing keys) |
+| 8 | Auto-update + GitHub Actions release matrix | ◐ release pipeline done & validated: reusable desktop-build.yml shared by Desktop CI (branch pushes) and Desktop Release (`desktop-v*` tags → version-stamped pre-release with installers; namespace disjoint from cloud `v*`/AKS). updater plugin shipped (launch-time check against the rolling desktop-latest manifest, native dialog, update & restart) — first self-update exercised beta.5 → beta.6 |
 | 9 | QA on clean VMs, beta, launch | ⬜ |
 
 ## What Phase 0/1 shipped

--- a/server.py
+++ b/server.py
@@ -155,35 +155,44 @@ mcp = FastMCP(
 )
 
 
-session.register(mcp)  # MUST be first — session startup tool
-job_hunt.register(mcp)
-resume.register(mcp)
-fitment.register(mcp)
-interview.register(mcp)
-interviews.register(mcp)
-project_scanner.register(mcp)
-health.register(mcp)
-oura.register(mcp)
-context.register(mcp)
-tone.register(mcp)
-rag.register(mcp)
-star.register(mcp)
-outreach.register(mcp)
-export.register(mcp)
-generate.register(mcp)
-langgraph_pipeline.register(mcp)
-people.register(mcp)
-posts.register(mcp)
-rejections.register(mcp)
-digest.register(mcp)
-compensation.register(mcp)
-ingest.register(mcp)
-hbdi.register(mcp)
-crossref.register(mcp)
-job_queue.register(mcp)
-setup.register(mcp)
-job_scraper.register(mcp)
-github.register(mcp)
+# Default surface: 11 consolidated domain tools (action-dispatch facades over
+# the same functions) — MCP clients budget tools, and VS Code caps 128 across
+# every server. JOBCONTEXT_LEGACY_TOOLS=1 restores the historical per-function
+# surface (85 tools) for anything that hardcoded the old names.
+if os.getenv("JOBCONTEXT_LEGACY_TOOLS", "").strip().lower() in ("1", "true", "yes"):
+    session.register(mcp)  # MUST be first — session startup tool
+    job_hunt.register(mcp)
+    resume.register(mcp)
+    fitment.register(mcp)
+    interview.register(mcp)
+    interviews.register(mcp)
+    project_scanner.register(mcp)
+    health.register(mcp)
+    oura.register(mcp)
+    context.register(mcp)
+    tone.register(mcp)
+    rag.register(mcp)
+    star.register(mcp)
+    outreach.register(mcp)
+    export.register(mcp)
+    generate.register(mcp)
+    langgraph_pipeline.register(mcp)
+    people.register(mcp)
+    posts.register(mcp)
+    rejections.register(mcp)
+    digest.register(mcp)
+    compensation.register(mcp)
+    ingest.register(mcp)
+    hbdi.register(mcp)
+    crossref.register(mcp)
+    job_queue.register(mcp)
+    setup.register(mcp)
+    job_scraper.register(mcp)
+    github.register(mcp)
+else:
+    from tools import consolidated
+
+    consolidated.register(mcp)
 
 
 get_job_hunt_status = job_hunt.get_job_hunt_status

--- a/services/chat_service.py
+++ b/services/chat_service.py
@@ -32,32 +32,23 @@ from lib.db import get_connection
 
 _log = logging.getLogger(__name__)
 
-# Tools the chat model may call. Curated: onboarding, job-hunt state, queue,
-# people, interviews, digests, generation. Nothing export-ish or admin-ish.
+# Tools the chat model may call. With the consolidated domain surface
+# (tools/consolidated.py) the full capability set fits in one context window
+# — 11 schemas instead of 85 — so chat carries everything. Overridable per-
+# config via "chat_tools" (and JOBCONTEXT_LEGACY_TOOLS servers can list the
+# old per-function names there).
 CHAT_TOOL_ALLOWLIST: tuple[str, ...] = (
-    "check_workspace",
-    "setup_workspace",
-    "get_job_hunt_status",
-    "get_job_queue",
-    "queue_job",
-    "evaluate_queued_job",
-    "assess_job_fitment",
-    "decide_job",
-    "update_application",
-    "log_application_event",
-    "get_daily_digest",
-    "weekly_summary",
-    "search_jobs",
-    "scrape_job_url",
-    "get_interviews",
-    "get_upcoming_interviews",
-    "log_interview",
-    "get_people",
-    "get_person",
-    "log_person",
-    "get_rejections",
-    "log_rejection",
-    "get_compensation_comparison",
+    "applications",
+    "job_search",
+    "documents",
+    "materials",
+    "interviews",
+    "people",
+    "stories",
+    "wellbeing",
+    "brand",
+    "insights",
+    "workspace",
 )
 
 MAX_TOOL_HOPS = 8
@@ -70,9 +61,11 @@ app. You have tools that read and update the user's real job hunt data
 (applications, queue, interviews, contacts, digests). Prefer calling a tool
 over guessing; never invent data. Be concise and concrete. When you change
 data (queue a job, log an event), confirm exactly what changed.
-For a new or empty workspace, check_workspace reports what's missing and
-setup_workspace fills it in from details the user gives you (contact info,
-master resume content).\
+Each tool covers one domain and takes an "action" parameter — its description
+lists every action with required/optional parameters. For a new or empty
+workspace, workspace(action="check") reports what's missing and
+workspace(action="setup") fills it in from details the user gives you
+(contact info, master resume content).\
 """
 
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,3 +4,13 @@ sonar.python.version=3.12
 sonar.sources=lib,tools,services,transport,server.py,cli.py
 sonar.tests=tests
 sonar.python.coverage.reportPaths=coverage.xml
+
+# S107 (max 13 parameters) is intentionally violated by tools/consolidated.py:
+# each domain facade's signature is the union of its actions' parameters, and
+# FastMCP derives the MCP tool inputSchema directly from that signature — the
+# wide, flat parameter list IS the machine-facing API the model reads. These
+# functions are dispatch-only (no human call sites) and each parameter is
+# documented per-action in the docstring.
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=python:S107
+sonar.issue.ignore.multicriteria.e1.resourceKey=tools/consolidated.py

--- a/templates/latex_assets/sections/experience.tex
+++ b/templates/latex_assets/sections/experience.tex
@@ -5,7 +5,7 @@
 \subsection{{\textbf{Senior Software Engineer} \textit{\ \ Contoso Cloud, Remote} \hfill 20XX --- Present}}
 \begin{zitemize}
 \item Led design and delivery of a customer-facing service from architecture through production and on-call; quantify the impact here (latency, scale, revenue, or adoption).
-\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1313 passing tests at 80\%+ line coverage through disciplined TDD.
+\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1328 passing tests at 80\%+ line coverage through disciplined TDD.
 \item Drove a cross-team win — a migration, a shared API pattern others adopted, or an SLA target consistently met.
 \end{zitemize}
 %====================

--- a/tests/test_chat_service.py
+++ b/tests/test_chat_service.py
@@ -96,21 +96,21 @@ def test_plain_answer_turn(mcp_instance):
     request = client.requests[0]
     assert request["messages"][0]["role"] == "system"
     names = {t["function"]["name"] for t in request["tools"]}
-    assert "get_job_hunt_status" in names
+    assert "applications" in names
     assert names <= set(chat_service.CHAT_TOOL_ALLOWLIST)
 
 
 def test_tool_call_turn_roundtrip(mcp_instance):
     sid = chat_service.create_session()
     client = FakeClient([
-        _response(tool_calls=[_tool_call("c1", "get_job_hunt_status", {})]),
+        _response(tool_calls=[_tool_call("c1", "applications", {"action": "status"})]),
         _response(content="You have N active applications."),
     ])
 
     events = _run_turn(mcp_instance, sid, "how's my pipeline?", client)
 
     assert [e.type for e in events] == ["tool_call", "tool_result", "message", "done"]
-    assert events[0].data["name"] == "get_job_hunt_status"
+    assert events[0].data["name"] == "applications"
     # Real tool executed against the isolated workspace: non-empty, no error.
     assert events[1].data["content"].strip()
     assert not events[1].data["content"].startswith("[error]")
@@ -118,7 +118,7 @@ def test_tool_call_turn_roundtrip(mcp_instance):
     # Second model request carries the assistant tool_calls + tool result.
     followup = client.requests[1]["messages"]
     assert followup[-2]["role"] == "assistant"
-    assert followup[-2]["tool_calls"][0]["function"]["name"] == "get_job_hunt_status"
+    assert followup[-2]["tool_calls"][0]["function"]["name"] == "applications"
     assert followup[-1]["role"] == "tool"
     assert followup[-1]["tool_call_id"] == "c1"
 

--- a/tests/test_consolidated_tools.py
+++ b/tests/test_consolidated_tools.py
@@ -1,0 +1,169 @@
+"""Tests for the consolidated MCP tool surface (tools/consolidated.py).
+
+The 11 domain facades must expose every capability of the legacy 85-tool
+surface: each action maps to a real function, dispatch forwards exactly the
+parameters the target accepts, and errors are actionable strings (never
+tracebacks). The registered tool count is pinned so the surface can't
+silently regrow.
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from tools import consolidated
+from tools.consolidated import DOMAINS, FACADES, _actions_doc, _run
+
+
+# ── surface shape ─────────────────────────────────────────────────────────────
+
+def test_eleven_domain_tools():
+    assert len(FACADES) == 11
+    assert set(FACADES) == set(DOMAINS)
+
+
+def test_every_action_targets_a_callable():
+    for domain, actions in DOMAINS.items():
+        for action, (fn, summary) in actions.items():
+            assert callable(fn), f"{domain}.{action}"
+            assert summary and isinstance(summary, str)
+
+
+def test_action_count_covers_legacy_surface():
+    # 84 actions ≙ the 85 legacy tools minus get_session_context's dual role
+    # (session startup is folded into insights.session_context).
+    total = sum(len(a) for a in DOMAINS.values())
+    assert total == 85, f"action count changed: {total} — update this pin deliberately"
+
+
+def test_facade_params_cover_every_target_param():
+    """Every parameter of every target function must exist on its facade —
+    otherwise a capability is silently unreachable."""
+    for domain, actions in DOMAINS.items():
+        facade_params = set(inspect.signature(FACADES[domain]).parameters)
+        for action, (fn, _) in actions.items():
+            for pname in inspect.signature(fn).parameters:
+                assert pname in facade_params, (
+                    f"{domain}.{action}: target param {pname!r} missing on facade"
+                )
+
+
+def test_registration_registers_eleven(monkeypatch):
+    registered = []
+
+    class FakeMCP:
+        def tool(self, name=None):
+            def deco(fn):
+                registered.append(name or fn.__name__)
+                return fn
+            return deco
+
+    consolidated.register(FakeMCP())
+    assert sorted(registered) == sorted(FACADES)
+
+
+def test_generated_docs_list_required_params():
+    doc = _actions_doc("applications")
+    assert "queue — " in doc
+    assert "Requires: company, role, jd" in doc
+
+
+def test_registered_docstrings_carry_action_docs():
+    class FakeMCP:
+        def tool(self, name=None):
+            def deco(fn):
+                return fn
+            return deco
+
+    consolidated.register(FakeMCP())
+    for name, fn in FACADES.items():
+        assert "Actions:" in fn.__doc__, name
+        # Registering twice must not duplicate the generated section.
+        consolidated.register(FakeMCP())
+        assert fn.__doc__.count("Actions:") == 1, name
+
+
+# ── dispatch behavior ─────────────────────────────────────────────────────────
+
+def test_dispatch_forwards_only_provided_accepted_params(monkeypatch):
+    seen = {}
+
+    def fake_update(company, role, status="", next_steps="", contact="", notes=""):
+        seen.update(company=company, role=role, status=status)
+        return "ok"
+
+    monkeypatch.setitem(DOMAINS["applications"], "update", (fake_update, "x"))
+    out = FACADES["applications"](
+        action="update", company="Acme", role="SWE", status="applied",
+        # params for other actions must be ignored, not crash the target:
+        decision="apply", fitment_score=9,
+    )
+    assert out == "ok"
+    assert seen == {"company": "Acme", "role": "SWE", "status": "applied"}
+
+
+def test_dispatch_unknown_action_lists_valid_ones():
+    out = _run("applications", "frobnicate", {})
+    assert "Unknown applications action" in out
+    assert "queue" in out and "decide" in out
+
+
+def test_dispatch_missing_required_params_is_actionable():
+    out = FACADES["applications"](action="queue", company="Acme")
+    assert "missing required parameter" in out
+    assert "role" in out and "jd" in out
+
+
+def test_dispatch_none_params_fall_back_to_target_defaults(monkeypatch):
+    seen = {}
+
+    def fake_search(query, location="", num_results=5, auto_queue=False):
+        seen.update(num_results=num_results, auto_queue=auto_queue)
+        return "ok"
+
+    monkeypatch.setitem(DOMAINS["job_search"], "web", (fake_search, "x"))
+    FACADES["job_search"](action="web", query="python")
+    assert seen == {"num_results": 5, "auto_queue": False}
+
+
+def test_end_to_end_workspace_check(tmp_path, monkeypatch):
+    """One real (non-mocked) dispatch: workspace.check runs the actual tool."""
+    import lib.config as cfg
+
+    monkeypatch.setattr(cfg, "DATA_FOLDER", tmp_path, raising=False)
+    out = FACADES["workspace"](action="check")
+    assert isinstance(out, str) and out  # diagnostic text, no exception
+
+
+# ── server registration modes ─────────────────────────────────────────────────
+
+def test_chat_allowlist_matches_domain_names():
+    from services.chat_service import CHAT_TOOL_ALLOWLIST
+
+    assert set(CHAT_TOOL_ALLOWLIST) == set(FACADES)
+
+
+@pytest.mark.parametrize("flag,expected", [("", 11), ("1", 85)])
+def test_server_surface_size(flag, expected, tmp_path):
+    """server.py registers 11 consolidated tools by default, 85 legacy ones
+    behind JOBCONTEXT_LEGACY_TOOLS=1.
+
+    Runs in a subprocess: re-importing server inside the test process would
+    register the conftest autouse stubs (lambdas) as tools.
+    """
+    import os
+    import subprocess
+    import sys
+
+    env = {**os.environ, "JOBCONTEXT_DATA_DIR": str(tmp_path)}
+    env.pop("JOBCONTEXT_LEGACY_TOOLS", None)
+    if flag:
+        env["JOBCONTEXT_LEGACY_TOOLS"] = flag
+    out = subprocess.run(
+        [sys.executable, "-c",
+         "import asyncio, server; print(len(asyncio.run(server.mcp.list_tools())))"],
+        capture_output=True, text=True, env=env, timeout=180,
+    )
+    assert out.returncode == 0, out.stderr[-800:]
+    assert int(out.stdout.strip().splitlines()[-1]) == expected

--- a/tools/consolidated.py
+++ b/tools/consolidated.py
@@ -1,0 +1,496 @@
+"""Consolidated MCP tool surface — 11 domain tools over the full function registry.
+
+Why: MCP clients budget tools (VS Code caps 128 across every server), and 85
+near-duplicate names both hog that budget and give the model look-alike
+choices to fumble. Each domain tool exposes an ``action`` enum and the union
+of its actions' parameters; dispatch passes through to the exact same
+functions the legacy per-function surface registered, so capabilities are
+identical.
+
+Set ``JOBCONTEXT_LEGACY_TOOLS=1`` to register the old 85-tool surface
+instead (escape hatch; the underlying modules are unchanged).
+
+Adding an action: add one row to the domain's spec below — the per-action
+"Requires/Optional" documentation in the tool description is generated from
+the target function's real signature, so it can't drift.
+"""
+from __future__ import annotations
+
+import inspect
+from typing import Literal
+
+from tools import (
+    compensation,
+    context,
+    crossref,
+    digest,
+    export,
+    fitment,
+    generate,
+    github,
+    hbdi,
+    health,
+    ingest,
+    interview,
+    interviews,
+    job_hunt,
+    job_queue,
+    job_scraper,
+    langgraph_pipeline,
+    oura,
+    outreach,
+    people,
+    posts,
+    project_scanner,
+    rag,
+    rejections,
+    resume,
+    session,
+    setup,
+    star,
+    tone,
+)
+from tools.latex_export import read_latex_asset, write_latex_section
+
+# ── dispatch core ──────────────────────────────────────────────────────────────
+
+# Domain name → {action name → (target function, one-line summary)}.
+DOMAINS: dict[str, dict[str, tuple]] = {
+    "applications": {
+        "status": (job_hunt.get_job_hunt_status, "Current tracked pipeline snapshot."),
+        "update": (job_hunt.update_application, "Create/update a tracked application."),
+        "log_event": (job_hunt.log_application_event, "Timestamped event on an application."),
+        "queue": (job_queue.queue_job, "Queue a job posting for evaluation."),
+        "get_queue": (job_queue.get_job_queue, "List queued jobs."),
+        "evaluate": (job_queue.evaluate_queued_job, "Evaluate a queued job against your profile."),
+        "decide": (job_queue.decide_job, "Record an apply/skip decision."),
+        "assess": (fitment.assess_job_fitment, "Quick fitment assessment for a role."),
+        "full_assessment": (fitment.run_job_assessment, "Full structured job assessment."),
+        "save_assessment": (fitment.save_job_assessment, "Persist an assessment to the workspace."),
+    },
+    "job_search": {
+        "web": (job_scraper.search_jobs, "Search job boards on the open web."),
+        "greenhouse": (job_scraper.search_greenhouse_jobs, "Search a company's Greenhouse board."),
+        "lever": (job_scraper.search_lever_jobs, "Search a company's Lever board."),
+        "url": (job_scraper.scrape_job_url, "Scrape a specific job posting URL."),
+    },
+    "documents": {
+        "generate_resume": (generate.generate_resume, "Generate a tailored resume."),
+        "generate_resume_agent": (langgraph_pipeline.generate_resume_agent, "Agentic multi-step resume generation."),
+        "generate_cover_letter": (generate.generate_cover_letter, "Generate a tailored cover letter."),
+        "export_resume_pdf": (export.export_resume_pdf, "Render a resume to PDF."),
+        "export_cover_letter_pdf": (export.export_cover_letter_pdf, "Render a cover letter to PDF."),
+        "export_resume_latex": (export.export_resume_latex, "Typeset a resume via LaTeX."),
+        "export_cover_letter_latex": (export.export_cover_letter_latex, "Typeset a cover letter via LaTeX."),
+        "save_resume": (resume.save_resume_txt, "Save resume text to the workspace."),
+        "save_cover_letter": (resume.save_cover_letter_txt, "Save cover letter text to the workspace."),
+        "diff": (resume.resume_diff, "Diff two resume files."),
+        "write_latex_section": (write_latex_section, "Write a LaTeX resume section file."),
+        "customization_strategy": (fitment.get_customization_strategy, "Resume customization strategy for a role type."),
+        "preview_story_retrieval": (generate.preview_story_retrieval, "Preview which stories generation would pull."),
+    },
+    "materials": {
+        "read_master_resume": (resume.read_master_resume, "Read the master resume."),
+        "read_resume": (resume.read_existing_resume, "Read an existing resume file."),
+        "read_reference": (resume.read_reference_file, "Read a reference-materials file."),
+        "read_latex_asset": (read_latex_asset, "Read a LaTeX template/section asset."),
+        "list": (resume.list_existing_materials, "List existing materials (optionally by company)."),
+        "search": (rag.search_materials, "Semantic search across materials."),
+        "reindex": (rag.reindex_materials, "Rebuild the materials search index."),
+        "reindex_stories": (rag.reindex_stories, "Rebuild the story retrieval index."),
+    },
+    "interviews": {
+        "log": (interviews.log_interview, "Log an interview debrief."),
+        "list": (interviews.get_interviews, "List logged interviews (filterable)."),
+        "context": (interviews.get_interview_context, "Everything known about a company's process."),
+        "upcoming": (interviews.get_upcoming_interviews, "Upcoming interviews."),
+        "prep_context": (interview.generate_interview_prep_context, "Build prep context for an interview."),
+        "save_prep": (interview.save_interview_prep, "Save a prep doc."),
+        "get_prep": (interview.get_existing_prep_file, "Read the existing prep doc for a company."),
+        "quick_reference": (interview.get_interview_quick_reference, "One-page interview quick reference."),
+        "leetcode_cheatsheet": (interview.get_leetcode_cheatsheet, "LeetCode pattern cheatsheet."),
+    },
+    "people": {
+        "log": (people.log_person, "Add/update a contact."),
+        "list": (people.get_people, "List contacts (filterable)."),
+        "get": (people.get_person, "Full profile for one contact."),
+        "referral_chains": (people.get_referral_chains, "Referral paths into a company."),
+        "draft_outreach": (outreach.draft_outreach_message, "Draft an outreach message in your voice."),
+        "draft_reply": (outreach.draft_reply, "Draft a reply to an incoming message."),
+        "review_message": (outreach.review_message, "Critique a drafted message."),
+        "crossref_run": (crossref.run_contact_crossref, "Cross-reference FB friends against contacts."),
+        "crossref_get": (crossref.get_contact_crossref, "Read cross-reference insights."),
+        "fb_queue": (crossref.get_fb_outreach_queue, "FB outreach queue."),
+    },
+    "stories": {
+        "log": (context.log_personal_story, "Log a personal story/anecdote."),
+        "ingest": (ingest.ingest_anecdote, "Ingest an anecdote (story + optional tone sample)."),
+        "personal_context": (context.get_personal_context, "Retrieve personal context by tag/person."),
+        "star_context": (star.get_star_story_context, "STAR stories for a company/role."),
+        "star_all": (star.get_all_star_context, "All STAR story context."),
+        "tone_log": (tone.log_tone_sample, "Log a writing-tone sample."),
+        "tone_profile": (tone.get_tone_profile, "Current tone profile."),
+        "tone_scan": (tone.scan_materials_for_tone, "Scan materials for tone samples."),
+    },
+    "wellbeing": {
+        "checkin": (health.log_mental_health_checkin, "Log a mood/energy check-in."),
+        "log": (health.get_mental_health_log, "Recent check-in history."),
+        "oura_sync": (oura.sync_oura_readiness, "Pull latest readiness from Oura."),
+        "oura_log": (oura.log_oura_readiness, "Manually log a readiness snapshot."),
+        "oura_get": (oura.get_oura_readiness, "Recent readiness history."),
+        "hbdi_run": (hbdi.run_hbdi_assessment, "Run the HBDI thinking-style assessment."),
+        "hbdi_profile": (hbdi.get_hbdi_profile, "Stored HBDI profile."),
+    },
+    "brand": {
+        "post_log": (posts.log_linkedin_post, "Log a LinkedIn post."),
+        "post_metrics": (posts.update_post_metrics, "Update a post's metrics."),
+        "posts": (posts.get_linkedin_posts, "List logged posts (filterable)."),
+        "github_stats": (github.get_github_stats, "GitHub contribution stats."),
+        "portfolio": (github.get_portfolio_metrics, "Stored portfolio metrics."),
+        "portfolio_refresh": (github.refresh_portfolio_metrics, "Refresh portfolio metrics."),
+        "scan_project_skills": (project_scanner.scan_project_for_skills, "Scan side projects for skills."),
+    },
+    "insights": {
+        "daily_digest": (digest.get_daily_digest, "Morning briefing: pipeline + action items."),
+        "weekly_summary": (digest.weekly_summary, "Week-in-review summary."),
+        "session_context": (session.get_session_context, "Session startup context bundle."),
+        "rejection_log": (rejections.log_rejection, "Log a rejection."),
+        "rejections": (rejections.get_rejections, "Rejection history + funnel patterns."),
+        "compensation_update": (compensation.update_compensation, "Record a comp datapoint."),
+        "compensation_compare": (compensation.get_compensation_comparison, "Compare recorded comp."),
+    },
+    "workspace": {
+        "check": (setup.check_workspace, "Diagnose what's present/missing (read-only)."),
+        "setup": (setup.setup_workspace, "Create/complete the workspace from your details."),
+    },
+}
+
+
+def _actions_doc(domain: str) -> str:
+    """Generate per-action parameter docs from the real target signatures."""
+    lines = ["", "Actions:"]
+    for action, (fn, summary) in DOMAINS[domain].items():
+        sig = inspect.signature(fn)
+        required = [p.name for p in sig.parameters.values() if p.default is inspect.Parameter.empty]
+        optional = [p.name for p in sig.parameters.values() if p.default is not inspect.Parameter.empty]
+        parts = [f"  {action} — {summary}"]
+        if required:
+            parts.append(f" Requires: {', '.join(required)}.")
+        if optional:
+            parts.append(f" Optional: {', '.join(optional)}.")
+        lines.append("".join(parts))
+    return "\n".join(lines)
+
+
+def _run(domain: str, action: str, params: dict) -> str:
+    """Dispatch a domain call: validate the action, pass only provided params."""
+    actions = DOMAINS[domain]
+    spec = actions.get(action)
+    if spec is None:
+        return (
+            f"Unknown {domain} action {action!r}. "
+            f"Valid actions: {', '.join(actions)}."
+        )
+    fn = spec[0]
+    sig = inspect.signature(fn)
+    provided = {
+        k: v for k, v in params.items()
+        if k != "action" and v is not None and k in sig.parameters
+    }
+    missing = [
+        p.name for p in sig.parameters.values()
+        if p.default is inspect.Parameter.empty and p.name not in provided
+    ]
+    if missing:
+        return (
+            f"{domain}.{action} is missing required parameter(s): {', '.join(missing)}. "
+            f"({spec[1]})"
+        )
+    return fn(**provided)
+
+
+# ── domain tools ───────────────────────────────────────────────────────────────
+# Every parameter is optional (None = "not provided"); _run forwards only the
+# ones the chosen action's real function accepts, so per-function defaults
+# still apply. Docstrings get the generated per-action Requires/Optional
+# listing appended at registration.
+
+
+def applications(
+    action: Literal["status", "update", "log_event", "queue", "get_queue", "evaluate", "decide", "assess", "full_assessment", "save_assessment"],
+    company: str | None = None,
+    role: str | None = None,
+    jd: str | None = None,
+    job_description: str | None = None,
+    source: str | None = None,
+    status: str | None = None,
+    persona: str | None = None,
+    decision: str | None = None,
+    notes: str | None = None,
+    fitment_score: int | None = None,
+    next_steps: str | None = None,
+    contact: str | None = None,
+    event_type: str | None = None,
+    auto_save: bool | None = None,
+    filename: str | None = None,
+    content: str | None = None,
+) -> str:
+    """Track and evaluate job applications: pipeline status, the evaluation queue, fitment assessments, and application events."""
+    return _run("applications", action, locals())
+
+
+def job_search(
+    action: Literal["web", "greenhouse", "lever", "url"],
+    query: str | None = None,
+    location: str | None = None,
+    num_results: int | None = None,
+    company_slug: str | None = None,
+    url: str | None = None,
+    auto_queue: bool | None = None,
+) -> str:
+    """Find job postings: open-web search, Greenhouse/Lever company boards, or scrape a posting URL."""
+    return _run("job_search", action, locals())
+
+
+def documents(
+    action: Literal["generate_resume", "generate_resume_agent", "generate_cover_letter", "export_resume_pdf", "export_cover_letter_pdf", "export_resume_latex", "export_cover_letter_latex", "save_resume", "save_cover_letter", "diff", "write_latex_section", "customization_strategy", "preview_story_retrieval"],
+    company: str | None = None,
+    role: str | None = None,
+    job_description: str | None = None,
+    output_filename: str | None = None,
+    template: str | None = None,
+    style: str | None = None,
+    filename: str | None = None,
+    content: str | None = None,
+    footer_tag: str | None = None,
+    role_title: str | None = None,
+    letter_date: str | None = None,
+    body: str | None = None,
+    resume_text: str | None = None,
+    export_pipeline: bool | None = None,
+    cl_template: str | None = None,
+    cl_style: str | None = None,
+    file_a: str | None = None,
+    file_b: str | None = None,
+    role_type: str | None = None,
+    section_filename: str | None = None,
+) -> str:
+    """Generate, export, and manage application documents: resumes and cover letters (text, PDF, LaTeX), diffs, and customization strategy."""
+    return _run("documents", action, locals())
+
+
+def materials(
+    action: Literal["read_master_resume", "read_resume", "read_reference", "read_latex_asset", "list", "search", "reindex", "reindex_stories"],
+    filename: str | None = None,
+    company: str | None = None,
+    query: str | None = None,
+    category: str | None = None,
+) -> str:
+    """Read and search your existing materials: master resume, saved resumes/letters, reference files, LaTeX assets, and the semantic index."""
+    return _run("materials", action, locals())
+
+
+def interviews_tool(
+    action: Literal["log", "list", "context", "upcoming", "prep_context", "save_prep", "get_prep", "quick_reference", "leetcode_cheatsheet"],
+    company: str | None = None,
+    role: str | None = None,
+    stage: str | None = None,
+    job_description: str | None = None,
+    content: str | None = None,
+    filename: str | None = None,
+    interview_date: str | None = None,
+    interview_type: str | None = None,
+    interviewer: str | None = None,
+    interviewer_role: str | None = None,
+    duration_minutes: int | None = None,
+    self_rating: int | None = None,
+    interview_format: str | None = None,
+    what_landed: str | None = None,
+    what_didnt: str | None = None,
+    verbatim_quotes: str | None = None,
+    surfaced_priorities: str | None = None,
+    process_details: str | None = None,
+    comp_signals: str | None = None,
+    follow_up_commitments: str | None = None,
+    tags: str | None = None,
+    notes: str | None = None,
+    tag: str | None = None,
+    since: str | None = None,
+    include_full: bool | None = None,
+    days_ahead: int | None = None,
+    section: str | None = None,
+) -> str:
+    """Interview lifecycle: log debriefs, review history and company context, see upcoming interviews, and build/save prep docs."""
+    return _run("interviews", action, locals())
+
+
+def people_tool(
+    action: Literal["log", "list", "get", "referral_chains", "draft_outreach", "draft_reply", "review_message", "crossref_run", "crossref_get", "fb_queue"],
+    name: str | None = None,
+    relationship: str | None = None,
+    company: str | None = None,
+    context: str | None = None,
+    tags: str | None = None,
+    contact_info: str | None = None,
+    outreach_status: str | None = None,
+    notes: str | None = None,
+    sent_message: str | None = None,
+    tag: str | None = None,
+    slim: bool | None = None,
+    target_company: str | None = None,
+    contact: str | None = None,
+    message_type: str | None = None,
+    text: str | None = None,
+    incoming_message: str | None = None,
+    intent: str | None = None,
+    fb_folder: str | None = None,
+    insight: str | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+    sort_by: str | None = None,
+    include_pending: bool | None = None,
+) -> str:
+    """Contacts and outreach: log/list people, referral paths, draft and review outreach messages, and the FB cross-reference queue."""
+    return _run("people", action, locals())
+
+
+def stories(
+    action: Literal["log", "ingest", "personal_context", "star_context", "star_all", "tone_log", "tone_profile", "tone_scan"],
+    story: str | None = None,
+    tags: str | None = None,
+    people: str | None = None,
+    title: str | None = None,
+    tag: str | None = None,
+    person: str | None = None,
+    tone_sample: bool | None = None,
+    company: str | None = None,
+    role_type: str | None = None,
+    text: str | None = None,
+    source: str | None = None,
+    context: str | None = None,
+    category: str | None = None,
+    limit: int | None = None,
+    force: bool | None = None,
+) -> str:
+    """Personal stories and voice: log anecdotes, retrieve STAR/personal context for applications, and manage your writing-tone profile."""
+    return _run("stories", action, locals())
+
+
+def wellbeing(
+    action: Literal["checkin", "log", "oura_sync", "oura_log", "oura_get", "hbdi_run", "hbdi_profile"],
+    mood: int | None = None,
+    energy: int | None = None,
+    notes: str | None = None,
+    productive: bool | None = None,
+    days: int | None = None,
+    readiness_score: int | None = None,
+    sleep_score: int | None = None,
+    hrv: int | None = None,
+    recovery_index: int | None = None,
+    date: str | None = None,
+    raw_json: str | None = None,
+    q1_no_spec_project: str | None = None,
+    q2_critical_feedback: str | None = None,
+    q3_tedious_finish: str | None = None,
+    q4_senior_disagreement: str | None = None,
+    score_a: int | None = None,
+    score_b: int | None = None,
+    score_c: int | None = None,
+    score_d: int | None = None,
+) -> str:
+    """Wellbeing during the hunt: mood/energy check-ins, Oura readiness (sync/log/history), and the HBDI thinking-style profile."""
+    return _run("wellbeing", action, locals())
+
+
+def brand(
+    action: Literal["post_log", "post_metrics", "posts", "github_stats", "portfolio", "portfolio_refresh", "scan_project_skills"],
+    text: str | None = None,
+    source: str | None = None,
+    context: str | None = None,
+    posted_date: str | None = None,
+    url: str | None = None,
+    hashtags: str | None = None,
+    links: str | None = None,
+    title: str | None = None,
+    auto_log_tone: bool | None = None,
+    post_id: str | None = None,
+    impressions: int | None = None,
+    members_reached: int | None = None,
+    reactions: int | None = None,
+    comments: int | None = None,
+    reposts: int | None = None,
+    saves: int | None = None,
+    link_clicks: int | None = None,
+    profile_views_from_post: int | None = None,
+    followers_gained: int | None = None,
+    audience_highlights: str | None = None,
+    hashtag: str | None = None,
+    min_reactions: int | None = None,
+    include_text: bool | None = None,
+    username: str | None = None,
+) -> str:
+    """Professional brand: LinkedIn post pipeline + metrics, GitHub stats, portfolio metrics, and side-project skill scans."""
+    return _run("brand", action, locals())
+
+
+def insights(
+    action: Literal["daily_digest", "weekly_summary", "session_context", "rejection_log", "rejections", "compensation_update", "compensation_compare"],
+    company: str | None = None,
+    role: str | None = None,
+    stage: str | None = None,
+    reason: str | None = None,
+    notes: str | None = None,
+    date: str | None = None,
+    since: str | None = None,
+    include_pattern_analysis: bool | None = None,
+    base: int | None = None,
+    equity_total: int | None = None,
+    equity_vest_years: int | None = None,
+    bonus_target_pct: int | None = None,
+    level: str | None = None,
+    location: str | None = None,
+    remote: bool | None = None,
+) -> str:
+    """Digests and analysis: daily/weekly summaries, session context, rejection funnel patterns, and compensation comparison."""
+    return _run("insights", action, locals())
+
+
+def workspace(
+    action: Literal["check", "setup"],
+    name: str | None = None,
+    email: str | None = None,
+    phone: str | None = None,
+    linkedin: str | None = None,
+    city_state: str | None = None,
+    master_resume_content: str | None = None,
+    address: str | None = None,
+    openai_api_key: str | None = None,
+    leetcode_language: str | None = None,
+    side_project_folders: str | None = None,
+) -> str:
+    """Workspace setup: check what's present/missing, and create or complete the workspace from your details."""
+    return _run("workspace", action, locals())
+
+
+# MCP tool name → facade. interviews/people shadow imported modules, hence
+# the _tool suffix on the functions; the registered names stay clean.
+FACADES: dict[str, object] = {
+    "applications": applications,
+    "job_search": job_search,
+    "documents": documents,
+    "materials": materials,
+    "interviews": interviews_tool,
+    "people": people_tool,
+    "stories": stories,
+    "wellbeing": wellbeing,
+    "brand": brand,
+    "insights": insights,
+    "workspace": workspace,
+}
+
+
+def register(mcp) -> None:
+    for name, fn in FACADES.items():
+        if "Actions:" not in (fn.__doc__ or ""):
+            fn.__doc__ = (fn.__doc__ or "").rstrip() + "\n" + _actions_doc(name)
+        mcp.tool(name=name)(fn)

--- a/tools/consolidated.py
+++ b/tools/consolidated.py
@@ -13,6 +13,11 @@ instead (escape hatch; the underlying modules are unchanged).
 Adding an action: add one row to the domain's spec below — the per-action
 "Requires/Optional" documentation in the tool description is generated from
 the target function's real signature, so it can't drift.
+
+Wide signatures are intentional (Sonar S107 is excluded for this file in
+sonar-project.properties): FastMCP derives each tool's inputSchema from the
+function signature, so a facade's parameter list must be the union of its
+actions' parameters. These functions are dispatch-only — no human call sites.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
Promotes the tool consolidation (PR #75) from qa to production, validated on qa with a live Claude session confirming all capabilities remain accessible.

- **11 domain tools** (`applications`, `job_search`, `documents`, `materials`, `interviews`, `people`, `stories`, `wellbeing`, `brand`, `insights`, `workspace`) — action-dispatch facades over every one of the 85 existing implementations, which are unchanged underneath.
- MCP clients discover tools dynamically, so existing connect configs keep working; jobContext now uses ~11 of VS Code's 128 tool slots instead of 85.
- Embedded desktop chat allowlist becomes the full 11-tool surface — the whole capability set instead of the previous 23-tool subset.
- `JOBCONTEXT_LEGACY_TOOLS=1` restores the historical per-function surface as an escape hatch.

After merge: tag `desktop-v1.0.0-beta.5` so the desktop channel picks up the consolidated surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)