### PR TITLE
feat(desktop): auto-updater for beta.5

### DIFF
--- a/.github/workflows/desktop-backend.yml
+++ b/.github/workflows/desktop-backend.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - feat/desktop-app
+      - feat/desktop-*
     paths:
       - desktop_main.py
       - packaging/**

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -40,6 +40,10 @@ jobs:
       APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
       APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
       APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+      # Tauri updater artifact signing (all platforms). Empty on forks —
+      # updater artifacts are simply skipped without it.
+      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
     strategy:
       fail-fast: false
       matrix:
@@ -50,6 +54,8 @@ jobs:
             bundles: dmg
             installer_glob: |
               desktop/src-tauri/target/release/bundle/dmg/*.dmg
+              desktop/src-tauri/target/release/bundle/macos/*.app.tar.gz
+              desktop/src-tauri/target/release/bundle/macos/*.app.tar.gz.sig
           # macos-13 was retired 2025-12-08; macos-15-intel is the last Intel
           # image (until Fall 2027). Plan to go arm64-only when it sunsets.
           - os: macos-15-intel
@@ -58,12 +64,15 @@ jobs:
             bundles: dmg
             installer_glob: |
               desktop/src-tauri/target/release/bundle/dmg/*.dmg
+              desktop/src-tauri/target/release/bundle/macos/*.app.tar.gz
+              desktop/src-tauri/target/release/bundle/macos/*.app.tar.gz.sig
           - os: windows-latest
             label: windows-x64
             binary: dist/jobcontext-backend/jobcontext-backend.exe
             bundles: nsis,msi
             installer_glob: |
               desktop/src-tauri/target/release/bundle/nsis/*.exe
+              desktop/src-tauri/target/release/bundle/nsis/*.sig
               desktop/src-tauri/target/release/bundle/msi/*.msi
           - os: ubuntu-22.04    # oldest supported glibc for AppImage compatibility
             label: linux-x64
@@ -71,6 +80,7 @@ jobs:
             bundles: appimage,deb
             installer_glob: |
               desktop/src-tauri/target/release/bundle/appimage/*.AppImage
+              desktop/src-tauri/target/release/bundle/appimage/*.sig
               desktop/src-tauri/target/release/bundle/deb/*.deb
 
     steps:
@@ -279,14 +289,24 @@ jobs:
             BUNDLES="$(printf '%s' "$BUNDLES" | tr ',' '\n' | grep -vx msi | paste -sd, -)"
             echo "pre-release version ${VERSION} — Windows bundles: ${BUNDLES} (msi dropped)"
           fi
-          # One merged --config overlay: release version stamp and/or the
-          # Windows signCommand.
+          # One merged --config overlay: release version stamp, the Windows
+          # signCommand, and updater artifacts (.sig files via the
+          # TAURI_SIGNING_* secrets). macOS skips createUpdaterArtifacts —
+          # Tauri would tar the .app BEFORE rcodesign signs it, so the mac
+          # signing step builds the updater archive itself from the signed app.
           OVERLAY=""
+          BUNDLE_OVERLAY=""
           if [ -n "${VERSION:-}" ]; then
             OVERLAY+="\"version\":\"${VERSION}\","
           fi
           if [ "$RUNNER_OS" = "Windows" ] && [ -n "$AZURE_CLIENT_ID" ]; then
-            OVERLAY+="\"bundle\":{\"windows\":{\"signCommand\":\"trusted-signing-cli -e https://eus.codesigning.azure.net -a jobContext -c jobcontext-public %1\"}},"
+            BUNDLE_OVERLAY+="\"windows\":{\"signCommand\":\"trusted-signing-cli -e https://eus.codesigning.azure.net -a jobContext -c jobcontext-public %1\"},"
+          fi
+          if [ "$RUNNER_OS" != "macOS" ] && [ -n "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
+            BUNDLE_OVERLAY+="\"createUpdaterArtifacts\":true,"
+          fi
+          if [ -n "$BUNDLE_OVERLAY" ]; then
+            OVERLAY+="\"bundle\":{${BUNDLE_OVERLAY%,}},"
           fi
           EXTRA=()
           if [ -n "$OVERLAY" ]; then
@@ -356,6 +376,24 @@ jobs:
             --p12-password-file "$RUNNER_TEMP/cert.pass" "$DMG"
           rm -f "$RUNNER_TEMP/cert.p12" "$RUNNER_TEMP/cert.pass"
           echo "signed dmg: $DMG"
+
+          # Updater artifact: tar of the SIGNED .app + minisign signature.
+          # (Tauri's own createUpdaterArtifacts would archive the pre-signing
+          # app, so it's disabled on macOS and built here instead.)
+          if [ -n "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
+            MAC_DIR="desktop/src-tauri/target/release/bundle/macos"
+            rm -f "$MAC_DIR"/*.app.tar.gz "$MAC_DIR"/*.app.tar.gz.sig
+            UPDATER_TAR="$MAC_DIR/jobContext_${DMG_VERSION}_${DMG_ARCH}.app.tar.gz"
+            tar -czf "$UPDATER_TAR" -C "$MAC_DIR" jobContext.app
+            printf '%s' "$TAURI_SIGNING_PRIVATE_KEY" > "$RUNNER_TEMP/updater.key"
+            (cd desktop && npx tauri signer sign \
+              --private-key-path "$RUNNER_TEMP/updater.key" \
+              --password "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" \
+              "$GITHUB_WORKSPACE/$UPDATER_TAR")
+            rm -f "$RUNNER_TEMP/updater.key"
+            test -s "$UPDATER_TAR.sig"
+            echo "updater artifact: $UPDATER_TAR"
+          fi
 
       # Notarize the signed dmg ourselves so the submission log is visible.
       # The Notary log lists every issue (unsigned/unhardened Mach-O, bad

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -385,12 +385,9 @@ jobs:
             rm -f "$MAC_DIR"/*.app.tar.gz "$MAC_DIR"/*.app.tar.gz.sig
             UPDATER_TAR="$MAC_DIR/jobContext_${DMG_VERSION}_${DMG_ARCH}.app.tar.gz"
             tar -czf "$UPDATER_TAR" -C "$MAC_DIR" jobContext.app
-            printf '%s' "$TAURI_SIGNING_PRIVATE_KEY" > "$RUNNER_TEMP/updater.key"
-            (cd desktop && npx tauri signer sign \
-              --private-key-path "$RUNNER_TEMP/updater.key" \
-              --password "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" \
-              "$GITHUB_WORKSPACE/$UPDATER_TAR")
-            rm -f "$RUNNER_TEMP/updater.key"
+            # The tauri CLI reads TAURI_SIGNING_PRIVATE_KEY(_PASSWORD) from
+            # the environment; passing key flags as well is a CLI conflict.
+            (cd desktop && npx tauri signer sign "$GITHUB_WORKSPACE/$UPDATER_TAR")
             test -s "$UPDATER_TAR.sig"
             echo "updater artifact: $UPDATER_TAR"
           fi

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -43,8 +43,56 @@ jobs:
         run: |
           shopt -s globstar nullglob
           files=(installers/**/*.dmg installers/**/*.exe installers/**/*.msi
-                 installers/**/*.AppImage installers/**/*.deb)
-          echo "attaching ${#files[@]} installers"
+                 installers/**/*.AppImage installers/**/*.deb
+                 installers/**/*.app.tar.gz installers/**/*.sig)
+          echo "attaching ${#files[@]} installers + updater artifacts"
+
+          # Updater manifest: version + per-platform artifact URL/signature,
+          # consumed by tauri-plugin-updater in the installed apps. Attached
+          # to this release AND clobbered onto the rolling `desktop-latest`
+          # release (the fixed endpoint apps poll — /releases/latest can't be
+          # used because desktop releases are pre-releases in a shared repo).
+          python3 - "$GITHUB_REF_NAME" <<'PYEOF'
+          import datetime, json, os, pathlib, sys
+
+          tag = sys.argv[1]
+          version = tag.removeprefix("desktop-v")
+          repo = os.environ["GITHUB_REPOSITORY"]
+          base = f"https://github.com/{repo}/releases/download/{tag}"
+          arts = {p.name: p for p in pathlib.Path("installers").rglob("*") if p.is_file()}
+
+          def entry(name):
+              sig = arts.get(name + ".sig")
+              if name not in arts or sig is None:
+                  return None
+              return {"signature": sig.read_text().strip(), "url": f"{base}/{name}"}
+
+          platforms = {}
+          for key, name in [
+              ("darwin-aarch64", f"jobContext_{version}_aarch64.app.tar.gz"),
+              ("darwin-x86_64",  f"jobContext_{version}_x64.app.tar.gz"),
+              ("windows-x86_64", f"jobContext_{version}_x64-setup.exe"),
+              ("linux-x86_64",   f"jobContext_{version}_amd64.AppImage"),
+          ]:
+              e = entry(name)
+              if e:
+                  platforms[key] = e
+          if not platforms:
+              print("no signed updater artifacts found — skipping latest.json")
+              raise SystemExit(0)
+          manifest = {
+              "version": version,
+              "notes": f"jobContext Desktop {version}",
+              "pub_date": datetime.datetime.now(datetime.timezone.utc)
+                  .isoformat(timespec="seconds").replace("+00:00", "Z"),
+              "platforms": platforms,
+          }
+          pathlib.Path("latest.json").write_text(json.dumps(manifest, indent=2))
+          print(f"latest.json: {sorted(platforms)}")
+          PYEOF
+          if [ -f latest.json ]; then
+            files+=(latest.json)
+          fi
 
           # Install notes prepended above the auto-generated changelog. These
           # builds aren't Apple-notarized yet (Phase 7), so testers need the
@@ -79,3 +127,17 @@ jobs:
             --notes-file NOTES.md \
             --generate-notes \
             "${files[@]}"
+
+          # Refresh the rolling updater channel: a fixed-tag release whose
+          # only job is hosting the newest latest.json at a stable URL.
+          if [ -f latest.json ]; then
+            if ! gh release view desktop-latest --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+              gh release create desktop-latest \
+                --repo "${GITHUB_REPOSITORY}" \
+                --prerelease \
+                --title "Desktop updater channel" \
+                --notes "Machine-consumed update manifest for jobContext Desktop's auto-updater. Install from the newest desktop-v* release, not from here."
+            fi
+            gh release upload desktop-latest latest.json --clobber --repo "${GITHUB_REPOSITORY}"
+            echo "updater channel now points at ${GITHUB_REF_NAME}"
+          fi

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -54,6 +54,13 @@ reputation, SmartScreen may warn — click **More info → Run anyway**.
 - **AppImage:** `chmod +x jobContext_*_amd64.AppImage && ./jobContext_*_amd64.AppImage`
 - **Debian/Ubuntu:** `sudo dpkg -i jobContext_*_amd64.deb`
 
+### Updating
+
+From `v1.0.0-beta.5` onward the app checks for updates at launch and offers
+**Update & restart** (signed manifest, downloads from GitHub Releases). Older
+builds: download the new installer and install over the existing app — your
+data lives in the per-OS app-data folder and is never touched by upgrades.
+
 ### First run
 
 Open **Settings** to (optionally) add an AI provider key — OpenAI, Anthropic,

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -48,6 +48,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,6 +680,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,6 +972,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1499,6 +1529,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1748,6 +1793,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1779,9 +1854,13 @@ dependencies = [
 name = "jobcontext-desktop"
 version = "0.1.0"
 dependencies = [
+ "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
+ "tauri-plugin-process",
  "tauri-plugin-single-instance",
+ "tauri-plugin-updater",
 ]
 
 [[package]]
@@ -1944,6 +2023,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2177,6 +2262,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2190,6 +2276,18 @@ dependencies = [
  "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2256,6 +2354,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2269,6 +2373,20 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2662,15 +2780,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2680,6 +2803,44 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2711,6 +2872,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2723,6 +2957,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2781,6 +3024,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3003,6 +3269,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3115,6 +3397,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3197,7 +3485,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -3231,6 +3519,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3253,7 +3552,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -3350,6 +3649,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74be5dd4bed9afbd145e5716b5fa2ec28cbc29c34ffa61c258c9273d896c8020"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
 name = "tauri-plugin-single-instance"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3365,6 +3732,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3374,7 +3774,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -3397,7 +3797,7 @@ checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -3593,6 +3993,16 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -3909,6 +4319,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4152,6 +4568,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4379,6 +4804,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4676,7 +5110,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -4721,6 +5155,16 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]
@@ -4829,6 +5273,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4859,6 +5309,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -10,6 +10,10 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-single-instance = "2"
+tauri-plugin-updater = "2"
+tauri-plugin-dialog = "2"
+tauri-plugin-process = "2"
+serde_json = "1"
 
 [profile.release]
 strip = true

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -148,6 +148,64 @@ fn stop_backend(state: &BackendState) {
     }
 }
 
+/// Background update check (shell-side, no SPA involvement): ask the rolling
+/// `desktop-latest` manifest whether a newer build exists; if so, offer a
+/// native dialog and on Yes download + install + relaunch. Any failure is
+/// silent — updates must never break a working app, and the user can always
+/// install a release manually.
+fn check_for_updates(handle: tauri::AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
+        use tauri_plugin_updater::UpdaterExt;
+
+        let updater = match handle.updater() {
+            Ok(u) => u,
+            Err(_) => return,
+        };
+        let update = match updater.check().await {
+            Ok(Some(update)) => update,
+            _ => return,
+        };
+        let version = update.version.clone();
+        let proceed = handle
+            .dialog()
+            .message(format!(
+                "jobContext {version} is available (you have {}).\n\nDownload and install now? \
+                 The app restarts when it finishes.",
+                handle.package_info().version
+            ))
+            .title("Update available")
+            .kind(MessageDialogKind::Info)
+            .buttons(MessageDialogButtons::OkCancelCustom(
+                "Update & restart".into(),
+                "Later".into(),
+            ))
+            .blocking_show();
+        if !proceed {
+            return;
+        }
+        match update.download_and_install(|_, _| {}, || {}).await {
+            Ok(()) => {
+                // The backend must exit cleanly before the new shell spawns
+                // its own (SQLite single-writer). RunEvent::Exit handles it,
+                // and restart() takes the normal exit path.
+                handle.restart();
+            }
+            Err(_) => {
+                handle
+                    .dialog()
+                    .message(
+                        "The update could not be installed. You can download the latest \
+                         version from the jobContext releases page.",
+                    )
+                    .title("Update failed")
+                    .kind(MessageDialogKind::Warning)
+                    .blocking_show();
+            }
+        }
+    });
+}
+
 fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
@@ -156,8 +214,12 @@ fn main() {
                 let _ = window.set_focus();
             }
         }))
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_process::init())
         .manage(BackendState(Mutex::new(None)))
         .setup(|app| {
+            check_for_updates(app.handle().clone());
             let handle = app.handle().clone();
             std::thread::spawn(move || {
                 let result = spawn_backend(&handle).and_then(|backend| {

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -22,8 +22,17 @@
       "csp": null
     }
   },
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEY5QTI5RjIwRjBCMEI1MDUKUldRRnRiRHdJSitpK1pmN0c3QzU3b1pDM0szTWt3OHgxbnI0WUwxSkMrUk50bUtic2tTYkNyVDEK",
+      "endpoints": [
+        "https://github.com/JustLikeFrank3/jobContextMCP/releases/download/desktop-latest/latest.json"
+      ]
+    }
+  },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": ["dmg", "nsis", "msi", "appimage", "deb"],
     "category": "Productivity",
     "shortDescription": "Local-first job search copilot with MCP",

--- a/docs/desktop/ROADMAP.md
+++ b/docs/desktop/ROADMAP.md
@@ -23,7 +23,7 @@ pywebview spike remains a cheap fallback demo if ever needed.
 | 5.5 | Embedded chat panel (agent loop + tool calling in the SPA) | ✅ agent loop + SSE + persistence, chat UI w/ tool chips + model indicator, Anthropic/OpenAI/Ollama BYOK with in-app Settings key entry — all live-verified; deferred polish: markdown rendering, token streaming |
 | 6 | Installers (dmg / NSIS+msi / AppImage+deb) | ✅ all four platforms green in CI (2026-07-06): arm64+Intel dmg, NSIS exe+msi, AppImage+deb — unsigned pending Phase 7 |
 | 7 | Signing & notarization | ✅ (2026-07-06) Windows Authenticode via Azure Trusted Signing (individual validation; org later). macOS Developer ID + notarization green: sign the **final** .app with rcodesign two-pass — Tauri's resource copy dereferences symlinks into duplicate Python Mach-Os that pre-bundle signing can never cover; notarytool crashes on GH runners → rcodesign notary-submit + staple |
-| 8 | Auto-update + GitHub Actions release matrix | ◐ release pipeline done & validated: reusable desktop-build.yml shared by Desktop CI (branch pushes) and Desktop Release (`desktop-v*` tags → version-stamped pre-release with installers; namespace disjoint from cloud `v*`/AKS). Remaining: updater plugin (wants signing keys) |
+| 8 | Auto-update + GitHub Actions release matrix | ◐ release pipeline done & validated: reusable desktop-build.yml shared by Desktop CI (branch pushes) and Desktop Release (`desktop-v*` tags → version-stamped pre-release with installers; namespace disjoint from cloud `v*`/AKS). updater plugin shipped (launch-time check against the rolling desktop-latest manifest, native dialog, update & restart) — first self-update exercised beta.5 → beta.6 |
 | 9 | QA on clean VMs, beta, launch | ⬜ |
 
 ## What Phase 0/1 shipped


### PR DESCRIPTION
Adds the Phase 8 auto-updater so beta.5 installs can self-update to beta.6+ — no more manual dmg downloads for testers.

**In-app flow (shell-side Rust, zero SPA/IPC surface):** on launch the app checks a rolling `desktop-latest` manifest; if a newer build exists it shows a native "Update available — Update & restart / Later" dialog, downloads the signed artifact, verifies it against the minisign pubkey baked into the app, installs, and relaunches. Every failure path is silent or dialog-only — an update can never break a working install, and manual installs keep working.

**Pipeline:**
- New `TAURI_SIGNING_PRIVATE_KEY(_PASSWORD)` secrets sign updater artifacts (key generated offline, never displayed; pubkey committed in `tauri.conf.json`). Secretless/fork builds skip updater artifacts entirely.
- Windows (`-setup.exe`) and Linux (AppImage) signatures come from Tauri's `createUpdaterArtifacts` (enabled via `--config` overlay only when the key is present). macOS builds its `.app.tar.gz` manually **after** rcodesign signs the app, since Tauri would archive the pre-signing bundle.
- The release workflow assembles `latest.json` (version + per-platform URL/signature), attaches it to the versioned release, and clobbers it onto a rolling `desktop-latest` release — a fixed URL, because `/releases/latest` can't serve pre-releases in a repo shared with the cloud product's `v*` releases.

Desktop-only change; nothing here executes on the cloud. `cargo check` clean; branch CI builds the full installer matrix with updater artifacts.

The beta.5 → beta.6 hop will be the first real self-update exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)