### PR TITLE
chore(sonar): accept S107 for consolidated tool facades

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,3 +4,13 @@ sonar.python.version=3.12
 sonar.sources=lib,tools,services,transport,server.py,cli.py
 sonar.tests=tests
 sonar.python.coverage.reportPaths=coverage.xml
+
+# S107 (max 13 parameters) is intentionally violated by tools/consolidated.py:
+# each domain facade's signature is the union of its actions' parameters, and
+# FastMCP derives the MCP tool inputSchema directly from that signature — the
+# wide, flat parameter list IS the machine-facing API the model reads. These
+# functions are dispatch-only (no human call sites) and each parameter is
+# documented per-action in the docstring.
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=python:S107
+sonar.issue.ignore.multicriteria.e1.resourceKey=tools/consolidated.py

--- a/tools/consolidated.py
+++ b/tools/consolidated.py
@@ -13,6 +13,11 @@ instead (escape hatch; the underlying modules are unchanged).
 Adding an action: add one row to the domain's spec below — the per-action
 "Requires/Optional" documentation in the tool description is generated from
 the target function's real signature, so it can't drift.
+
+Wide signatures are intentional (Sonar S107 is excluded for this file in
+sonar-project.properties): FastMCP derives each tool's inputSchema from the
+function signature, so a facade's parameter list must be the union of its
+actions' parameters. These functions are dispatch-only — no human call sites.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
Clears the 8 Major "too many parameters" code smells on `tools/consolidated.py` with a scoped rule exclusion rather than code churn: the wide signatures are the design — FastMCP derives each MCP tool's inputSchema from the function signature, so each domain facade carries the union of its actions' parameters. Dispatch-only functions, no human call sites, per-action parameter docs generated from the real signatures. Exclusion is one rule (`python:S107`) on one file, documented in both `sonar-project.properties` and the module docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)