### PR TITLE
fix(desktop): workspace import rejected legit filenames (em dashes etc.)

### DIFF
--- a/tests/test_desktop_mode.py
+++ b/tests/test_desktop_mode.py
@@ -576,3 +576,35 @@ def test_import_workspace_rejects_absolute_and_backslash_paths(desktop_client, d
             headers={"Content-Type": "application/zip"},
         )
         assert resp.status_code == 422, evil
+
+
+def test_import_workspace_allows_unicode_punctuation_filenames(desktop_client, desktop_data_dir_env):
+    """Regression: the export produces filenames with em dashes / curly quotes
+    (e.g. '07-Job-Assessments/Airbnb — Shannon Mock Interview Script.md') and
+    the old charset allowlist rejected them on import."""
+    name = "workspace/07-Job-Assessments/Airbnb — Shannon’s Mock – Interview Script.md"
+    payload = _make_export_zip({
+        "config.json": b"{}",
+        "db/jobcontextmcp.db": b"x",
+        name: b"script",
+    })
+    resp = desktop_client.post(
+        "/desktop/import-workspace", content=payload,
+        headers={"Content-Type": "application/zip"},
+    )
+    assert resp.status_code == 200, resp.text
+    target = desktop_data_dir_env / "workspace" / "07-Job-Assessments" / "Airbnb — Shannon’s Mock – Interview Script.md"
+    assert target.read_bytes() == b"script"
+
+
+def test_import_workspace_still_rejects_dangerous_parts(desktop_client, desktop_data_dir_env):
+    # (No NUL-byte case: Python's zipfile truncates names at \x00 on read,
+    # so it can't be constructed here — the control-char regex still guards
+    # against zips from writers that pass them through.)
+    for evil in ("../evil.txt", "a/../../evil.txt", "db:alt.db"):
+        payload = _make_export_zip({"config.json": b"{}", evil: b"nope"})
+        resp = desktop_client.post(
+            "/desktop/import-workspace", content=payload,
+            headers={"Content-Type": "application/zip"},
+        )
+        assert resp.status_code == 422, evil

--- a/transport/http/desktop.py
+++ b/transport/http/desktop.py
@@ -271,12 +271,13 @@ async def set_ai_provider(request: AiProviderRequest) -> dict:
 # cloud workspace from the hosted dashboard, then imports it here to replace
 # the local data. Raw zip body (no multipart — python-multipart isn't a dep).
 
-# Zip-slip guard: each path component of an archive entry must match this
-# allowlist (unicode word chars + common filename punctuation — covers the
-# provisioned tree and user-named materials). No separators, no drive
-# letters, and ".."/"." are rejected outright, so a validated entry can only
-# land inside the extraction root.
-_SAFE_ZIP_PART = re.compile(r"[\w .()'@#&+,%=\[\]{}~^-]+", re.UNICODE)
+# Zip-slip guard: every character of a path component must be outside the
+# dangerous set — separators (/, \\), drive colons, and control chars — and
+# ".."/"." components are rejected outright, so a validated entry can only
+# land inside the extraction root. A denylist, not a charset allowlist: user
+# filenames legitimately carry unicode punctuation (em dashes, curly quotes)
+# that an allowlist kept rejecting — from zips our own export produced.
+_SAFE_ZIP_PART = re.compile(r"[^/\\:\x00-\x1f]+")
 
 
 def _validated_member_path(extract_root: Path, name: str) -> Path:


### PR DESCRIPTION
Beta.5 field report: importing a cloud export failed with `Unsafe path in archive: '07-Job-Assessments/Airbnb — Shannon Mock Interview Script.md'` — the zip-slip guard's charset allowlist didn't include unicode punctuation, so export and import disagreed about our own files.

Validation now denylists what's actually dangerous per path component (separators, drive colons, control chars, plus `..`/`.`) instead of allowlisting characters. Regression tests cover em dash/curly-quote names and re-prove the traversal rejections. 1,347 tests pass under the deploy env.

This needs to reach the desktop channel as beta.6 — which conveniently makes it the first live test of the beta.5 auto-updater.

🤖 Generated with [Claude Code](https://claude.com/claude-code)