### PR TITLE
fix(interviews): string args coerce to lists — no more character explosion

### DIFF
--- a/tests/test_interviews_coercion.py
+++ b/tests/test_interviews_coercion.py
@@ -1,0 +1,59 @@
+"""LLM tool calls pass strings where schemas say list[str] — never explode
+them into characters (the Cox follow_up_commitments corruption)."""
+from __future__ import annotations
+
+import pytest
+
+import lib.config as cfg
+
+
+@pytest.fixture()
+def workspace(tmp_path, monkeypatch):
+    from lib.user_provisioning import provision_user_data
+
+    monkeypatch.setattr(cfg, "DATA_FOLDER", str(tmp_path), raising=False)
+    # Static module-level file paths were computed at import from the real
+    # DATA_FOLDER — repoint them or the test writes into the repo's live
+    # data/ files (which is exactly how a leaked entry broke the migration
+    # roundtrip test).
+    monkeypatch.setattr(cfg, "INTERVIEWS_FILE", tmp_path / "interviews.json", raising=False)
+    provision_user_data(tmp_path)
+    return tmp_path
+
+
+def test_string_list_fields_coerce_not_explode(workspace):
+    from tools.interviews import get_interviews, log_interview
+
+    result = log_interview(
+        company="Cox Automotive",
+        role="Senior Platform Engineer",
+        interview_date="2026-07-08",
+        interview_type="recruiter_screen",
+        follow_up_commitments="Proceed as agreed; send Azure architecture examples.",
+        surfaced_priorities="System design panel is the heavy round",
+        tags="recruiter,comp-discussed",
+        verbatim_quotes="Budget tops out at 135K base",
+    )
+    assert result.startswith("✓")
+    out = get_interviews(company="Cox Automotive", include_full=True)
+    assert "Proceed as agreed; send Azure architecture examples." in out
+    # No character explosion: single letters never appear as standalone items.
+    assert "'P', 'r', 'o'" not in out and '"P", "r"' not in out
+
+
+def test_string_merge_on_update_stays_intact(workspace):
+    from tools.interviews import get_interviews, log_interview
+
+    log_interview(
+        company="Cox Automotive", role="SWE", interview_date="2026-07-08",
+        interview_type="recruiter_screen",
+        follow_up_commitments=["Send portfolio link"],
+    )
+    log_interview(
+        company="Cox Automotive", role="SWE", interview_date="2026-07-08",
+        interview_type="recruiter_screen",
+        follow_up_commitments="Follow up on comp band by Friday",
+    )
+    out = get_interviews(company="Cox Automotive", include_full=True)
+    assert "Send portfolio link" in out
+    assert "Follow up on comp band by Friday" in out

--- a/tools/interviews.py
+++ b/tools/interviews.py
@@ -51,6 +51,25 @@ def _next_id(interviews: list[dict]) -> int:
     return max(i.get("id", 0) for i in interviews) + 1
 
 
+def _as_str_list(value) -> list[str]:
+    """Coerce a list-ish tool argument to a list of strings.
+
+    LLM tool calls routinely pass a plain string where the schema says
+    list[str]; ``list("Proceed as…")`` explodes it into characters (the Cox
+    follow_up_commitments corruption). A string becomes a one-item list; an
+    iterable is stringified item-wise; None is empty.
+    """
+    if value is None:
+        return []
+    if isinstance(value, str):
+        value = value.strip()
+        return [value] if value else []
+    try:
+        return [str(v).strip() for v in value if str(v).strip()]
+    except TypeError:
+        return [str(value)]
+
+
 def _find_interview(
     interviews: list[dict],
     interview_id: int | None = None,
@@ -80,6 +99,8 @@ def _normalize_quotes(quotes) -> list[dict]:
     list[dict] with {speaker, quote, context} keys. Return list[dict]."""
     if not quotes:
         return []
+    if isinstance(quotes, str):
+        quotes = [quotes]  # a bare string would iterate as characters
     normalized = []
     for q in quotes:
         if isinstance(q, str):
@@ -165,11 +186,11 @@ def log_interview(  # NOSONAR — 18 params are intentional: structured debrief 
         except (TypeError, ValueError):
             return "✗ self_rating must be an integer 1-10."
 
-    what_landed = list(what_landed or [])
-    what_didnt = list(what_didnt or [])
-    surfaced_priorities = list(surfaced_priorities or [])
-    follow_up_commitments = list(follow_up_commitments or [])
-    tags = list(tags or [])
+    what_landed = _as_str_list(what_landed)
+    what_didnt = _as_str_list(what_didnt)
+    surfaced_priorities = _as_str_list(surfaced_priorities)
+    follow_up_commitments = _as_str_list(follow_up_commitments)
+    tags = _as_str_list(tags)
     quotes = _normalize_quotes(verbatim_quotes)
 
     data = _load_json(config.INTERVIEWS_FILE, {"interviews": []})


### PR DESCRIPTION
Live repro from Claude mobile after the first successful desktop→cloud sync: `follow_up_commitments` stored as deduplicated single characters. Root cause is in the tool, not the sync — `list[str]` params passed as plain strings get character-iterated by `list()`. All list-ish `log_interview` params now coerce (`str → [str]`), the quotes normalizer guards bare strings, and regression tests pin both create and update-merge paths. Also hardens the test fixture against writing into the repo's live data files.

After merge + deploy + next desktop beta: re-log the Cox follow-up commitments via chat (the original text is unrecoverable from deduplicated characters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)