### PR TITLE
fix(tests): unbreak qa deploy — setup tests need isolated_server in CI

### DIFF
--- a/tests/test_setup_desktop.py
+++ b/tests/test_setup_desktop.py
@@ -10,7 +10,14 @@ import lib.config as cfg
 
 
 @pytest.fixture()
-def desktop_workspace(tmp_path, monkeypatch):
+def desktop_workspace(isolated_server, tmp_path, monkeypatch):
+    """Desktop-mode workspace on top of the suite's canonical isolation.
+
+    isolated_server redirects EVERY module path global to tmp and restores
+    after — without it, environments lacking a repo-root config.json (CI)
+    fall back to placeholder defaults like /path/to/… and setup_workspace's
+    directory steps try to mkdir at the filesystem root.
+    """
     from lib.user_provisioning import provision_user_data
 
     monkeypatch.setenv("DEPLOY_MODE", "desktop")


### PR DESCRIPTION
The qa deploy is red on the two new setup_workspace tests: they passed locally because a repo-root config.json exists there, but CI has none, so path globals fall back to /path/to/… placeholders and mkdir hits the filesystem root. Fixture now layers the canonical isolated_server; verified with the repo config hidden. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)