### PR TITLE
Fix cloud share-capture: propagate partition context into worker

### DIFF
--- a/tests/test_mobile_api.py
+++ b/tests/test_mobile_api.py
@@ -77,3 +77,57 @@ def test_capture_kicks_background_assessment(mobile_client, monkeypatch):
 
     resp = mobile_client.post("/api/capture", json={"url": "javascript:alert(1)"})
     assert resp.status_code == 422
+
+
+def test_capture_worker_inherits_request_context(monkeypatch):
+    """run_in_executor drops contextvars unless the handler copies them — the
+    worker must see the same data-folder override as the request (multi-tenant
+    partitioning), or it reads/writes the wrong user's database."""
+    import asyncio
+
+    import transport.http.routes.mobile as mobile_mod
+    from lib.user_context import get_data_folder_override, reset_data_folder, set_data_folder
+
+    seen = {}
+
+    def probe(url):
+        seen["override"] = get_data_folder_override()
+
+    monkeypatch.setattr(mobile_mod, "_capture_and_assess", probe)
+
+    async def request_with_partition():
+        # Mirrors UserDataContextMiddleware: the override is active only for
+        # the duration of the handler coroutine.
+        token = set_data_folder("/partitions/user-abc")
+        try:
+            resp = await mobile_mod.capture(
+                mobile_mod.CaptureRequest(url="https://jobs.example.com/9"), user=None
+            )
+        finally:
+            reset_data_folder(token)
+        assert resp["status"] == "capturing"
+        # Wait for the executor thread without blocking the loop.
+        for _ in range(100):
+            if "override" in seen:
+                break
+            await asyncio.sleep(0.02)
+
+    asyncio.run(request_with_partition())
+    assert str(seen["override"]) == "/partitions/user-abc"
+
+
+def test_capture_worker_failure_sends_push(monkeypatch):
+    """An exception mid-assessment must surface as a failure push, not silence."""
+    import transport.http.routes.mobile as mobile_mod
+
+    pushes = []
+    monkeypatch.setattr(
+        mobile_mod, "send_push", lambda title, body, data=None: pushes.append((title, data))
+    )
+    monkeypatch.setattr(
+        mobile_mod,
+        "_capture_and_assess_inner",
+        lambda url: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    mobile_mod._capture_and_assess("https://jobs.example.com/9")
+    assert pushes and pushes[0][1]["type"] == "capture_failed"

--- a/transport/http/routes/mobile.py
+++ b/transport/http/routes/mobile.py
@@ -19,6 +19,7 @@ product the middleware resolves the caller's partition.
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import json
 import logging
 from typing import Annotated
@@ -177,7 +178,24 @@ class CaptureRequest(BaseModel):
 
 
 def _capture_and_assess(url: str) -> None:
-    """Blocking worker: import → queue → assess → push. Runs off-loop."""
+    """Blocking worker: import → queue → assess → push. Runs off-loop.
+
+    Must execute inside a copy of the request's context (see capture()) so the
+    per-user data-folder ContextVar still scopes every read/write and the push
+    lookup to the caller's partition.
+    """
+    try:
+        _capture_and_assess_inner(url)
+    except Exception:  # noqa: BLE001 — the user is waiting on a push either way
+        _log.exception("capture worker failed for %s", url)
+        send_push(
+            "Assessment failed",
+            "Something went wrong while evaluating that job. Try sharing it again.",
+            {"type": "capture_failed"},
+        )
+
+
+def _capture_and_assess_inner(url: str) -> None:
     from tools.job_scraper import scrape_job_url
 
     result = scrape_job_url(url, auto_queue=True)
@@ -223,6 +241,10 @@ async def capture(
     url = request.url.strip()
     if not url.startswith(("http://", "https://")):
         raise HTTPException(status_code=422, detail="Share a job posting URL.")
+    # run_in_executor does NOT propagate contextvars (asyncio.to_thread does,
+    # but it would tie the worker's lifetime to this handler). Copy the request
+    # context explicitly so the worker stays inside the caller's partition.
+    ctx = contextvars.copy_context()
     loop = asyncio.get_running_loop()
-    loop.run_in_executor(None, _capture_and_assess, url)
+    loop.run_in_executor(None, ctx.run, _capture_and_assess, url)
     return {"status": "capturing", "detail": "Saved. Assessment running…"}


### PR DESCRIPTION
## What
Share-sheet capture (`POST /api/capture`) offloads scrape → assess → push to a thread with `loop.run_in_executor`, which **does not propagate contextvars**. On the multi-tenant cloud the worker therefore lost the per-request data-folder override, escaped the caller's partition, and died on `OperationalError: no such table` — swallowed by the executor. The user saw "Saved. Assessment running…" and then nothing, ever (prod pod logs: `Future exception was never retrieved` in `_capture_and_assess`).

## Fix
- `capture()` snapshots the request context (`contextvars.copy_context()`) and runs the worker via `ctx.run`, keeping every DB read/write and the push-token lookup inside the caller's partition. (Desktop single-tenant was unaffected, which is why this never reproduced locally.)
- The worker now wraps the whole pipeline: any unexpected failure logs the traceback and sends a `capture_failed` push, so the phone is never left hanging silently.

## Tests
- `test_capture_worker_inherits_request_context` — worker observes the request's partition override (fails on the old code).
- `test_capture_worker_failure_sends_push` — a mid-assessment crash produces the failure push.

Audited the codebase for the same pattern: this was the only fire-and-forget `run_in_executor`; everything else uses `asyncio.to_thread` (which propagates context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)