### PR TITLE
API: Oura history endpoint + full people roster for mobile Networking

### DIFF
--- a/tests/test_dashboard_coverage.py
+++ b/tests/test_dashboard_coverage.py
@@ -1704,6 +1704,8 @@ class TestDashboardPeopleCoverage:
         assert [person["name"] for person in payload["follow_up_queue"]] == ["Dana", "Eli"]
         assert payload["by_status"][0] == {"status": "sent", "count": 1}
         assert {"relationship": "peer", "count": 1} in payload["by_relationship"]
+        # full roster for client-side facet filtering (mobile Networking tab)
+        assert [person["name"] for person in payload["people"]] == ["Dana", "Eli", "Fran"]
 
 
 class TestDashboardPipelineCoverage:

--- a/tests/test_oura.py
+++ b/tests/test_oura.py
@@ -152,6 +152,21 @@ def test_get_oura_readiness_lists_rows(tmp_data, oura_mod):
     assert "High" in out  # >= 85
 
 
+def test_oura_readiness_rows_for_graphing(tmp_data, oura_mod):
+    import datetime
+    d1 = (datetime.date.today() - datetime.timedelta(days=2)).isoformat()
+    d2 = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
+    oura_mod.log_oura_readiness(readiness_score=70, sleep_score=60, hrv=50, recovery_index=75, date=d1)
+    oura_mod.log_oura_readiness(readiness_score=85, sleep_score=78, hrv=66, recovery_index=88, date=d2)
+    rows = oura_mod.oura_readiness_rows(days=7)
+    # oldest first, typed dicts ready for a chart
+    assert [r["date"] for r in rows] == [d1, d2]
+    assert rows[1] == {"date": d2, "readiness": 85, "sleep": 78, "hrv": 66, "recovery": 88}
+    # days clamps to >= 1: a 1-day window keeps only yesterday's row
+    assert oura_mod.oura_readiness_rows(days=0) == [rows[1]]
+    assert oura_mod.oura_readiness_rows(days=1) == [rows[1]]
+
+
 # ── dashboard _load_oura integration ─────────────────────────────────────────
 
 def test_load_oura_prefers_sqlite(tmp_data, oura_mod):

--- a/tools/oura.py
+++ b/tools/oura.py
@@ -168,6 +168,30 @@ def log_oura_readiness(
     )
 
 
+def oura_readiness_rows(days: int = 14) -> list[dict]:
+    """Recent readiness rows for the current user, oldest first (for graphing)."""
+    days = min(max(1, days), 90)
+    cutoff = (datetime.date.today() - datetime.timedelta(days=days)).isoformat()
+    oid = get_current_user_oid()
+    with get_connection() as con:
+        rows = con.execute(
+            "SELECT date, readiness_score, sleep_score, hrv, recovery_index "
+            "FROM oura_readiness WHERE oid = ? AND date >= ? "
+            "ORDER BY date ASC",
+            (oid, cutoff),
+        ).fetchall()
+    return [
+        {
+            "date": r["date"],
+            "readiness": r["readiness_score"],
+            "sleep": r["sleep_score"],
+            "hrv": r["hrv"],
+            "recovery": r["recovery_index"],
+        }
+        for r in rows
+    ]
+
+
 def get_oura_readiness(days: int = 7) -> str:
     """Return recent Oura readiness records for the current user.
 

--- a/transport/http/routes/dashboard/api.py
+++ b/transport/http/routes/dashboard/api.py
@@ -407,6 +407,21 @@ async def settings_summary(
 # user's real Oura account via OAuth (the MCP tool remains for the iOS Shortcut).
 
 
+@router.get("/oura/history", response_model=None)
+async def oura_history(
+    user: Annotated[User, Depends(require_authenticated_user)],  # noqa: ARG001
+    days: int = 14,
+) -> JSONResponse:
+    """Readiness history for graphing (mobile Today, future web sparkline)."""
+    from tools.oura import oura_readiness_rows
+
+    try:
+        rows = await asyncio.to_thread(oura_readiness_rows, days)
+    except Exception:  # noqa: BLE001 — an unprovisioned table just means no data
+        rows = []
+    return JSONResponse({"days": rows})
+
+
 @router.post("/oura/sync", response_model=None)
 async def oura_sync(
     user: Annotated[User, Depends(require_authenticated_user)],  # noqa: ARG001

--- a/transport/http/routes/dashboard/people.py
+++ b/transport/http/routes/dashboard/people.py
@@ -43,6 +43,9 @@ def _people_payload() -> dict:
         "by_relationship": [{"relationship": r, "count": c} for r, c in relationship_counts.most_common()],
         "follow_up_queue": follow_up[:30],
         "recent": people_sorted[:20],
+        # Full roster (recency-sorted, sanity-capped) so clients can filter by
+        # outreach_status/relationship without a round-trip per facet.
+        "people": people_sorted[:500],
     }
 
 


### PR DESCRIPTION
Backing API for the mobile Networking tab (outreach-status filters need the full roster, not the 20-row recent slice) and the Today readiness graph. Replaces #91 (branch renamed to fix/* so CI triggers).

- **GET /api/dashboard/oura/history?days=N** (auth-gated) — readiness rows oldest-first: `{days: [{date, readiness, sleep, hrv, recovery}]}`; `[]` when unprovisioned/no data
- **/dashboard/people/data** additionally returns `people` (recency-sorted, capped 500); existing fields unchanged
- `tools/oura.py: oura_readiness_rows()` shared helper + tests (row shape, ordering, day clamping, full-roster field)

Additive only — no existing consumer changes shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)