### PR TITLE
Promote qa → main: capture partition fix + Networking/Oura API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/version-1.2.0-blue" alt="Version 1.2.0"/>
-  <img src="https://img.shields.io/badge/tests-1361%20passing-brightgreen" alt="1361 tests passing"/>
+  <img src="https://img.shields.io/badge/tests-1364%20passing-brightgreen" alt="1364 tests passing"/>
   <a href="https://sonarcloud.io/component_measures?id=JustLikeFrank3_jobContextMCP&metric=coverage"><img src="https://sonarcloud.io/api/project_badges/measure?project=JustLikeFrank3_jobContextMCP&metric=coverage" alt="Coverage"/></a>
   <img src="https://img.shields.io/badge/tools-11%20domains%20%C2%B7%2085%20actions-informational" alt="11 domain tools, 85 actions"/>
   <img src="https://img.shields.io/badge/license-MIT-lightgrey" alt="MIT License"/>
@@ -35,7 +35,7 @@ Available as a **double-clickable desktop app** (macOS · Windows · Linux), a l
 | | |
 |---|---|
 | 11 domain tools (85 actions) | Resume + cover letter generation |
-| 1361 passing tests | Job fitment analysis with persona lenses |
+| 1364 passing tests | Job fitment analysis with persona lenses |
 | SQLite persistence + JSON fallback | Interview prep + debrief logging |
 | Local RAG semantic search | Outreach + relationship tracking |
 | Azure AKS deployment | Microsoft Entra ID authentication |

--- a/templates/latex_assets/sections/experience.tex
+++ b/templates/latex_assets/sections/experience.tex
@@ -5,7 +5,7 @@
 \subsection{{\textbf{Senior Software Engineer} \textit{\ \ Contoso Cloud, Remote} \hfill 20XX --- Present}}
 \begin{zitemize}
 \item Led design and delivery of a customer-facing service from architecture through production and on-call; quantify the impact here (latency, scale, revenue, or adoption).
-\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1361 passing tests at 80\%+ line coverage through disciplined TDD.
+\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1364 passing tests at 80\%+ line coverage through disciplined TDD.
 \item Drove a cross-team win — a migration, a shared API pattern others adopted, or an SLA target consistently met.
 \end{zitemize}
 %====================

--- a/tests/test_dashboard_coverage.py
+++ b/tests/test_dashboard_coverage.py
@@ -1704,6 +1704,8 @@ class TestDashboardPeopleCoverage:
         assert [person["name"] for person in payload["follow_up_queue"]] == ["Dana", "Eli"]
         assert payload["by_status"][0] == {"status": "sent", "count": 1}
         assert {"relationship": "peer", "count": 1} in payload["by_relationship"]
+        # full roster for client-side facet filtering (mobile Networking tab)
+        assert [person["name"] for person in payload["people"]] == ["Dana", "Eli", "Fran"]
 
 
 class TestDashboardPipelineCoverage:

--- a/tests/test_mobile_api.py
+++ b/tests/test_mobile_api.py
@@ -77,3 +77,57 @@ def test_capture_kicks_background_assessment(mobile_client, monkeypatch):
 
     resp = mobile_client.post("/api/capture", json={"url": "javascript:alert(1)"})
     assert resp.status_code == 422
+
+
+def test_capture_worker_inherits_request_context(monkeypatch):
+    """run_in_executor drops contextvars unless the handler copies them — the
+    worker must see the same data-folder override as the request (multi-tenant
+    partitioning), or it reads/writes the wrong user's database."""
+    import asyncio
+
+    import transport.http.routes.mobile as mobile_mod
+    from lib.user_context import get_data_folder_override, reset_data_folder, set_data_folder
+
+    seen = {}
+
+    def probe(url):
+        seen["override"] = get_data_folder_override()
+
+    monkeypatch.setattr(mobile_mod, "_capture_and_assess", probe)
+
+    async def request_with_partition():
+        # Mirrors UserDataContextMiddleware: the override is active only for
+        # the duration of the handler coroutine.
+        token = set_data_folder("/partitions/user-abc")
+        try:
+            resp = await mobile_mod.capture(
+                mobile_mod.CaptureRequest(url="https://jobs.example.com/9"), user=None
+            )
+        finally:
+            reset_data_folder(token)
+        assert resp["status"] == "capturing"
+        # Wait for the executor thread without blocking the loop.
+        for _ in range(100):
+            if "override" in seen:
+                break
+            await asyncio.sleep(0.02)
+
+    asyncio.run(request_with_partition())
+    assert str(seen["override"]) == "/partitions/user-abc"
+
+
+def test_capture_worker_failure_sends_push(monkeypatch):
+    """An exception mid-assessment must surface as a failure push, not silence."""
+    import transport.http.routes.mobile as mobile_mod
+
+    pushes = []
+    monkeypatch.setattr(
+        mobile_mod, "send_push", lambda title, body, data=None: pushes.append((title, data))
+    )
+    monkeypatch.setattr(
+        mobile_mod,
+        "_capture_and_assess_inner",
+        lambda url: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    mobile_mod._capture_and_assess("https://jobs.example.com/9")
+    assert pushes and pushes[0][1]["type"] == "capture_failed"

--- a/tests/test_oura.py
+++ b/tests/test_oura.py
@@ -152,6 +152,21 @@ def test_get_oura_readiness_lists_rows(tmp_data, oura_mod):
     assert "High" in out  # >= 85
 
 
+def test_oura_readiness_rows_for_graphing(tmp_data, oura_mod):
+    import datetime
+    d1 = (datetime.date.today() - datetime.timedelta(days=2)).isoformat()
+    d2 = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
+    oura_mod.log_oura_readiness(readiness_score=70, sleep_score=60, hrv=50, recovery_index=75, date=d1)
+    oura_mod.log_oura_readiness(readiness_score=85, sleep_score=78, hrv=66, recovery_index=88, date=d2)
+    rows = oura_mod.oura_readiness_rows(days=7)
+    # oldest first, typed dicts ready for a chart
+    assert [r["date"] for r in rows] == [d1, d2]
+    assert rows[1] == {"date": d2, "readiness": 85, "sleep": 78, "hrv": 66, "recovery": 88}
+    # days clamps to >= 1: a 1-day window keeps only yesterday's row
+    assert oura_mod.oura_readiness_rows(days=0) == [rows[1]]
+    assert oura_mod.oura_readiness_rows(days=1) == [rows[1]]
+
+
 # ── dashboard _load_oura integration ─────────────────────────────────────────
 
 def test_load_oura_prefers_sqlite(tmp_data, oura_mod):

--- a/tools/oura.py
+++ b/tools/oura.py
@@ -168,6 +168,30 @@ def log_oura_readiness(
     )
 
 
+def oura_readiness_rows(days: int = 14) -> list[dict]:
+    """Recent readiness rows for the current user, oldest first (for graphing)."""
+    days = min(max(1, days), 90)
+    cutoff = (datetime.date.today() - datetime.timedelta(days=days)).isoformat()
+    oid = get_current_user_oid()
+    with get_connection() as con:
+        rows = con.execute(
+            "SELECT date, readiness_score, sleep_score, hrv, recovery_index "
+            "FROM oura_readiness WHERE oid = ? AND date >= ? "
+            "ORDER BY date ASC",
+            (oid, cutoff),
+        ).fetchall()
+    return [
+        {
+            "date": r["date"],
+            "readiness": r["readiness_score"],
+            "sleep": r["sleep_score"],
+            "hrv": r["hrv"],
+            "recovery": r["recovery_index"],
+        }
+        for r in rows
+    ]
+
+
 def get_oura_readiness(days: int = 7) -> str:
     """Return recent Oura readiness records for the current user.
 

--- a/transport/http/routes/dashboard/api.py
+++ b/transport/http/routes/dashboard/api.py
@@ -407,6 +407,21 @@ async def settings_summary(
 # user's real Oura account via OAuth (the MCP tool remains for the iOS Shortcut).
 
 
+@router.get("/oura/history", response_model=None)
+async def oura_history(
+    user: Annotated[User, Depends(require_authenticated_user)],  # noqa: ARG001
+    days: int = 14,
+) -> JSONResponse:
+    """Readiness history for graphing (mobile Today, future web sparkline)."""
+    from tools.oura import oura_readiness_rows
+
+    try:
+        rows = await asyncio.to_thread(oura_readiness_rows, days)
+    except Exception:  # noqa: BLE001 — an unprovisioned table just means no data
+        rows = []
+    return JSONResponse({"days": rows})
+
+
 @router.post("/oura/sync", response_model=None)
 async def oura_sync(
     user: Annotated[User, Depends(require_authenticated_user)],  # noqa: ARG001

--- a/transport/http/routes/dashboard/people.py
+++ b/transport/http/routes/dashboard/people.py
@@ -43,6 +43,9 @@ def _people_payload() -> dict:
         "by_relationship": [{"relationship": r, "count": c} for r, c in relationship_counts.most_common()],
         "follow_up_queue": follow_up[:30],
         "recent": people_sorted[:20],
+        # Full roster (recency-sorted, sanity-capped) so clients can filter by
+        # outreach_status/relationship without a round-trip per facet.
+        "people": people_sorted[:500],
     }
 
 

--- a/transport/http/routes/mobile.py
+++ b/transport/http/routes/mobile.py
@@ -19,6 +19,7 @@ product the middleware resolves the caller's partition.
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import json
 import logging
 from typing import Annotated
@@ -177,7 +178,24 @@ class CaptureRequest(BaseModel):
 
 
 def _capture_and_assess(url: str) -> None:
-    """Blocking worker: import → queue → assess → push. Runs off-loop."""
+    """Blocking worker: import → queue → assess → push. Runs off-loop.
+
+    Must execute inside a copy of the request's context (see capture()) so the
+    per-user data-folder ContextVar still scopes every read/write and the push
+    lookup to the caller's partition.
+    """
+    try:
+        _capture_and_assess_inner(url)
+    except Exception:  # noqa: BLE001 — the user is waiting on a push either way
+        _log.exception("capture worker failed for %s", url)
+        send_push(
+            "Assessment failed",
+            "Something went wrong while evaluating that job. Try sharing it again.",
+            {"type": "capture_failed"},
+        )
+
+
+def _capture_and_assess_inner(url: str) -> None:
     from tools.job_scraper import scrape_job_url
 
     result = scrape_job_url(url, auto_queue=True)
@@ -223,6 +241,10 @@ async def capture(
     url = request.url.strip()
     if not url.startswith(("http://", "https://")):
         raise HTTPException(status_code=422, detail="Share a job posting URL.")
+    # run_in_executor does NOT propagate contextvars (asyncio.to_thread does,
+    # but it would tie the worker's lifetime to this handler). Copy the request
+    # context explicitly so the worker stays inside the caller's partition.
+    ctx = contextvars.copy_context()
     loop = asyncio.get_running_loop()
-    loop.run_in_executor(None, _capture_and_assess, url)
+    loop.run_in_executor(None, ctx.run, _capture_and_assess, url)
     return {"status": "capturing", "detail": "Saved. Assessment running…"}


### PR DESCRIPTION
Promotes to production:
- #90 — share-capture worker now runs inside the caller's partition (contextvars copied into the executor); failures push "Assessment failed" instead of vanishing. Fixes the field-reported silent share hang-then-nothing.
- #92 — GET /api/dashboard/oura/history + full `people` roster in /dashboard/people/data (backs mobile Networking filters and the Today readiness graph). Additive only.

qa deploy green (badge-bot push race only). After main deploys, TestFlight build 9 ships the Networking tab + readiness graph UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)