### PR TITLE
Control plane P0: durable work items + dispatcher

### DIFF
--- a/.github/workflows/desktop-backend.yml
+++ b/.github/workflows/desktop-backend.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - feat/desktop-*
+      - feat/*
       - fix/*
     paths:
       - desktop_main.py

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -1,0 +1,62 @@
+# Control Plane
+
+Every background unit of work is a durable row with a lifecycle, executed by
+one dispatcher — never a fire-and-forget thread inside a request handler.
+
+## Why (the incident that motivated it)
+
+2026-07-09: mobile share-capture handed scrape→assess→push to
+`loop.run_in_executor`, which does not propagate contextvars. On multi-tenant
+cloud the worker escaped the caller's partition, crashed on a missing table,
+and the exception vanished into the executor. The user saw "Saved." and then
+silence — for days. A control plane makes that failure mode structurally
+impossible *and* visible when anything else goes wrong.
+
+## Shape (P0, shipped)
+
+Three pieces, no new infrastructure:
+
+1. **`work_items` table** (`lib/work.py`) — per-user partition DB, like all
+   tenant data: `kind, inputs_json, status (queued→running→succeeded/failed),
+   attempt/max_attempts, origin, error (traceback), artifacts_json, timings`.
+2. **Dispatcher** — an asyncio loop started in the FastAPI lifespan, bounded
+   concurrency, executors run via `to_thread`. The worker sets partition
+   context **from the work row's home partition**, never from ambient
+   request context. On startup it sweeps partitions for rows orphaned by a
+   restart: re-dispatches those with attempts left, fails the rest with
+   `abandoned`.
+3. **Status API** — `GET /api/work` and `GET /api/work/{id}`, partition-scoped
+   like everything else.
+
+Executors are blocking callables registered per kind:
+
+```python
+from lib import work
+work.register_kind("capture_url", fn)          # fn(inputs: dict) -> artifacts dict
+work_id = work.enqueue("capture_url", {"url": u}, origin="mobile-share")
+```
+
+An executor that raises fails the row with the traceback attached; success
+stores its returned dict as artifacts. Pushes/notifications are signals the
+executor sends; **the row is the system of record**.
+
+Kinds registered today: `capture_url` (mobile share → import → assess → push).
+
+## Roadmap
+
+- **P1 — document generation**: route assessment / interview-prep /
+  cover-letter generation (MCP tools, dashboard, chat) through `enqueue`;
+  stamp artifacts with work id + prompt/template version + model (provenance).
+- **P2 — policy**: per-kind model routing, token budgets, fallbacks, retries
+  as data; per-tenant quotas; token/cost accounting on the row.
+- **P3 — scheduler**: cron-style enqueuers (Oura autosync, weekly digest,
+  follow-up nudges) so recurring work gets the same durability and audit.
+- **Deferred**: journaling work rows through sync (cross-device status),
+  Career Inbox events for work transitions, cancellation endpoint.
+
+## Non-goals
+
+No external queue/broker, no workflow engine, no separate service. The same
+table + loop runs inside the frozen desktop sidecar (single partition) and on
+AKS (many partitions). Multi-step pipelines stay one executor per kind until
+proven otherwise.

--- a/lib/work.py
+++ b/lib/work.py
@@ -1,0 +1,273 @@
+"""Control plane P0: durable work items + in-process dispatcher.
+
+Every background unit of work (share capture, and — in P1 — all document
+generation) becomes a row in the per-user ``work_items`` table with a
+lifecycle, instead of a fire-and-forget thread. The dispatcher is the only
+thing that executes work, and it sets the partition context FROM THE ROW's
+own home partition — workers can never run against the wrong tenant the way
+ambient-context offloads could (see the 2026-07-09 capture incident).
+
+Design constraints (docs/control-plane.md has the longer story):
+  - No external queue/service. A table + an asyncio loop, so the identical
+    code runs in the frozen desktop sidecar and on multi-tenant AKS.
+  - Rows live in each user's own DB, like all tenant data. Cross-restart
+    recovery sweeps partitions for orphaned queued/running rows.
+  - Executors are plain blocking callables registered by kind; they run via
+    asyncio.to_thread with bounded concurrency.
+
+Public surface:
+  register_kind(kind, fn)          — map a work kind to its executor
+  enqueue(kind, inputs, ...)       — insert a queued row + wake the dispatcher
+  get_item(item_id) / list_items() — status reads (current partition)
+  start_dispatcher(app)/stop_...   — lifespan integration
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import traceback
+from pathlib import Path
+from typing import Any, Callable
+
+from lib.db import get_connection
+from lib.user_context import (
+    get_data_folder_override,
+    reset_data_folder,
+    set_data_folder,
+)
+
+_log = logging.getLogger(__name__)
+
+# kind -> blocking callable(inputs: dict) -> dict (artifacts; JSON-serializable)
+_KINDS: dict[str, Callable[[dict], dict]] = {}
+
+MAX_CONCURRENCY = 2
+
+_SCHEMA = """CREATE TABLE IF NOT EXISTS work_items (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    kind           TEXT    NOT NULL,
+    inputs_json    TEXT    NOT NULL DEFAULT '{}',
+    status         TEXT    NOT NULL DEFAULT 'queued'
+                   CHECK (status IN ('queued','running','succeeded','failed','cancelled')),
+    attempt        INTEGER NOT NULL DEFAULT 0,
+    max_attempts   INTEGER NOT NULL DEFAULT 1,
+    origin         TEXT    NOT NULL DEFAULT '',
+    error          TEXT,
+    artifacts_json TEXT,
+    created_at     TEXT    NOT NULL DEFAULT (datetime('now')),
+    started_at     TEXT,
+    finished_at    TEXT
+)"""
+
+
+def register_kind(kind: str, fn: Callable[[dict], dict]) -> None:
+    _KINDS[kind] = fn
+
+
+def _ensure_schema() -> None:
+    """Create work_items in the current partition's DB (idempotent)."""
+    with get_connection() as con:
+        con.execute(_SCHEMA)
+        con.commit()
+
+
+# ── enqueue / read (run inside a request's partition context) ─────────────────
+
+def enqueue(kind: str, inputs: dict, origin: str = "", max_attempts: int = 1) -> int:
+    """Insert a queued row in the CURRENT partition and wake the dispatcher."""
+    if kind not in _KINDS:
+        raise ValueError(f"unknown work kind: {kind}")
+    _ensure_schema()
+    with get_connection() as con:
+        cur = con.execute(
+            "INSERT INTO work_items (kind, inputs_json, origin, max_attempts) "
+            "VALUES (?, ?, ?, ?)",
+            (kind, json.dumps(inputs), origin, max(1, max_attempts)),
+        )
+        con.commit()
+        item_id = int(cur.lastrowid)
+    _notify(get_data_folder_override(), item_id)
+    return item_id
+
+
+def _row_to_dict(row) -> dict:
+    d = dict(row)
+    d["inputs"] = json.loads(d.pop("inputs_json") or "{}")
+    d["artifacts"] = json.loads(d.pop("artifacts_json") or "null")
+    return d
+
+
+def get_item(item_id: int) -> "dict | None":
+    _ensure_schema()
+    with get_connection() as con:
+        row = con.execute("SELECT * FROM work_items WHERE id = ?", (item_id,)).fetchone()
+    return _row_to_dict(row) if row else None
+
+
+def list_items(status: str = "", limit: int = 50) -> list[dict]:
+    _ensure_schema()
+    limit = max(1, min(limit, 200))
+    with get_connection() as con:
+        if status:
+            rows = con.execute(
+                "SELECT * FROM work_items WHERE status = ? ORDER BY id DESC LIMIT ?",
+                (status, limit),
+            ).fetchall()
+        else:
+            rows = con.execute(
+                "SELECT * FROM work_items ORDER BY id DESC LIMIT ?", (limit,)
+            ).fetchall()
+    return [_row_to_dict(r) for r in rows]
+
+
+# ── dispatcher ─────────────────────────────────────────────────────────────────
+
+# Queue items are (partition_path_or_None, item_id). None = default partition
+# (desktop single-tenant / dev).
+_queue: "asyncio.Queue[tuple[str | None, int]] | None" = None
+_workers: list[asyncio.Task] = []
+
+
+def _notify(partition: "Path | str | None", item_id: int) -> None:
+    """Hand a claimed-able item to the dispatcher; no-op when not running
+    (tests / CLI): the startup sweep will find it later."""
+    if _queue is not None:
+        _queue.put_nowait((str(partition) if partition else None, item_id))
+
+
+def _in_partition(partition: "str | None", fn: Callable[[], Any]) -> Any:
+    """Run fn with the partition context taken from the WORK ROW's home, not
+    from whatever context the dispatcher happens to hold."""
+    if partition is None:
+        return fn()
+    token = set_data_folder(partition)
+    try:
+        return fn()
+    finally:
+        reset_data_folder(token)
+
+
+def _execute(partition: "str | None", item_id: int) -> None:
+    """Blocking: claim, run the kind's executor, persist the outcome."""
+    def _claim() -> "tuple[str, dict] | None":
+        _ensure_schema()
+        with get_connection() as con:
+            row = con.execute(
+                "SELECT * FROM work_items WHERE id = ? AND status IN ('queued','running')",
+                (item_id,),
+            ).fetchone()
+            if row is None:
+                return None
+            con.execute(
+                "UPDATE work_items SET status='running', attempt=attempt+1, "
+                "started_at=datetime('now') WHERE id = ?",
+                (item_id,),
+            )
+            con.commit()
+            return row["kind"], json.loads(row["inputs_json"] or "{}")
+
+    claimed = _in_partition(partition, _claim)
+    if claimed is None:
+        return
+    kind, inputs = claimed
+    fn = _KINDS.get(kind)
+
+    def _finish(status: str, error: str = "", artifacts: "dict | None" = None) -> None:
+        def _write() -> None:
+            with get_connection() as con:
+                con.execute(
+                    "UPDATE work_items SET status=?, error=?, artifacts_json=?, "
+                    "finished_at=datetime('now') WHERE id = ?",
+                    (status, error or None,
+                     json.dumps(artifacts) if artifacts is not None else None, item_id),
+                )
+                con.commit()
+        _in_partition(partition, _write)
+
+    if fn is None:
+        _finish("failed", error=f"no executor registered for kind '{kind}'")
+        return
+    try:
+        artifacts = _in_partition(partition, lambda: fn(inputs))
+        _finish("succeeded", artifacts=artifacts if isinstance(artifacts, dict) else None)
+    except Exception as exc:  # noqa: BLE001 — outcome is the record, never a crash
+        _log.exception("work item %s (%s) failed", item_id, kind)
+        _finish("failed", error=f"{exc}\n{traceback.format_exc(limit=8)}")
+
+
+async def _worker_loop() -> None:
+    assert _queue is not None
+    while True:
+        partition, item_id = await _queue.get()
+        try:
+            await asyncio.to_thread(_execute, partition, item_id)
+        except Exception:  # noqa: BLE001
+            _log.exception("dispatcher worker error on item %s", item_id)
+        finally:
+            _queue.task_done()
+
+
+def _sweep_partitions() -> list[tuple["str | None", int]]:
+    """Find queued/running rows abandoned by a previous process. Running rows
+    are re-run: executors must stay idempotent-ish or bounded by max_attempts."""
+    import lib.config as cfg
+
+    found: list[tuple[str | None, int]] = []
+
+    def _scan(partition: "str | None") -> None:
+        def _q() -> list[int]:
+            with get_connection() as con:
+                try:
+                    rows = con.execute(
+                        "SELECT id, attempt, max_attempts FROM work_items "
+                        "WHERE status IN ('queued','running') ORDER BY id"
+                    ).fetchall()
+                except Exception:  # noqa: BLE001 — table may not exist yet
+                    return []
+                ids: list[int] = []
+                for r in rows:
+                    if r["attempt"] >= r["max_attempts"]:
+                        con.execute(
+                            "UPDATE work_items SET status='failed', "
+                            "error='abandoned: attempts exhausted (process restart)', "
+                            "finished_at=datetime('now') WHERE id = ?",
+                            (r["id"],),
+                        )
+                    else:
+                        ids.append(int(r["id"]))
+                con.commit()
+                return ids
+        for item_id in _in_partition(partition, _q):
+            found.append((partition, item_id))
+
+    _scan(None)  # default partition (desktop / dev / admin)
+    users_root = Path(str(cfg.DATA_FOLDER)) / "users"
+    if users_root.is_dir():
+        for child in sorted(users_root.iterdir()):
+            if (child / "db").is_dir():
+                _scan(str(child))
+    return found
+
+
+async def start_dispatcher() -> None:
+    global _queue
+    if _queue is not None:
+        return
+    _queue = asyncio.Queue()
+    for _ in range(MAX_CONCURRENCY):
+        _workers.append(asyncio.create_task(_worker_loop()))
+    try:
+        for partition, item_id in await asyncio.to_thread(_sweep_partitions):
+            _queue.put_nowait((partition, item_id))
+    except Exception:  # noqa: BLE001 — recovery is best-effort at startup
+        _log.exception("work sweep failed")
+    _log.info("work dispatcher started (concurrency=%d)", MAX_CONCURRENCY)
+
+
+async def stop_dispatcher() -> None:
+    global _queue
+    for t in _workers:
+        t.cancel()
+    _workers.clear()
+    _queue = None

--- a/tests/test_mobile_api.py
+++ b/tests/test_mobile_api.py
@@ -61,15 +61,20 @@ def test_push_register_validates_token(mobile_client):
 
 
 def test_capture_kicks_background_assessment(mobile_client, monkeypatch):
-    import transport.http.routes.mobile as mobile_mod
+    """Capture enqueues a durable work item; the lifespan dispatcher runs it.
+    Partition correctness + failure durability live in tests/test_work.py."""
+    from lib import work
 
     ran = {}
-    monkeypatch.setattr(mobile_mod, "_capture_and_assess", lambda url: ran.setdefault("url", url))
+    monkeypatch.setitem(
+        work._KINDS, "capture_url", lambda inputs: ran.setdefault("url", inputs["url"]) or {}
+    )
     resp = mobile_client.post("/api/capture", json={"url": "https://jobs.example.com/123"})
     assert resp.status_code == 200
     assert resp.json()["status"] == "capturing"
+    assert isinstance(resp.json()["work_id"], int)
     import time
-    for _ in range(50):
+    for _ in range(100):
         if "url" in ran:
             break
         time.sleep(0.05)
@@ -79,45 +84,11 @@ def test_capture_kicks_background_assessment(mobile_client, monkeypatch):
     assert resp.status_code == 422
 
 
-def test_capture_worker_inherits_request_context(monkeypatch):
-    """run_in_executor drops contextvars unless the handler copies them — the
-    worker must see the same data-folder override as the request (multi-tenant
-    partitioning), or it reads/writes the wrong user's database."""
-    import asyncio
-
-    import transport.http.routes.mobile as mobile_mod
-    from lib.user_context import get_data_folder_override, reset_data_folder, set_data_folder
-
-    seen = {}
-
-    def probe(url):
-        seen["override"] = get_data_folder_override()
-
-    monkeypatch.setattr(mobile_mod, "_capture_and_assess", probe)
-
-    async def request_with_partition():
-        # Mirrors UserDataContextMiddleware: the override is active only for
-        # the duration of the handler coroutine.
-        token = set_data_folder("/partitions/user-abc")
-        try:
-            resp = await mobile_mod.capture(
-                mobile_mod.CaptureRequest(url="https://jobs.example.com/9"), user=None
-            )
-        finally:
-            reset_data_folder(token)
-        assert resp["status"] == "capturing"
-        # Wait for the executor thread without blocking the loop.
-        for _ in range(100):
-            if "override" in seen:
-                break
-            await asyncio.sleep(0.02)
-
-    asyncio.run(request_with_partition())
-    assert str(seen["override"]) == "/partitions/user-abc"
-
-
 def test_capture_worker_failure_sends_push(monkeypatch):
-    """An exception mid-assessment must surface as a failure push, not silence."""
+    """An exception mid-assessment must push a failure AND re-raise so the
+    work row records it — the push is a signal, the row is the record."""
+    import pytest as _pytest
+
     import transport.http.routes.mobile as mobile_mod
 
     pushes = []
@@ -129,5 +100,6 @@ def test_capture_worker_failure_sends_push(monkeypatch):
         "_capture_and_assess_inner",
         lambda url: (_ for _ in ()).throw(RuntimeError("boom")),
     )
-    mobile_mod._capture_and_assess("https://jobs.example.com/9")
+    with _pytest.raises(RuntimeError):
+        mobile_mod._capture_and_assess({"url": "https://jobs.example.com/9"})
     assert pushes and pushes[0][1]["type"] == "capture_failed"

--- a/tests/test_work.py
+++ b/tests/test_work.py
@@ -1,0 +1,181 @@
+"""Control plane P0 (lib/work.py): durable work items + dispatcher.
+
+The invariants that matter:
+  - executors run inside the work row's OWN partition (never ambient context)
+  - outcomes are durable rows: success stores artifacts, failure stores the
+    traceback — nothing vanishes into an executor
+  - restart recovery: orphaned queued rows are re-dispatched, exhausted ones
+    are marked failed
+  - the HTTP surface exposes rows to the owning caller
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+import lib.config as cfg
+from lib import work
+from lib.user_context import get_data_folder_override, reset_data_folder, set_data_folder
+
+
+@pytest.fixture()
+def work_env(tmp_path, monkeypatch):
+    monkeypatch.setattr(cfg, "DATA_FOLDER", str(tmp_path), raising=False)
+    saved = dict(work._KINDS)
+    yield tmp_path
+    work._KINDS.clear()
+    work._KINDS.update(saved)
+
+
+def test_enqueue_requires_registered_kind(work_env):
+    with pytest.raises(ValueError):
+        work.enqueue("no_such_kind", {})
+
+
+def test_execute_runs_in_the_rows_partition(work_env):
+    """The whole point: the executor sees the row's home partition, not the
+    dispatcher's ambient context."""
+    seen = {}
+    work.register_kind("probe", lambda inputs: seen.update(
+        override=str(get_data_folder_override()), **inputs) or {"ok": True})
+
+    partition = work_env / "users" / "user-abc"
+    (partition / "db").mkdir(parents=True)
+    token = set_data_folder(partition)
+    try:
+        item_id = work.enqueue("probe", {"x": 1})
+    finally:
+        reset_data_folder(token)
+
+    work._execute(str(partition), item_id)
+
+    assert seen["override"] == str(partition)
+    assert seen["x"] == 1
+    token = set_data_folder(partition)
+    try:
+        item = work.get_item(item_id)
+    finally:
+        reset_data_folder(token)
+    assert item["status"] == "succeeded"
+    assert item["artifacts"] == {"ok": True}
+    assert item["attempt"] == 1 and item["started_at"] and item["finished_at"]
+
+
+def test_failure_is_recorded_not_swallowed(work_env):
+    def boom(inputs):
+        raise RuntimeError("scraper exploded")
+
+    work.register_kind("boom", boom)
+    item_id = work.enqueue("boom", {"url": "https://x"})
+    work._execute(None, item_id)
+    item = work.get_item(item_id)
+    assert item["status"] == "failed"
+    assert "scraper exploded" in item["error"]
+    assert "Traceback" in item["error"]
+
+
+def test_unregistered_kind_at_execution_fails_row(work_env):
+    work.register_kind("temp", lambda i: {})
+    item_id = work.enqueue("temp", {})
+    del work._KINDS["temp"]
+    work._execute(None, item_id)
+    assert "no executor registered" in work.get_item(item_id)["error"]
+
+
+def test_sweep_recovers_orphans_and_fails_exhausted(work_env):
+    work.register_kind("probe", lambda i: {})
+    fresh = work.enqueue("probe", {})          # queued, attempt 0 → re-dispatch
+    stuck = work.enqueue("probe", {})          # simulate died mid-run, attempts spent
+    from lib.db import get_connection
+    with get_connection() as con:
+        con.execute(
+            "UPDATE work_items SET status='running', attempt=1 WHERE id=?", (stuck,))
+        con.commit()
+
+    found = work._sweep_partitions()
+
+    assert (None, fresh) in found
+    assert all(item_id != stuck for _, item_id in found)
+    item = work.get_item(stuck)
+    assert item["status"] == "failed" and "abandoned" in item["error"]
+
+
+def test_sweep_scans_user_partitions(work_env):
+    work.register_kind("probe", lambda i: {})
+    partition = work_env / "users" / "user-xyz"
+    (partition / "db").mkdir(parents=True)
+    token = set_data_folder(partition)
+    try:
+        item_id = work.enqueue("probe", {})
+    finally:
+        reset_data_folder(token)
+    assert (str(partition), item_id) in work._sweep_partitions()
+
+
+# ── end to end through the live app (dispatcher running in lifespan) ─────────
+
+@pytest.fixture()
+def app_client(monkeypatch, tmp_path):
+    import lib.config as cfg_mod
+    from lib.user_provisioning import provision_user_data
+
+    root = tmp_path / "data"
+    root.mkdir()
+    monkeypatch.setattr(cfg_mod, "DATA_FOLDER", str(root), raising=False)
+    provision_user_data(root)
+    monkeypatch.delenv("API_KEY", raising=False)
+    from fastapi.testclient import TestClient
+    from transport.http.app import create_app
+    from transport.http.config import reset_settings_cache
+
+    reset_settings_cache()
+    saved = dict(work._KINDS)
+    with TestClient(create_app()) as client:
+        yield client
+    reset_settings_cache()
+    work._KINDS.clear()
+    work._KINDS.update(saved)
+
+
+def _wait_status(client, work_id: int, timeout: float = 5.0) -> dict:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        item = client.get(f"/api/work/{work_id}").json()
+        if item.get("status") in ("succeeded", "failed"):
+            return item
+        time.sleep(0.05)
+    raise AssertionError(f"work {work_id} never finished: {item}")
+
+
+def test_capture_flows_through_control_plane(app_client, monkeypatch):
+    monkeypatch.setitem(
+        work._KINDS, "capture_url",
+        lambda inputs: {"imported": True, "company": "Acme", "url": inputs["url"]},
+    )
+    resp = app_client.post("/api/capture", json={"url": "https://jobs.example.com/1"})
+    assert resp.status_code == 200
+    work_id = resp.json()["work_id"]
+
+    item = _wait_status(app_client, work_id)
+    assert item["status"] == "succeeded"
+    assert item["artifacts"]["company"] == "Acme"
+    assert item["kind"] == "capture_url" and item["origin"] == "mobile-share"
+
+    listing = app_client.get("/api/work?status=succeeded").json()["items"]
+    assert any(i["id"] == work_id for i in listing)
+
+
+def test_capture_failure_visible_via_api(app_client, monkeypatch):
+    def die(inputs):
+        raise RuntimeError("blocked by LinkedIn")
+
+    monkeypatch.setitem(work._KINDS, "capture_url", die)
+    resp = app_client.post("/api/capture", json={"url": "https://jobs.example.com/2"})
+    item = _wait_status(app_client, resp.json()["work_id"])
+    assert item["status"] == "failed"
+    assert "blocked by LinkedIn" in item["error"]
+
+
+def test_work_get_404(app_client):
+    assert app_client.get("/api/work/99999").status_code == 404

--- a/transport/http/app.py
+++ b/transport/http/app.py
@@ -215,14 +215,21 @@ def create_app(mcp: "FastMCP | None" = None) -> FastAPI:
     # ── Lifespan: drive MCP session manager alongside FastAPI startup ─────────
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
-        if mcp_starlette is not None:
-            # The Starlette sub-app carries its own lifespan that initialises
-            # the StreamableHTTPSessionManager task group.  We must enter it
-            # here; FastAPI does NOT propagate lifespan into mounted sub-apps.
-            async with mcp_starlette.router.lifespan_context(mcp_starlette):
+        from lib import work as _work
+
+        # Control plane: durable background work (capture, doc generation).
+        await _work.start_dispatcher()
+        try:
+            if mcp_starlette is not None:
+                # The Starlette sub-app carries its own lifespan that initialises
+                # the StreamableHTTPSessionManager task group.  We must enter it
+                # here; FastAPI does NOT propagate lifespan into mounted sub-apps.
+                async with mcp_starlette.router.lifespan_context(mcp_starlette):
+                    yield
+            else:
                 yield
-        else:
-            yield
+        finally:
+            await _work.stop_dispatcher()
 
     app = FastAPI(
         title="jobContextMCP HTTP API",
@@ -263,9 +270,11 @@ def create_app(mcp: "FastMCP | None" = None) -> FastAPI:
         app.include_router(chat_routes.router)  # embedded chat — desktop-only in v1
     from transport.http.routes import mobile as mobile_routes
     from transport.http.routes import sync as sync_routes
+    from transport.http.routes import work as work_routes
 
     app.include_router(sync_routes.router)  # desktop⇄cloud sync (auth-gated)
     app.include_router(mobile_routes.router)  # Career Inbox / push / capture
+    app.include_router(work_routes.router)  # control-plane work-item status
     app.include_router(jobs_routes.router)
     app.include_router(resumes_routes.router)
     app.include_router(context_routes.router)

--- a/transport/http/routes/mobile.py
+++ b/transport/http/routes/mobile.py
@@ -18,8 +18,6 @@ product the middleware resolves the caller's partition.
 """
 from __future__ import annotations
 
-import asyncio
-import contextvars
 import json
 import logging
 from typing import Annotated
@@ -27,6 +25,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
+from lib import work
 from transport.http.auth import require_authenticated_user
 from transport.http.security import User
 
@@ -177,15 +176,17 @@ class CaptureRequest(BaseModel):
     text: str = ""   # future: pasted JD text instead of a URL
 
 
-def _capture_and_assess(url: str) -> None:
-    """Blocking worker: import → queue → assess → push. Runs off-loop.
+def _capture_and_assess(inputs: dict) -> dict:
+    """Work executor (kind=capture_url): import → queue → assess → push.
 
-    Must execute inside a copy of the request's context (see capture()) so the
-    per-user data-folder ContextVar still scopes every read/write and the push
-    lookup to the caller's partition.
+    Runs under the dispatcher, which sets the partition context from the work
+    row's home partition — the outcome (success, failure, artifacts, error)
+    is durably recorded on the row either way. Pushes are the human-facing
+    signal; the row is the system of record.
     """
+    url = inputs["url"]
     try:
-        _capture_and_assess_inner(url)
+        return _capture_and_assess_inner(url)
     except Exception:  # noqa: BLE001 — the user is waiting on a push either way
         _log.exception("capture worker failed for %s", url)
         send_push(
@@ -193,9 +194,10 @@ def _capture_and_assess(url: str) -> None:
             "Something went wrong while evaluating that job. Try sharing it again.",
             {"type": "capture_failed"},
         )
+        raise  # the work row records the failure + traceback
 
 
-def _capture_and_assess_inner(url: str) -> None:
+def _capture_and_assess_inner(url: str) -> dict:
     from tools.job_scraper import scrape_job_url
 
     result = scrape_job_url(url, auto_queue=True)
@@ -207,7 +209,7 @@ def _capture_and_assess_inner(url: str) -> None:
             role = line.split(":", 1)[1].strip()
     if not company:
         send_push("Import failed", "Couldn't read that job posting.", {"type": "capture_failed"})
-        return
+        return {"imported": False}
 
     from lib.db import get_connection
 
@@ -230,6 +232,10 @@ def _capture_and_assess_inner(url: str) -> None:
         f"{company} — {role}",
         {"type": "assessment_done", "company": company, "role": role},
     )
+    return {"imported": True, "company": company, "role": role, "score": score}
+
+
+work.register_kind("capture_url", _capture_and_assess)
 
 
 @router.post("/capture")
@@ -237,14 +243,10 @@ async def capture(
     request: CaptureRequest,
     user: Annotated[User, Depends(require_authenticated_user)],  # noqa: ARG001
 ) -> dict:
-    """Share-sheet entry: return fast, assess in the background, push after."""
+    """Share-sheet entry: enqueue a durable work item, return its id fast.
+    The dispatcher assesses in the background and pushes when it lands."""
     url = request.url.strip()
     if not url.startswith(("http://", "https://")):
         raise HTTPException(status_code=422, detail="Share a job posting URL.")
-    # run_in_executor does NOT propagate contextvars (asyncio.to_thread does,
-    # but it would tie the worker's lifetime to this handler). Copy the request
-    # context explicitly so the worker stays inside the caller's partition.
-    ctx = contextvars.copy_context()
-    loop = asyncio.get_running_loop()
-    loop.run_in_executor(None, ctx.run, _capture_and_assess, url)
-    return {"status": "capturing", "detail": "Saved. Assessment running…"}
+    work_id = work.enqueue("capture_url", {"url": url}, origin="mobile-share")
+    return {"status": "capturing", "work_id": work_id, "detail": "Saved. Assessment running…"}

--- a/transport/http/routes/work.py
+++ b/transport/http/routes/work.py
@@ -1,0 +1,39 @@
+"""Work-item status API — the read side of the control plane (lib/work.py).
+
+  GET /api/work           — recent work items for the caller's partition
+  GET /api/work/{id}      — one item: status, error, artifacts, timings
+
+Auth matches the rest of the tenant API; the partition middleware scopes
+every read to the caller's own rows.
+"""
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from lib import work
+from transport.http.auth import require_authenticated_user
+from transport.http.security import User
+
+router = APIRouter(prefix="/api/work", tags=["work"])
+
+
+@router.get("")
+async def work_list(
+    user: Annotated[User, Depends(require_authenticated_user)],  # noqa: ARG001
+    status: str = "",
+    limit: int = 50,
+) -> dict:
+    return {"items": work.list_items(status=status, limit=limit)}
+
+
+@router.get("/{item_id}")
+async def work_get(
+    item_id: int,
+    user: Annotated[User, Depends(require_authenticated_user)],  # noqa: ARG001
+) -> dict:
+    item = work.get_item(item_id)
+    if item is None:
+        raise HTTPException(status_code=404, detail="No such work item.")
+    return item


### PR DESCRIPTION
## What
The execution route we discussed: a **thin in-repo control plane** — a table + a dispatcher + a status API. No external queue, no new service; identical code runs in the frozen desktop sidecar and on multi-tenant AKS.

- **`lib/work.py`** — `work_items` table in each user's partition DB (`kind, inputs, status queued→running→succeeded/failed, attempt/max_attempts, origin, error, artifacts, timings`); executor registry by kind; `enqueue()`; dispatcher started in the FastAPI lifespan (bounded concurrency, `to_thread`). **Workers take partition context from the work row's home partition, never ambient context** — the capture-incident bug class is structurally impossible now. Startup sweep re-dispatches rows orphaned by restarts and fails exhausted ones as `abandoned`.
- **First tenant: share capture.** `/api/capture` enqueues `capture_url` and returns `work_id`. Success stores `{company, role, score}` artifacts; failure stores the traceback on the row *and* still sends the failure push. The push is the signal; the row is the record.
- **Status API**: `GET /api/work?status=&limit=`, `GET /api/work/{id}` (auth + partition scoped).
- **docs/control-plane.md** — design, incident context, P1–P3 roadmap (doc generation → policy/costs → scheduler), non-goals.
- **CI**: desktop-backend branch filter `feat/desktop-*` → `feat/*` (two branches silently missed CI today).

## Tests
`tests/test_work.py` (9): partition invariant, failure durability with traceback, unregistered-kind, restart sweep (recover + abandon), per-user partition scan, end-to-end through the live app (enqueue → dispatcher → status API) for success and failure, 404. Mobile capture tests updated to the enqueue contract. Full suite: **1389 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)