### PR TITLE
Fix LinkedIn capture: jobs-guest fallback + client-supplied page text

### DIFF
--- a/tests/test_job_scraper.py
+++ b/tests/test_job_scraper.py
@@ -105,11 +105,65 @@ class TestScrapeJobUrl:
         result = srv.scrape_job_url("https://boards.greenhouse.io/stripe/jobs/12345")
         assert "403" in result or "login" in result.lower()
 
-    def test_linkedin_url_returns_blocked_message(self, isolated_server):
-        # LinkedIn URLs bypass Jina entirely and return a user-friendly message.
+    def test_linkedin_url_returns_blocked_message(self, isolated_server, monkeypatch):
+        # LinkedIn URLs bypass Jina entirely; when neither the page (no
+        # JSON-LD) nor the jobs-guest fragment (no title element) yields a
+        # posting, the user gets the friendly blocked message.
+        monkeypatch.setattr(
+            "httpx.get", lambda *a, **kw: _mock_response("<html>authwall page</html>"))
         result = srv.scrape_job_url("https://www.linkedin.com/jobs/view/12345")
         assert "linkedin" in result.lower()
         assert "paste" in result.lower() or "dashboard" in result.lower()
+
+    def test_page_text_skips_network_entirely(self, isolated_server, monkeypatch):
+        """Client-supplied content (mobile fetches pages our datacenter IP
+        can't) must be used verbatim — no server-side fetch at all."""
+        def _no_network(*a, **kw):
+            raise AssertionError("network fetch attempted despite page_text")
+
+        monkeypatch.setattr("httpx.get", _no_network)
+        result = srv.scrape_job_url(
+            "https://www.linkedin.com/jobs/view/12345",
+            auto_queue=True,
+            page_text=_SAMPLE_MARKDOWN,
+        )
+        assert "Scraped" in result
+        data = json.loads(srv.JOB_QUEUE_FILE.read_text())
+        assert data["jobs"][0]["company"] == "Stripe"
+
+    def test_linkedin_guest_fallback_rescues_blocked_direct(self, isolated_server, monkeypatch):
+        """When the full page serves an authwall (no JSON-LD), the jobs-guest
+        fragment endpoint is tried before giving up."""
+        from tools import job_scraper as scraper
+
+        guest_html = (
+            '<h2 class="top-card-layout__title">Senior Platform Engineer</h2>'
+            '<h4>at Cox Automotive</h4>'
+            '<div class="description__text">' + "Build the dealer platform. " * 20 + "</div>"
+        )
+
+        def fake_get(url, *a, **kw):
+            if "jobs-guest" in url:
+                return _mock_response(guest_html)
+            return _mock_response("<html>authwall</html>")  # no JSON-LD
+
+        monkeypatch.setattr("httpx.get", fake_get)
+        result = scraper.scrape_job_url(
+            "https://www.linkedin.com/jobs/view/4242", auto_queue=True)
+        assert "Scraped" in result
+        data = json.loads(srv.JOB_QUEUE_FILE.read_text())
+        assert data["jobs"][0]["company"] == "Cox Automotive"
+
+    def test_linkedin_guest_rejects_authwall_boilerplate(self, isolated_server, monkeypatch):
+        from tools import job_scraper as scraper
+
+        def fake_get(url, *a, **kw):
+            return _mock_response(
+                "<html>Join LinkedIn " + "to see who you already know. " * 20 + "</html>")
+
+        monkeypatch.setattr("httpx.get", fake_get)
+        result = scraper.scrape_job_url("https://www.linkedin.com/jobs/view/4242")
+        assert "linkedin" in result.lower()  # blocked message, not junk import
 
     def test_empty_response_handled_gracefully(self, isolated_server, monkeypatch):
         monkeypatch.setattr("httpx.get", lambda *a, **kw: _mock_response("   "))

--- a/tests/test_mobile_api.py
+++ b/tests/test_mobile_api.py
@@ -98,7 +98,7 @@ def test_capture_worker_failure_sends_push(monkeypatch):
     monkeypatch.setattr(
         mobile_mod,
         "_capture_and_assess_inner",
-        lambda url: (_ for _ in ()).throw(RuntimeError("boom")),
+        lambda url, text="": (_ for _ in ()).throw(RuntimeError("boom")),
     )
     with _pytest.raises(RuntimeError):
         mobile_mod._capture_and_assess({"url": "https://jobs.example.com/9"})

--- a/tools/job_scraper.py
+++ b/tools/job_scraper.py
@@ -147,6 +147,59 @@ def _fetch_linkedin_direct(url: str) -> str:  # NOSONAR
     return ""
 
 
+def _fetch_linkedin_guest(url: str) -> str:
+    """Fallback: LinkedIn's public jobs-guest fragment endpoint.
+
+    /jobs-guest/jobs/api/jobPosting/{id} serves a server-rendered HTML
+    fragment of the posting without login and is less aggressively gated for
+    datacenter IPs than the full page (which often serves an authwall with no
+    JSON-LD from cloud egress). Returns plain text or "".
+    """
+    m = re.search(r"/jobs/view/(\d+)", url) or re.search(r"currentJobId=(\d+)", url)
+    if not m:
+        return ""
+    guest_url = f"https://www.linkedin.com/jobs-guest/jobs/api/jobPosting/{m.group(1)}"
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/124.0.0.0 Safari/537.36"
+        ),
+        "Accept": "text/html",
+        "Accept-Language": "en-US,en;q=0.9",
+    }
+    try:
+        resp = httpx.get(guest_url, headers=headers, timeout=_HTTP_TIMEOUT, follow_redirects=True)
+        if resp.status_code != 200:
+            return ""
+        # LinkedIn HTML wraps attributes across lines — normalize before any
+        # tag-level regex work.
+        html = re.sub(r"\s+", " ", resp.text)
+        # Extract the title from its dedicated element. No title element ⇒
+        # authwall/expired/interstitial — refuse rather than import junk
+        # (a nonexistent job id still returns 200 with a decorative page).
+        m_title = re.search(
+            r"<h2[^>]*(?:top-card|title)[^>]*>(.*?)</h2>", html, re.IGNORECASE)
+        title = _strip_html(m_title.group(1)).strip() if m_title else ""
+        if not title:
+            return ""
+        m_org = re.search(
+            r"<a[^>]*org-name[^>]*>(.*?)</a>|<h4[^>]*>(.*?)</h4>", html, re.IGNORECASE)
+        company = ""
+        if m_org:
+            company = _strip_html(m_org.group(1) or m_org.group(2) or "").strip()
+            company = re.sub(r"^at\s+", "", company)
+        body = _strip_html(html)
+        parts = [f"# {title}"]
+        if company:
+            parts.append(f"at {company}")
+        parts.append(body[:8000])
+        text = "\n\n".join(parts)
+        return text if len(text) > 100 else ""
+    except Exception:
+        return ""
+
+
 def _fetch_jina(url: str) -> str:
     """Return cleaned markdown text for *url* via Jina Reader.
 
@@ -155,7 +208,7 @@ def _fetch_jina(url: str) -> str:
     :exc:`LinkedInBlockedError` if no usable content can be extracted.
     """
     if _is_linkedin_url(url):
-        fallback = _fetch_linkedin_direct(url)
+        fallback = _fetch_linkedin_direct(url) or _fetch_linkedin_guest(url)
         if fallback.strip():
             return fallback
         raise LinkedInBlockedError(url)
@@ -250,27 +303,36 @@ def _parse_job_from_markdown(text: str, url: str) -> tuple[str, str, str]:
 
 # ── Public API ────────────────────────────────────────────────────────────────
 
-def scrape_job_url(url: str, auto_queue: bool = True) -> str:
+def scrape_job_url(url: str, auto_queue: bool = True, page_text: str = "") -> str:
     """Fetch a job posting from a URL, extract the content, and optionally queue it for fitment review.
 
     Uses Jina Reader (r.jina.ai) to strip HTML and return clean text from any
     job board page — Greenhouse, Lever, Ashby, Workday, and company career
-    pages all work well.  LinkedIn job pages are not reliably supported.
+    pages all work well.  LinkedIn job pages are not reliably supported
+    server-side; clients that can read the page themselves (the mobile app
+    fetches from a residential IP where LinkedIn serves real content) pass
+    the extracted content as *page_text* and no server fetch happens at all.
 
     Args:
         url:        Full URL to the job posting (https://...).
         auto_queue: If True (default), immediately calls queue_job so the
                     posting enters the evaluation pipeline.  If False, returns
                     the extracted content for review without queuing.
+        page_text:  Optional client-supplied page content. When non-empty it
+                    is trusted as the posting text and the URL is only used
+                    for metadata (company-from-URL, source link).
     """
-    try:
-        text = _fetch_jina(url)
-    except LinkedInBlockedError as exc:
-        return str(exc)
-    except httpx.HTTPStatusError as exc:
-        return f"HTTP {exc.response.status_code} fetching {url}. The page may require login."
-    except httpx.HTTPError as exc:
-        return f"Failed to fetch {url}: {exc}"
+    if page_text.strip():
+        text = page_text
+    else:
+        try:
+            text = _fetch_jina(url)
+        except LinkedInBlockedError as exc:
+            return str(exc)
+        except httpx.HTTPStatusError as exc:
+            return f"HTTP {exc.response.status_code} fetching {url}. The page may require login."
+        except httpx.HTTPError as exc:
+            return f"Failed to fetch {url}: {exc}"
 
     if not text.strip():
         return (

--- a/transport/http/routes/mobile.py
+++ b/transport/http/routes/mobile.py
@@ -173,7 +173,7 @@ def send_push(title: str, body: str, data: "dict | None" = None) -> int:
 
 class CaptureRequest(BaseModel):
     url: str = ""
-    text: str = ""   # future: pasted JD text instead of a URL
+    text: str = ""   # client-extracted page content (or pasted JD text)
 
 
 def _capture_and_assess(inputs: dict) -> dict:
@@ -186,7 +186,7 @@ def _capture_and_assess(inputs: dict) -> dict:
     """
     url = inputs["url"]
     try:
-        return _capture_and_assess_inner(url)
+        return _capture_and_assess_inner(url, inputs.get("text", ""))
     except Exception:  # noqa: BLE001 — the user is waiting on a push either way
         _log.exception("capture worker failed for %s", url)
         send_push(
@@ -197,10 +197,12 @@ def _capture_and_assess(inputs: dict) -> dict:
         raise  # the work row records the failure + traceback
 
 
-def _capture_and_assess_inner(url: str) -> dict:
+def _capture_and_assess_inner(url: str, text: str = "") -> dict:
     from tools.job_scraper import scrape_job_url
 
-    result = scrape_job_url(url, auto_queue=True)
+    # text = client-extracted page content (the phone can read pages that
+    # block our datacenter IPs — e.g. LinkedIn's authwall).
+    result = scrape_job_url(url, auto_queue=True, page_text=text)
     company = role = ""
     for line in str(result).splitlines():
         if line.lower().startswith("company:"):
@@ -248,5 +250,9 @@ async def capture(
     url = request.url.strip()
     if not url.startswith(("http://", "https://")):
         raise HTTPException(status_code=422, detail="Share a job posting URL.")
-    work_id = work.enqueue("capture_url", {"url": url}, origin="mobile-share")
+    work_id = work.enqueue(
+        "capture_url",
+        {"url": url, "text": request.text[:100_000]},
+        origin="mobile-share",
+    )
     return {"status": "capturing", "work_id": work_id, "detail": "Saved. Assessment running…"}


### PR DESCRIPTION
LinkedIn serves an authwall (no JSON-LD) to Azure datacenter IPs, so mobile shares died with "Import failed" (the failure push worked — that part's new and good). Two-layer fix:

1. **jobs-guest fallback** — after the direct fetch, try LinkedIn's public `/jobs-guest/jobs/api/jobPosting/{id}` fragment. Title/company are extracted from their dedicated elements; a response without a title element (authwall, expired, nonexistent id — still HTTP 200) is refused instead of imported as junk.
2. **Client-supplied page text** — `scrape_job_url(page_text=...)` skips server fetching when the client already read the page. `/api/capture` passes `text` through the work item. The mobile app (companion PR on feat/mobile-app) fetches the shared URL on-device — residential IPs get real content — and sends the extracted posting along with the URL. Cloud IP blocks stop mattering entirely.

Tests: guest-fragment rescue, junk/authwall refusal, page_text bypasses network (asserts no fetch), existing suite green (51 in the touched files). The legacy LinkedIn test no longer performs a real network call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)