### PR TITLE
Fix qa: expose page_text on job_search facade

### DIFF
--- a/tools/consolidated.py
+++ b/tools/consolidated.py
@@ -252,8 +252,9 @@ def job_search(
     company_slug: str | None = None,
     url: str | None = None,
     auto_queue: bool | None = None,
+    page_text: str | None = None,
 ) -> str:
-    """Find job postings: open-web search, Greenhouse/Lever company boards, or scrape a posting URL."""
+    """Find job postings: open-web search, Greenhouse/Lever company boards, or scrape a posting URL (pass page_text with copied page content for sites that block server fetches, e.g. LinkedIn)."""
     return _run("job_search", action, locals())
 
 


### PR DESCRIPTION
qa's test job is red: #95 added `page_text` to `scrape_job_url` and I missed the consolidated `job_search` facade, which the facade-coverage guard (`test_facade_params_cover_every_target_param`) correctly caught. This exposes the param (also handy in chat — paste posting text when a site blocks server fetches).

`tests/test_consolidated_tools.py`: 15 passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)