### PR TITLE
Telemetry P0: metrics registry, /metrics, work stats

### DIFF
--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -42,6 +42,25 @@ executor sends; **the row is the system of record**.
 
 Kinds registered today: `capture_url` (mobile share → import → assess → push).
 
+## Telemetry (P0, shipped alongside)
+
+Two complementary layers, still zero new infrastructure (`lib/metrics.py`):
+
+- **`GET /metrics`** — Prometheus text format from an in-process registry.
+  Instrumented: every HTTP request (`http_requests_total` /
+  `http_request_seconds`, labeled by route *template* to bound cardinality),
+  every work item (`work_items_total` / `work_item_seconds` by kind/status),
+  and every LLM call through the `create_chat_completion` funnel
+  (`llm_calls_total` by label/model/outcome, `llm_call_seconds`,
+  `llm_tokens_total` by direction). Aggregates only — no user data. The AKS
+  pods carry `prometheus.io/*` annotations for Azure Monitor's managed
+  Prometheus (enable pod-annotation scraping in
+  ama-metrics-settings-configmap to activate collection).
+- **`GET /api/work/stats`** — per-tenant JSON aggregates straight off the
+  work_items table (counts + avg duration by kind/status, recent failures
+  with error heads): the control plane doubling as its own telemetry source,
+  consumable by the dashboard, mobile, or Claude in chat.
+
 ## Roadmap
 
 - **P1 — document generation**: route assessment / interview-prep /

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -17,6 +17,13 @@ spec:
       labels:
         app: jcmcp
         azure.workload.identity/use: "true"
+      annotations:
+        # Azure Monitor managed Prometheus (ama-metrics) pod-annotation
+        # scraping — requires podannotationnamespaceregex to include this
+        # namespace in the ama-metrics-settings-configmap.
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "8000"
     spec:
       serviceAccountName: jcmcp-workload-sa
       initContainers:

--- a/lib/metrics.py
+++ b/lib/metrics.py
@@ -1,0 +1,129 @@
+"""Telemetry P0: an in-process metrics registry with Prometheus exposition.
+
+Counters and duration summaries, thread-safe, zero dependencies — the same
+constraint as the control plane (this module ships inside the frozen desktop
+sidecar too). The cloud's AKS cluster already runs Azure Monitor's managed
+Prometheus agents (ama-metrics); GET /metrics exposes the standard text
+format so scraping is a pod-annotation away. Locally it's a debugging page.
+
+What gets instrumented where:
+  - HTTP requests   → transport/http/app.py MetricsMiddleware
+                      http_requests_total / http_request_seconds{method,route,status}
+  - Work items      → lib/work.py dispatcher
+                      work_items_total / work_item_seconds{kind,status}
+  - LLM calls       → lib/openai_calls.create_chat_completion
+                      llm_calls_total{label,model,outcome}
+                      llm_call_seconds{label,model}
+                      llm_tokens_total{label,model,direction}
+
+Aggregates only — never user content, URLs, or identifiers. Route labels are
+route *templates* (/api/work/{item_id}), not raw paths, to bound cardinality.
+"""
+from __future__ import annotations
+
+import threading
+import time
+
+_LabelKey = tuple[str, tuple[tuple[str, str], ...]]
+
+_LOCK = threading.Lock()
+_COUNTERS: dict[_LabelKey, float] = {}
+_SUMMARIES: dict[_LabelKey, list[float]] = {}  # [count, sum]
+_STARTED_AT = time.time()
+
+
+def _key(name: str, labels: dict[str, str]) -> _LabelKey:
+    return name, tuple(sorted((k, str(v)) for k, v in labels.items()))
+
+
+def inc(name: str, amount: float = 1.0, **labels: str) -> None:
+    """Increment a counter."""
+    key = _key(name, labels)
+    with _LOCK:
+        _COUNTERS[key] = _COUNTERS.get(key, 0.0) + amount
+
+
+def observe(name: str, value: float, **labels: str) -> None:
+    """Record one observation into a summary (exposed as _count and _sum)."""
+    key = _key(name, labels)
+    with _LOCK:
+        entry = _SUMMARIES.setdefault(key, [0.0, 0.0])
+        entry[0] += 1
+        entry[1] += value
+
+
+def snapshot() -> dict:
+    """Plain-dict view for tests and debugging: one entry per label set."""
+    with _LOCK:
+        counters = [
+            {"name": name, "labels": dict(labels), "value": v}
+            for (name, labels), v in sorted(_COUNTERS.items())
+        ]
+        summaries = [
+            {"name": name, "labels": dict(labels), "count": e[0], "sum": e[1]}
+            for (name, labels), e in sorted(_SUMMARIES.items())
+        ]
+    return {"counters": counters, "summaries": summaries}
+
+
+def reset() -> None:
+    """Test hook: clear all series."""
+    with _LOCK:
+        _COUNTERS.clear()
+        _SUMMARIES.clear()
+
+
+def _escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def _fmt_labels(labels: tuple[tuple[str, str], ...]) -> str:
+    if not labels:
+        return ""
+    inner = ",".join(f'{k}="{_escape(v)}"' for k, v in labels)
+    return "{" + inner + "}"
+
+
+def render_prometheus() -> str:
+    """Render every series in the Prometheus text exposition format."""
+    lines: list[str] = [
+        "# TYPE process_uptime_seconds gauge",
+        f"process_uptime_seconds {time.time() - _STARTED_AT:.1f}",
+    ]
+    with _LOCK:
+        counter_names = sorted({name for name, _ in _COUNTERS})
+        for name in counter_names:
+            lines.append(f"# TYPE {name} counter")
+            for (n, labels), value in sorted(_COUNTERS.items()):
+                if n == name:
+                    lines.append(f"{name}{_fmt_labels(labels)} {value:g}")
+        summary_names = sorted({name for name, _ in _SUMMARIES})
+        for name in summary_names:
+            lines.append(f"# TYPE {name} summary")
+            for (n, labels), (count, total) in sorted(_SUMMARIES.items()):
+                if n == name:
+                    lines.append(f"{name}_count{_fmt_labels(labels)} {count:g}")
+                    lines.append(f"{name}_sum{_fmt_labels(labels)} {total:g}")
+    return "\n".join(lines) + "\n"
+
+
+class timed:  # noqa: N801 — context manager reads like a keyword
+    """Measure a block and record it: ``with metrics.timed("x_seconds", k=v): ...``
+
+    The ``outcome`` label is added automatically ("ok" or "error" by whether
+    the block raised) unless the caller supplied one.
+    """
+
+    def __init__(self, name: str, **labels: str) -> None:
+        self._name = name
+        self._labels = labels
+        self._start = 0.0
+
+    def __enter__(self) -> "timed":
+        self._start = time.monotonic()
+        return self
+
+    def __exit__(self, exc_type, _exc, _tb) -> None:
+        labels = dict(self._labels)
+        labels.setdefault("outcome", "error" if exc_type else "ok")
+        observe(self._name, time.monotonic() - self._start, **labels)

--- a/lib/openai_calls.py
+++ b/lib/openai_calls.py
@@ -7,6 +7,8 @@ import time
 from random import SystemRandom
 from typing import Any
 
+from lib import metrics
+
 _LOG = logging.getLogger(__name__)
 # Cryptographically-seeded RNG used only for retry-backoff jitter. Avoids the
 # non-secure global PRNG so static analysers don't flag it (Sonar S2245 / B311).
@@ -104,6 +106,12 @@ def create_chat_completion(client: Any, *, label: str = "chat", max_attempts: in
             except Exception as exc:
                 _LAST_CHAT_CALL = time.monotonic()
                 status_code = getattr(getattr(exc, "response", None), "status_code", None)
+                metrics.inc(
+                    "llm_calls_total",
+                    label=label,
+                    model=str(kwargs.get("model")),
+                    outcome=f"error_{status_code or 'network'}",
+                )
                 payload = _error_payload(exc)
                 _LOG.warning(
                     "openai.chat error label=%s attempt=%s status=%s requested_max_tokens=%s payload=%s",
@@ -158,6 +166,16 @@ def create_chat_completion(client: Any, *, label: str = "chat", max_attempts: in
             prompt_tokens = getattr(usage, "prompt_tokens", None) if usage else None
             completion_tokens = getattr(usage, "completion_tokens", None) if usage else None
             total_tokens = getattr(usage, "total_tokens", None) if usage else None
+            model = str(kwargs.get("model"))
+            metrics.inc("llm_calls_total", label=label, model=model, outcome="ok")
+            metrics.observe(
+                "llm_call_seconds", time.monotonic() - started, label=label, model=model)
+            if prompt_tokens:
+                metrics.inc("llm_tokens_total", float(prompt_tokens),
+                            label=label, model=model, direction="prompt")
+            if completion_tokens:
+                metrics.inc("llm_tokens_total", float(completion_tokens),
+                            label=label, model=model, direction="completion")
             _LOG.info(
                 "openai.chat usage label=%s attempt=%s elapsed=%.2fs model=%s requested_max_tokens=%s prompt_tokens=%s completion_tokens=%s total_tokens=%s",
                 label,

--- a/lib/work.py
+++ b/lib/work.py
@@ -30,6 +30,7 @@ import traceback
 from pathlib import Path
 from typing import Any, Callable
 
+from lib import metrics
 from lib.db import get_connection
 from lib.user_context import (
     get_data_folder_override,
@@ -187,13 +188,17 @@ def _execute(partition: "str | None", item_id: int) -> None:
 
     if fn is None:
         _finish("failed", error=f"no executor registered for kind '{kind}'")
+        metrics.inc("work_items_total", kind=kind, status="failed")
         return
     try:
-        artifacts = _in_partition(partition, lambda: fn(inputs))
+        with metrics.timed("work_item_seconds", kind=kind):
+            artifacts = _in_partition(partition, lambda: fn(inputs))
         _finish("succeeded", artifacts=artifacts if isinstance(artifacts, dict) else None)
+        metrics.inc("work_items_total", kind=kind, status="succeeded")
     except Exception as exc:  # noqa: BLE001 — outcome is the record, never a crash
         _log.exception("work item %s (%s) failed", item_id, kind)
         _finish("failed", error=f"{exc}\n{traceback.format_exc(limit=8)}")
+        metrics.inc("work_items_total", kind=kind, status="failed")
 
 
 async def _worker_loop() -> None:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,148 @@
+"""Telemetry P0 (lib/metrics.py + instrumentation + exposition).
+
+Covers the registry itself, the Prometheus text rendering, the HTTP
+middleware labels (route templates, not raw paths), work-dispatcher
+instrumentation, and the /api/work/stats aggregate surface.
+"""
+from __future__ import annotations
+
+import pytest
+
+from lib import metrics
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    metrics.reset()
+    yield
+    metrics.reset()
+
+
+def test_counters_accumulate_by_label_set():
+    metrics.inc("jobs_total", kind="a", status="ok")
+    metrics.inc("jobs_total", kind="a", status="ok")
+    metrics.inc("jobs_total", kind="b", status="failed")
+    text = metrics.render_prometheus()
+    assert 'jobs_total{kind="a",status="ok"} 2' in text
+    assert 'jobs_total{kind="b",status="failed"} 1' in text
+    assert "# TYPE jobs_total counter" in text
+
+
+def test_summaries_render_count_and_sum():
+    metrics.observe("x_seconds", 1.5, op="scan")
+    metrics.observe("x_seconds", 2.5, op="scan")
+    text = metrics.render_prometheus()
+    assert 'x_seconds_count{op="scan"} 2' in text
+    assert 'x_seconds_sum{op="scan"} 4' in text
+    assert "# TYPE x_seconds summary" in text
+
+
+def test_timed_records_outcome_label():
+    with metrics.timed("op_seconds", kind="k"):
+        pass
+    with pytest.raises(ValueError):  # noqa: PT012
+        with metrics.timed("op_seconds", kind="k"):
+            raise ValueError("boom")
+    text = metrics.render_prometheus()
+    assert 'op_seconds_count{kind="k",outcome="ok"} 1' in text
+    assert 'op_seconds_count{kind="k",outcome="error"} 1' in text
+
+
+def test_label_values_escaped():
+    metrics.inc("weird_total", path='say "hi"\nthere')
+    text = metrics.render_prometheus()
+    assert 'weird_total{path="say \\"hi\\"\\nthere"} 1' in text
+
+
+def test_work_execution_is_instrumented(tmp_path, monkeypatch):
+    import lib.config as cfg
+    from lib import work
+
+    monkeypatch.setattr(cfg, "DATA_FOLDER", str(tmp_path), raising=False)
+    saved = dict(work._KINDS)
+    try:
+        work.register_kind("noop", lambda i: {})
+        work.register_kind("bad", lambda i: (_ for _ in ()).throw(RuntimeError("x")))
+        ok_id = work.enqueue("noop", {})
+        bad_id = work.enqueue("bad", {})
+        work._execute(None, ok_id)
+        work._execute(None, bad_id)
+    finally:
+        work._KINDS.clear()
+        work._KINDS.update(saved)
+    text = metrics.render_prometheus()
+    assert 'work_items_total{kind="noop",status="succeeded"} 1' in text
+    assert 'work_items_total{kind="bad",status="failed"} 1' in text
+    assert 'work_item_seconds_count{kind="noop",outcome="ok"} 1' in text
+
+
+# ── HTTP surface ───────────────────────────────────────────────────────────────
+
+@pytest.fixture()
+def app_client(monkeypatch, tmp_path):
+    import lib.config as cfg_mod
+    from lib.user_provisioning import provision_user_data
+
+    root = tmp_path / "data"
+    root.mkdir()
+    monkeypatch.setattr(cfg_mod, "DATA_FOLDER", str(root), raising=False)
+    provision_user_data(root)
+    monkeypatch.delenv("API_KEY", raising=False)
+    from fastapi.testclient import TestClient
+    from transport.http.app import create_app
+    from transport.http.config import reset_settings_cache
+
+    reset_settings_cache()
+    with TestClient(create_app()) as client:
+        yield client
+    reset_settings_cache()
+
+
+def test_metrics_endpoint_exposes_request_series(app_client):
+    app_client.get("/api/work")           # counted, route template label
+    app_client.get("/api/work/424242")    # 404s also counted
+    text = app_client.get("/metrics").text
+    assert "# TYPE http_requests_total counter" in text
+    assert 'route="/api/work"' in text
+    # route template, never the raw path (cardinality + privacy)
+    assert 'route="/api/work/{item_id}"' in text
+    assert "424242" not in text
+    assert "process_uptime_seconds" in text
+
+
+def test_metrics_endpoint_does_not_count_itself(app_client):
+    app_client.get("/metrics")
+    text = app_client.get("/metrics").text
+    assert 'route="/metrics"' not in text
+
+
+def test_work_stats_aggregates(app_client, monkeypatch):
+    import time
+
+    from lib import work
+
+    monkeypatch.setitem(work._KINDS, "capture_url", lambda inputs: {})
+    ok = app_client.post("/api/capture", json={"url": "https://jobs.example.com/1"})
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        item = app_client.get(f"/api/work/{ok.json()['work_id']}").json()
+        if item["status"] == "succeeded":
+            break
+        time.sleep(0.05)
+    monkeypatch.setitem(
+        work._KINDS, "capture_url",
+        lambda inputs: (_ for _ in ()).throw(RuntimeError("scrape wall")),
+    )
+    bad = app_client.post("/api/capture", json={"url": "https://jobs.example.com/2"})
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        item = app_client.get(f"/api/work/{bad.json()['work_id']}").json()
+        if item["status"] == "failed":
+            break
+        time.sleep(0.05)
+
+    stats = app_client.get("/api/work/stats").json()
+    rows = {(r["kind"], r["status"]): r["count"] for r in stats["by_kind_status"]}
+    assert rows[("capture_url", "succeeded")] == 1
+    assert rows[("capture_url", "failed")] == 1
+    assert stats["recent_failures"][0]["error_head"].startswith("scrape wall")

--- a/transport/http/app.py
+++ b/transport/http/app.py
@@ -12,13 +12,14 @@ can connect to the remote server via type:"http" in mcp.json).
 """
 
 import logging
+import time
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, AsyncGenerator
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, HTMLResponse, RedirectResponse
+from fastapi.responses import FileResponse, HTMLResponse, PlainTextResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request as StarletteRequest
@@ -87,6 +88,33 @@ def _mount_spa(app: FastAPI) -> None:
     _logger.info("React SPA mounted at /app (dist=%s)", spa_dist)
 
 
+class MetricsMiddleware(BaseHTTPMiddleware):
+    """Time every request; label by method + route TEMPLATE (bounded
+    cardinality) + status. /metrics and /health are excluded as self-noise."""
+
+    async def dispatch(self, request: StarletteRequest, call_next):
+        from lib import metrics
+
+        path = request.url.path
+        if path in ("/metrics", "/health", "/healthz"):
+            return await call_next(request)
+        started = time.monotonic()
+        status = "500"  # if call_next raises, record the request as a 500
+        try:
+            response = await call_next(request)
+            status = str(response.status_code)
+            return response
+        finally:
+            route = request.scope.get("route")
+            route_path = getattr(route, "path", None) or "(unrouted)"
+            labels = {"method": request.method, "route": route_path, "status": status}
+            metrics.inc("http_requests_total", **labels)
+            metrics.observe(
+                "http_request_seconds", time.monotonic() - started,
+                method=request.method, route=route_path,
+            )
+
+
 class UserDataContextMiddleware(BaseHTTPMiddleware):
     """Starlette middleware that routes each authenticated request to the
     requesting user's own data partition under DATA_FOLDER/users/{oid}/.
@@ -121,6 +149,7 @@ class UserDataContextMiddleware(BaseHTTPMiddleware):
         _PUBLIC_PREFIXES = (
             "/.well-known/",
             "/health",
+            "/metrics",       # aggregate counters only — no user data (scraped by ama-metrics)
             "/oauth/",
             "/logout",
             "/setup",
@@ -245,6 +274,7 @@ def create_app(mcp: "FastMCP | None" = None) -> FastAPI:
     # Per-user data isolation for every authenticated request.
     # Registered first so it sits inside CORS (CORS must be outermost).
     app.add_middleware(UserDataContextMiddleware)
+    app.add_middleware(MetricsMiddleware)
 
     if settings.cors_origins:
         app.add_middleware(
@@ -282,6 +312,12 @@ def create_app(mcp: "FastMCP | None" = None) -> FastAPI:
     app.include_router(personas_routes.router)
     app.include_router(dashboard_api_router)  # /api/dashboard/* JSON for the React SPA
     app.include_router(dashboard_router)
+
+    @app.get("/metrics", include_in_schema=False)
+    async def _metrics() -> PlainTextResponse:
+        from lib import metrics
+
+        return PlainTextResponse(metrics.render_prometheus(), media_type="text/plain; version=0.0.4")
 
     @app.get("/", include_in_schema=False)
     async def _root_landing() -> HTMLResponse:

--- a/transport/http/routes/work.py
+++ b/transport/http/routes/work.py
@@ -28,6 +28,38 @@ async def work_list(
     return {"items": work.list_items(status=status, limit=limit)}
 
 
+@router.get("/stats")
+async def work_stats(
+    user: Annotated[User, Depends(require_authenticated_user)],  # noqa: ARG001
+) -> dict:
+    """Aggregates over the caller's work: counts, durations, recent failures.
+    Everything here is a GROUP BY over work_items — the control plane doubles
+    as its own telemetry source."""
+    from lib.db import get_connection
+
+    work._ensure_schema()
+    with get_connection() as con:
+        by_kind_status = [
+            dict(r)
+            for r in con.execute(
+                "SELECT kind, status, COUNT(*) AS count, "
+                "ROUND(AVG((julianday(finished_at) - julianday(started_at)) * 86400.0), 2) "
+                "  AS avg_seconds "
+                "FROM work_items GROUP BY kind, status ORDER BY kind, status"
+            ).fetchall()
+        ]
+        recent_failures = [
+            dict(r)
+            for r in con.execute(
+                "SELECT id, kind, finished_at, "
+                "substr(COALESCE(error, ''), 1, 200) AS error_head "
+                "FROM work_items WHERE status = 'failed' "
+                "ORDER BY id DESC LIMIT 5"
+            ).fetchall()
+        ]
+    return {"by_kind_status": by_kind_status, "recent_failures": recent_failures}
+
+
 @router.get("/{item_id}")
 async def work_get(
     item_id: int,


### PR DESCRIPTION
The telemetry pass discussed after control-plane P0 — same constraints: zero new dependencies, zero new services, identical code on desktop and cloud.

## What
- **`lib/metrics.py`** — thread-safe in-process registry (counters + duration summaries) with Prometheus text exposition. Hand-rolled (~120 lines) rather than prometheus_client to keep the frozen bundle dependency-free.
- **Instrumentation**:
  - every HTTP request — `http_requests_total` / `http_request_seconds`, labeled by method + **route template** + status (bounded cardinality; raw paths/ids never become labels)
  - every work item — `work_items_total` / `work_item_seconds` by kind/status
  - every LLM call through the funnel — `llm_calls_total` (label/model/outcome incl. error statuses), `llm_call_seconds`, `llm_tokens_total` (prompt/completion) — the raw material for P2 cost accounting
- **`GET /metrics`** — Prometheus format; public prefix (aggregates only, no user data). Pod annotations added for Azure Monitor managed Prometheus — collection activates when the namespace is enabled in `ama-metrics-settings-configmap` (cluster-side toggle, not in this PR).
- **`GET /api/work/stats`** — per-tenant JSON: counts + avg duration by kind/status, recent failures with error heads. The "work table doubles as telemetry" idea, consumable by dashboard/mobile/chat.
- docs/control-plane.md updated.

## Tests
`tests/test_metrics.py` (8): registry semantics, escaping, timed-block outcomes, work instrumentation, route-template labels (asserts raw ids do NOT appear), /metrics self-exclusion, work-stats aggregates end-to-end through the live app. **Full suite: 1400 passed** (consolidated-tools guard included this time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)