### PR TITLE
Fix desktop chat: sessions poisoned by interrupted tool turns

### DIFF
--- a/services/chat_service.py
+++ b/services/chat_service.py
@@ -146,10 +146,6 @@ def _save_message(
 def _history_as_openai_messages(session_id: int) -> list[dict]:
     """Rebuild the OpenAI-shaped message list from stored rows (capped)."""
     rows = list_messages(session_id)[-MAX_HISTORY_MESSAGES:]
-    # Never start history with orphaned tool results (their assistant row was
-    # capped away) — providers reject tool messages with no matching call.
-    while rows and rows[0]["role"] == "tool":
-        rows.pop(0)
     messages: list[dict] = []
     for row in rows:
         if row["role"] == "assistant" and row["tool_calls"]:
@@ -170,7 +166,49 @@ def _history_as_openai_messages(session_id: int) -> list[dict]:
             )
         else:
             messages.append({"role": row["role"], "content": row["content"]})
-    return messages
+    return _repair_tool_pairing(messages)
+
+
+def _repair_tool_pairing(messages: list[dict]) -> list[dict]:
+    """Make replayed history provider-legal, whatever state it was saved in.
+
+    Providers hard-reject (400) two shapes that real crashes produce:
+      - an assistant message with tool_calls not followed by a tool result for
+        EVERY tool_call_id (turn died mid-execution → results never saved;
+        the session is then permanently poisoned without this repair)
+      - a tool result with no preceding matching call (its assistant row was
+        capped away, or the same interrupted turn saved out of order)
+
+    Missing results are synthesized as interruption notes; orphaned results
+    are dropped.
+    """
+    repaired: list[dict] = []
+    pending: set[str] = set()  # ids from the last assistant tool_calls still unanswered
+
+    def _flush_pending() -> None:
+        repaired.extend(
+            {
+                "role": "tool",
+                "tool_call_id": missing_id,
+                "content": "(tool execution was interrupted — no result was recorded)",
+            }
+            for missing_id in sorted(pending)
+        )
+        pending.clear()
+
+    for msg in messages:
+        if msg["role"] == "tool":
+            if msg.get("tool_call_id") in pending:
+                pending.discard(msg["tool_call_id"])
+                repaired.append(msg)
+            # else: orphaned result — drop it
+            continue
+        _flush_pending()  # any non-tool message closes the response window
+        if msg["role"] == "assistant" and msg.get("tool_calls"):
+            pending.update(tc["id"] for tc in msg["tool_calls"] if tc.get("id"))
+        repaired.append(msg)
+    _flush_pending()
+    return repaired
 
 
 # ── tool surface ───────────────────────────────────────────────────────────────

--- a/tests/test_chat_service.py
+++ b/tests/test_chat_service.py
@@ -198,6 +198,56 @@ def test_history_replays_into_next_turn(mcp_instance):
     assert sent[2]["content"] == "Hi!"
 
 
+def test_dangling_tool_calls_get_synthesized_results(mcp_instance):
+    """A turn that died between saving the assistant tool_calls row and its
+    tool results permanently poisoned the session: every later replay was a
+    provider 400 ('tool_call_ids did not have response messages'). The repair
+    synthesizes interruption results so the session stays usable."""
+    sid = chat_service.create_session()
+    chat_service._save_message(sid, "user", "run something")
+    chat_service._save_message(
+        sid, "assistant", "",
+        tool_calls=[{"id": "toolu_dead", "type": "function",
+                     "function": {"name": "applications", "arguments": "{}"}}],
+    )
+    # no tool result row — the crash
+
+    client = FakeClient([_response(content="Recovered.")])
+    events = _run_turn(mcp_instance, sid, "Hello?", client)
+
+    assert any(e.type == "message" for e in events)
+    sent = client.requests[0]["messages"]
+    idx = next(i for i, m in enumerate(sent) if m["role"] == "assistant" and m.get("tool_calls"))
+    follow = sent[idx + 1]
+    assert follow["role"] == "tool" and follow["tool_call_id"] == "toolu_dead"
+    assert "interrupted" in follow["content"]
+
+
+def test_orphaned_tool_results_are_dropped():
+    """Tool results whose calls were capped away (or saved out of order) are
+    removed anywhere in history, not only at the head."""
+    messages = [
+        {"role": "tool", "tool_call_id": "gone", "content": "stale"},
+        {"role": "user", "content": "hi"},
+        {"role": "tool", "tool_call_id": "also-gone", "content": "stale"},
+        {"role": "assistant", "content": "hello"},
+    ]
+    repaired = chat_service._repair_tool_pairing(messages)
+    assert [m["role"] for m in repaired] == ["user", "assistant"]
+
+
+def test_well_formed_history_passes_through_unchanged():
+    messages = [
+        {"role": "user", "content": "go"},
+        {"role": "assistant", "content": None,
+         "tool_calls": [{"id": "a", "type": "function",
+                         "function": {"name": "x", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "a", "content": "done"},
+        {"role": "assistant", "content": "all set"},
+    ]
+    assert chat_service._repair_tool_pairing(list(messages)) == messages
+
+
 # ── HTTP endpoints (desktop-gated) ─────────────────────────────────────────────
 
 def test_chat_routes_absent_outside_desktop_mode(http_client_noauth):


### PR DESCRIPTION
Field report: a desktop chat session where every send — including plain "Hello?" — failed with `400 … tool_call_ids did not have response messages`.

**Root cause:** a previous turn died between persisting the assistant `tool_calls` row and its tool-result rows (process exit or the SSE client disconnecting, which closes the generator mid-loop). History replay then contains an assistant message with `tool_calls` and no responses — providers hard-reject that shape, so the session is permanently wedged.

**Fix:** `_repair_tool_pairing()` runs on every history rebuild:
- dangling `tool_calls` → synthesized `"(tool execution was interrupted — no result was recorded)"` results — the session recovers on the very next send, including sessions poisoned before this fix
- orphaned tool results → dropped anywhere in history (the old guard only handled the head)

Tests: poisoned-session recovery end-to-end (asserts the synthesized result lands right after the dangling call), mid-history orphan dropping, well-formed history passes through byte-identical. 18/18 in test_chat_service.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)