### PR TITLE
Telemetry: in-cluster Prometheus + Grafana (dashboards as code)

### DIFF
--- a/k8s/monitoring/grafana-dashboards.yaml
+++ b/k8s/monitoring/grafana-dashboards.yaml
@@ -1,0 +1,245 @@
+# Provisioned dashboard: jobContext Overview. Edit the JSON here (dashboards
+# as code) — in-UI edits to this dashboard do not persist across restarts.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-jobcontext
+  namespace: monitoring
+data:
+  jobcontext-overview.json: |
+    {
+     "uid": "jobcontext-overview",
+     "title": "jobContext Overview",
+     "schemaVersion": 39,
+     "refresh": "30s",
+     "time": {
+      "from": "now-6h",
+      "to": "now"
+     },
+     "panels": [
+      {
+       "id": 1,
+       "title": "Request rate by route",
+       "type": "timeseries",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+       },
+       "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 12,
+        "h": 8
+       },
+       "fieldConfig": {
+        "defaults": {
+         "unit": "reqps"
+        },
+        "overrides": []
+       },
+       "targets": [
+        {
+         "expr": "sum(rate(http_requests_total[5m])) by (route)",
+         "legendFormat": "{{route}}",
+         "refId": "A"
+        }
+       ]
+      },
+      {
+       "id": 2,
+       "title": "5xx error rate",
+       "type": "timeseries",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+       },
+       "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 12,
+        "h": 8
+       },
+       "fieldConfig": {
+        "defaults": {
+         "unit": "reqps"
+        },
+        "overrides": []
+       },
+       "targets": [
+        {
+         "expr": "sum(rate(http_requests_total{status=~\"5..\"}[5m]))",
+         "legendFormat": "5xx",
+         "refId": "A"
+        }
+       ]
+      },
+      {
+       "id": 3,
+       "title": "Avg request latency by route",
+       "type": "timeseries",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+       },
+       "gridPos": {
+        "x": 0,
+        "y": 8,
+        "w": 12,
+        "h": 8
+       },
+       "fieldConfig": {
+        "defaults": {
+         "unit": "s"
+        },
+        "overrides": []
+       },
+       "targets": [
+        {
+         "expr": "rate(http_request_seconds_sum[5m]) / rate(http_request_seconds_count[5m])",
+         "legendFormat": "{{route}}",
+         "refId": "A"
+        }
+       ]
+      },
+      {
+       "id": 4,
+       "title": "Work items (1h) by kind/status",
+       "type": "timeseries",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+       },
+       "gridPos": {
+        "x": 12,
+        "y": 8,
+        "w": 12,
+        "h": 8
+       },
+       "fieldConfig": {
+        "defaults": {
+         "unit": "short"
+        },
+        "overrides": []
+       },
+       "targets": [
+        {
+         "expr": "sum(increase(work_items_total[1h])) by (kind, status)",
+         "legendFormat": "{{kind}} {{status}}",
+         "refId": "A"
+        }
+       ]
+      },
+      {
+       "id": 5,
+       "title": "Avg work-item duration",
+       "type": "timeseries",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+       },
+       "gridPos": {
+        "x": 0,
+        "y": 16,
+        "w": 12,
+        "h": 8
+       },
+       "fieldConfig": {
+        "defaults": {
+         "unit": "s"
+        },
+        "overrides": []
+       },
+       "targets": [
+        {
+         "expr": "rate(work_item_seconds_sum[15m]) / rate(work_item_seconds_count[15m])",
+         "legendFormat": "{{kind}} ({{outcome}})",
+         "refId": "A"
+        }
+       ]
+      },
+      {
+       "id": 6,
+       "title": "LLM calls by model/outcome",
+       "type": "timeseries",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+       },
+       "gridPos": {
+        "x": 12,
+        "y": 16,
+        "w": 12,
+        "h": 8
+       },
+       "fieldConfig": {
+        "defaults": {
+         "unit": "short"
+        },
+        "overrides": []
+       },
+       "targets": [
+        {
+         "expr": "sum(increase(llm_calls_total[1h])) by (model, outcome)",
+         "legendFormat": "{{model}} {{outcome}}",
+         "refId": "A"
+        }
+       ]
+      },
+      {
+       "id": 7,
+       "title": "LLM tokens/hour by direction",
+       "type": "timeseries",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+       },
+       "gridPos": {
+        "x": 0,
+        "y": 24,
+        "w": 12,
+        "h": 8
+       },
+       "fieldConfig": {
+        "defaults": {
+         "unit": "short"
+        },
+        "overrides": []
+       },
+       "targets": [
+        {
+         "expr": "sum(increase(llm_tokens_total[1h])) by (model, direction)",
+         "legendFormat": "{{model}} {{direction}}",
+         "refId": "A"
+        }
+       ]
+      },
+      {
+       "id": 8,
+       "title": "App uptime",
+       "type": "stat",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+       },
+       "gridPos": {
+        "x": 12,
+        "y": 24,
+        "w": 12,
+        "h": 8
+       },
+       "fieldConfig": {
+        "defaults": {
+         "unit": "s"
+        },
+        "overrides": []
+       },
+       "targets": [
+        {
+         "expr": "process_uptime_seconds",
+         "legendFormat": "{{pod}}",
+         "refId": "A"
+        }
+       ]
+      }
+     ]
+    }

--- a/k8s/monitoring/grafana.yaml
+++ b/k8s/monitoring/grafana.yaml
@@ -1,0 +1,149 @@
+# In-cluster Grafana OSS, fully provisioned as code: Prometheus datasource +
+# the jobContext overview dashboard (separate configmap, grafana-dashboards.yaml).
+#
+# Admin credentials come from the `grafana-admin` secret, created out-of-band
+# (never committed):
+#   kubectl -n monitoring create secret generic grafana-admin \
+#     --from-literal=admin-user=admin \
+#     --from-literal=admin-password="$(openssl rand -base64 24)"
+# Retrieve later:
+#   kubectl -n monitoring get secret grafana-admin \
+#     -o jsonpath='{.data.admin-password}' | base64 -d
+#
+# Reach it with:  kubectl -n monitoring port-forward svc/grafana 3000:3000
+# or via https://grafana.jobcontext.ai after adding the GoDaddy CNAME
+# (grafana → jobcontextmcp.eastus.cloudapp.azure.com).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-provisioning
+  namespace: monitoring
+data:
+  datasource.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        uid: prometheus
+        type: prometheus
+        access: proxy
+        url: http://prometheus.monitoring.svc:9090
+        isDefault: true
+  dashboards.yaml: |
+    apiVersion: 1
+    providers:
+      - name: jobcontext
+        folder: jobContext
+        type: file
+        options:
+          path: /var/lib/grafana/dashboards
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana-data
+  namespace: monitoring
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: managed-csi
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      securityContext:
+        fsGroup: 472    # grafana image user
+      containers:
+        - name: grafana
+          image: grafana/grafana:11.1.0
+          ports:
+            - containerPort: 3000
+          env:
+            - name: GF_SECURITY_ADMIN_USER
+              valueFrom:
+                secretKeyRef: { name: grafana-admin, key: admin-user }
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef: { name: grafana-admin, key: admin-password }
+            - name: GF_USERS_ALLOW_SIGN_UP
+              value: "false"
+            - name: GF_SERVER_ROOT_URL
+              value: https://grafana.jobcontext.ai
+          resources:
+            requests: { cpu: 50m, memory: 128Mi }
+            limits: { cpu: 500m, memory: 512Mi }
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/grafana
+            - name: provisioning-datasources
+              mountPath: /etc/grafana/provisioning/datasources
+            - name: provisioning-dashboards
+              mountPath: /etc/grafana/provisioning/dashboards
+            - name: dashboards
+              mountPath: /var/lib/grafana/dashboards
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: grafana-data
+        - name: provisioning-datasources
+          configMap:
+            name: grafana-provisioning
+            items: [{ key: datasource.yaml, path: datasource.yaml }]
+        - name: provisioning-dashboards
+          configMap:
+            name: grafana-provisioning
+            items: [{ key: dashboards.yaml, path: dashboards.yaml }]
+        - name: dashboards
+          configMap:
+            name: grafana-dashboard-jobcontext
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  selector:
+    app: grafana
+  ports:
+    - port: 3000
+      targetPort: 3000
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grafana
+  namespace: monitoring
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts: [grafana.jobcontext.ai]
+      secretName: grafana-tls
+  rules:
+    - host: grafana.jobcontext.ai
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: grafana
+                port:
+                  number: 3000

--- a/k8s/monitoring/prometheus.yaml
+++ b/k8s/monitoring/prometheus.yaml
@@ -1,0 +1,144 @@
+# In-cluster Prometheus — scrapes pods annotated prometheus.io/scrape=true
+# in the jcmcp and jcmcp-qa namespaces (the app exposes /metrics; see
+# lib/metrics.py and docs/control-plane.md → Telemetry).
+#
+# Deliberately tiny: one replica, 7d retention, 2Gi PVC. This is a viewing
+# cache, not the system of record (work_items is). Upgrade path: Azure
+# Monitor managed Prometheus + Azure Managed Grafana.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-pod-reader
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-pod-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-pod-reader
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: monitoring
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: monitoring
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 30s
+      evaluation_interval: 30s
+    scrape_configs:
+      - job_name: jobcontext-pods
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names: [jcmcp, jcmcp-qa]
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            action: keep
+            regex: "true"
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+            action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: pod
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prometheus-data
+  namespace: monitoring
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: managed-csi
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: monitoring
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate   # RWO volume — old pod must release it first
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      serviceAccountName: prometheus
+      securityContext:
+        fsGroup: 65534    # nobody — prometheus image runs unprivileged
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v2.53.0
+          args:
+            - --config.file=/etc/prometheus/prometheus.yml
+            - --storage.tsdb.path=/prometheus
+            - --storage.tsdb.retention.time=7d
+          ports:
+            - containerPort: 9090
+          resources:
+            requests: { cpu: 50m, memory: 256Mi }
+            limits: { cpu: 500m, memory: 512Mi }
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus
+            - name: data
+              mountPath: /prometheus
+      volumes:
+        - name: config
+          configMap:
+            name: prometheus-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: prometheus-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: monitoring
+spec:
+  selector:
+    app: prometheus
+  ports:
+    - port: 9090
+      targetPort: 9090

--- a/k8s/qa/deployment.yaml
+++ b/k8s/qa/deployment.yaml
@@ -17,6 +17,10 @@ spec:
       labels:
         app: jcmcp-qa
         azure.workload.identity/use: "true"
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "8000"
     spec:
       serviceAccountName: jcmcp-workload-sa
       initContainers:


### PR DESCRIPTION
Second telemetry pass — visualization. In-cluster Grafana OSS + Prometheus instead of Azure Managed Grafana: zero Azure resources, zero monthly cost, no IAM changes; the managed offering stays as the upgrade path.

## What
`k8s/monitoring/` (new namespace `monitoring`):
- **Prometheus** — annotation-based pod discovery over `jcmcp`/`jcmcp-qa` (pods already annotated by #98), 30s interval, 7d retention, 2Gi PVC, RBAC scoped to pod get/list/watch
- **Grafana** — datasource + **jobContext Overview** dashboard provisioned from configmaps (dashboards live in git; UI edits don't silently drift): request rate & 5xx & latency by route template, work items by kind/status, work durations, LLM calls & tokens by model, uptime
- **Ingress** `grafana.jobcontext.ai` (cert-manager) — requires a GoDaddy CNAME `grafana → jobcontextmcp.eastus.cloudapp.azure.com`; until then `kubectl -n monitoring port-forward svc/grafana 3000:3000`

## Not in this PR (operator actions, after merge)
```
kubectl apply -f k8s/monitoring/prometheus.yaml
kubectl -n monitoring create secret generic grafana-admin \
  --from-literal=admin-user=admin \
  --from-literal=admin-password="$(openssl rand -base64 24)"
kubectl apply -f k8s/monitoring/grafana-dashboards.yaml -f k8s/monitoring/grafana.yaml
```
(The auto-mode permission gate correctly declined to let me mutate the cluster unreviewed — creating RBAC + a secret + a public ingress deserves a human eyeball. Password retrieval: `kubectl -n monitoring get secret grafana-admin -o jsonpath='{.data.admin-password}' | base64 -d`.)

Depends on #98 for the pods to actually serve /metrics; until then targets show as down, harmlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)