### PR TITLE
Promote qa → main: telemetry + chat-session fix + Grafana stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/version-1.2.0-blue" alt="Version 1.2.0"/>
-  <img src="https://img.shields.io/badge/tests-1375%20passing-brightgreen" alt="1375 tests passing"/>
+  <img src="https://img.shields.io/badge/tests-1386%20passing-brightgreen" alt="1386 tests passing"/>
   <a href="https://sonarcloud.io/component_measures?id=JustLikeFrank3_jobContextMCP&metric=coverage"><img src="https://sonarcloud.io/api/project_badges/measure?project=JustLikeFrank3_jobContextMCP&metric=coverage" alt="Coverage"/></a>
   <img src="https://img.shields.io/badge/tools-11%20domains%20%C2%B7%2085%20actions-informational" alt="11 domain tools, 85 actions"/>
   <img src="https://img.shields.io/badge/license-MIT-lightgrey" alt="MIT License"/>
@@ -35,7 +35,7 @@ Available as a **double-clickable desktop app** (macOS · Windows · Linux), a l
 | | |
 |---|---|
 | 11 domain tools (85 actions) | Resume + cover letter generation |
-| 1375 passing tests | Job fitment analysis with persona lenses |
+| 1386 passing tests | Job fitment analysis with persona lenses |
 | SQLite persistence + JSON fallback | Interview prep + debrief logging |
 | Local RAG semantic search | Outreach + relationship tracking |
 | Azure AKS deployment | Microsoft Entra ID authentication |

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -42,6 +42,25 @@ executor sends; **the row is the system of record**.
 
 Kinds registered today: `capture_url` (mobile share → import → assess → push).
 
+## Telemetry (P0, shipped alongside)
+
+Two complementary layers, still zero new infrastructure (`lib/metrics.py`):
+
+- **`GET /metrics`** — Prometheus text format from an in-process registry.
+  Instrumented: every HTTP request (`http_requests_total` /
+  `http_request_seconds`, labeled by route *template* to bound cardinality),
+  every work item (`work_items_total` / `work_item_seconds` by kind/status),
+  and every LLM call through the `create_chat_completion` funnel
+  (`llm_calls_total` by label/model/outcome, `llm_call_seconds`,
+  `llm_tokens_total` by direction). Aggregates only — no user data. The AKS
+  pods carry `prometheus.io/*` annotations for Azure Monitor's managed
+  Prometheus (enable pod-annotation scraping in
+  ama-metrics-settings-configmap to activate collection).
+- **`GET /api/work/stats`** — per-tenant JSON aggregates straight off the
+  work_items table (counts + avg duration by kind/status, recent failures
+  with error heads): the control plane doubling as its own telemetry source,
+  consumable by the dashboard, mobile, or Claude in chat.
+
 ## Roadmap
 
 - **P1 — document generation**: route assessment / interview-prep /

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -17,6 +17,13 @@ spec:
       labels:
         app: jcmcp
         azure.workload.identity/use: "true"
+      annotations:
+        # Azure Monitor managed Prometheus (ama-metrics) pod-annotation
+        # scraping — requires podannotationnamespaceregex to include this
+        # namespace in the ama-metrics-settings-configmap.
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "8000"
     spec:
       serviceAccountName: jcmcp-workload-sa
       initContainers:

--- a/k8s/monitoring/grafana-dashboards.yaml
+++ b/k8s/monitoring/grafana-dashboards.yaml
@@ -1,0 +1,245 @@
+# Provisioned dashboard: jobContext Overview. Edit the JSON here (dashboards
+# as code) — in-UI edits to this dashboard do not persist across restarts.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-jobcontext
+  namespace: monitoring
+data:
+  jobcontext-overview.json: |
+    {
+     "uid": "jobcontext-overview",
+     "title": "jobContext Overview",
+     "schemaVersion": 39,
+     "refresh": "30s",
+     "time": {
+      "from": "now-6h",
+      "to": "now"
+     },
+     "panels": [
+      {
+       "id": 1,
+       "title": "Request rate by route",
+       "type": "timeseries",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+       },
+       "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 12,
+        "h": 8
+       },
+       "fieldConfig": {
+        "defaults": {
+         "unit": "reqps"
+        },
+        "overrides": []
+       },
+       "targets": [
+        {
+         "expr": "sum(rate(http_requests_total[5m])) by (route)",
+         "legendFormat": "{{route}}",
+         "refId": "A"
+        }
+       ]
+      },
+      {
+       "id": 2,
+       "title": "5xx error rate",
+       "type": "timeseries",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+       },
+       "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 12,
+        "h": 8
+       },
+       "fieldConfig": {
+        "defaults": {
+         "unit": "reqps"
+        },
+        "overrides": []
+       },
+       "targets": [
+        {
+         "expr": "sum(rate(http_requests_total{status=~\"5..\"}[5m]))",
+         "legendFormat": "5xx",
+         "refId": "A"
+        }
+       ]
+      },
+      {
+       "id": 3,
+       "title": "Avg request latency by route",
+       "type": "timeseries",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+       },
+       "gridPos": {
+        "x": 0,
+        "y": 8,
+        "w": 12,
+        "h": 8
+       },
+       "fieldConfig": {
+        "defaults": {
+         "unit": "s"
+        },
+        "overrides": []
+       },
+       "targets": [
+        {
+         "expr": "rate(http_request_seconds_sum[5m]) / rate(http_request_seconds_count[5m])",
+         "legendFormat": "{{route}}",
+         "refId": "A"
+        }
+       ]
+      },
+      {
+       "id": 4,
+       "title": "Work items (1h) by kind/status",
+       "type": "timeseries",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+       },
+       "gridPos": {
+        "x": 12,
+        "y": 8,
+        "w": 12,
+        "h": 8
+       },
+       "fieldConfig": {
+        "defaults": {
+         "unit": "short"
+        },
+        "overrides": []
+       },
+       "targets": [
+        {
+         "expr": "sum(increase(work_items_total[1h])) by (kind, status)",
+         "legendFormat": "{{kind}} {{status}}",
+         "refId": "A"
+        }
+       ]
+      },
+      {
+       "id": 5,
+       "title": "Avg work-item duration",
+       "type": "timeseries",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+       },
+       "gridPos": {
+        "x": 0,
+        "y": 16,
+        "w": 12,
+        "h": 8
+       },
+       "fieldConfig": {
+        "defaults": {
+         "unit": "s"
+        },
+        "overrides": []
+       },
+       "targets": [
+        {
+         "expr": "rate(work_item_seconds_sum[15m]) / rate(work_item_seconds_count[15m])",
+         "legendFormat": "{{kind}} ({{outcome}})",
+         "refId": "A"
+        }
+       ]
+      },
+      {
+       "id": 6,
+       "title": "LLM calls by model/outcome",
+       "type": "timeseries",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+       },
+       "gridPos": {
+        "x": 12,
+        "y": 16,
+        "w": 12,
+        "h": 8
+       },
+       "fieldConfig": {
+        "defaults": {
+         "unit": "short"
+        },
+        "overrides": []
+       },
+       "targets": [
+        {
+         "expr": "sum(increase(llm_calls_total[1h])) by (model, outcome)",
+         "legendFormat": "{{model}} {{outcome}}",
+         "refId": "A"
+        }
+       ]
+      },
+      {
+       "id": 7,
+       "title": "LLM tokens/hour by direction",
+       "type": "timeseries",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+       },
+       "gridPos": {
+        "x": 0,
+        "y": 24,
+        "w": 12,
+        "h": 8
+       },
+       "fieldConfig": {
+        "defaults": {
+         "unit": "short"
+        },
+        "overrides": []
+       },
+       "targets": [
+        {
+         "expr": "sum(increase(llm_tokens_total[1h])) by (model, direction)",
+         "legendFormat": "{{model}} {{direction}}",
+         "refId": "A"
+        }
+       ]
+      },
+      {
+       "id": 8,
+       "title": "App uptime",
+       "type": "stat",
+       "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+       },
+       "gridPos": {
+        "x": 12,
+        "y": 24,
+        "w": 12,
+        "h": 8
+       },
+       "fieldConfig": {
+        "defaults": {
+         "unit": "s"
+        },
+        "overrides": []
+       },
+       "targets": [
+        {
+         "expr": "process_uptime_seconds",
+         "legendFormat": "{{pod}}",
+         "refId": "A"
+        }
+       ]
+      }
+     ]
+    }

--- a/k8s/monitoring/grafana.yaml
+++ b/k8s/monitoring/grafana.yaml
@@ -1,0 +1,149 @@
+# In-cluster Grafana OSS, fully provisioned as code: Prometheus datasource +
+# the jobContext overview dashboard (separate configmap, grafana-dashboards.yaml).
+#
+# Admin credentials come from the `grafana-admin` secret, created out-of-band
+# (never committed):
+#   kubectl -n monitoring create secret generic grafana-admin \
+#     --from-literal=admin-user=admin \
+#     --from-literal=admin-password="$(openssl rand -base64 24)"
+# Retrieve later:
+#   kubectl -n monitoring get secret grafana-admin \
+#     -o jsonpath='{.data.admin-password}' | base64 -d
+#
+# Reach it with:  kubectl -n monitoring port-forward svc/grafana 3000:3000
+# or via https://grafana.jobcontext.ai after adding the GoDaddy CNAME
+# (grafana → jobcontextmcp.eastus.cloudapp.azure.com).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-provisioning
+  namespace: monitoring
+data:
+  datasource.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        uid: prometheus
+        type: prometheus
+        access: proxy
+        url: http://prometheus.monitoring.svc:9090
+        isDefault: true
+  dashboards.yaml: |
+    apiVersion: 1
+    providers:
+      - name: jobcontext
+        folder: jobContext
+        type: file
+        options:
+          path: /var/lib/grafana/dashboards
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana-data
+  namespace: monitoring
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: managed-csi
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      securityContext:
+        fsGroup: 472    # grafana image user
+      containers:
+        - name: grafana
+          image: grafana/grafana:11.1.0
+          ports:
+            - containerPort: 3000
+          env:
+            - name: GF_SECURITY_ADMIN_USER
+              valueFrom:
+                secretKeyRef: { name: grafana-admin, key: admin-user }
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef: { name: grafana-admin, key: admin-password }
+            - name: GF_USERS_ALLOW_SIGN_UP
+              value: "false"
+            - name: GF_SERVER_ROOT_URL
+              value: https://grafana.jobcontext.ai
+          resources:
+            requests: { cpu: 50m, memory: 128Mi }
+            limits: { cpu: 500m, memory: 512Mi }
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/grafana
+            - name: provisioning-datasources
+              mountPath: /etc/grafana/provisioning/datasources
+            - name: provisioning-dashboards
+              mountPath: /etc/grafana/provisioning/dashboards
+            - name: dashboards
+              mountPath: /var/lib/grafana/dashboards
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: grafana-data
+        - name: provisioning-datasources
+          configMap:
+            name: grafana-provisioning
+            items: [{ key: datasource.yaml, path: datasource.yaml }]
+        - name: provisioning-dashboards
+          configMap:
+            name: grafana-provisioning
+            items: [{ key: dashboards.yaml, path: dashboards.yaml }]
+        - name: dashboards
+          configMap:
+            name: grafana-dashboard-jobcontext
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  selector:
+    app: grafana
+  ports:
+    - port: 3000
+      targetPort: 3000
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grafana
+  namespace: monitoring
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts: [grafana.jobcontext.ai]
+      secretName: grafana-tls
+  rules:
+    - host: grafana.jobcontext.ai
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: grafana
+                port:
+                  number: 3000

--- a/k8s/monitoring/prometheus.yaml
+++ b/k8s/monitoring/prometheus.yaml
@@ -1,0 +1,144 @@
+# In-cluster Prometheus — scrapes pods annotated prometheus.io/scrape=true
+# in the jcmcp and jcmcp-qa namespaces (the app exposes /metrics; see
+# lib/metrics.py and docs/control-plane.md → Telemetry).
+#
+# Deliberately tiny: one replica, 7d retention, 2Gi PVC. This is a viewing
+# cache, not the system of record (work_items is). Upgrade path: Azure
+# Monitor managed Prometheus + Azure Managed Grafana.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-pod-reader
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-pod-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-pod-reader
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: monitoring
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: monitoring
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 30s
+      evaluation_interval: 30s
+    scrape_configs:
+      - job_name: jobcontext-pods
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names: [jcmcp, jcmcp-qa]
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            action: keep
+            regex: "true"
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+            action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: pod
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prometheus-data
+  namespace: monitoring
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: managed-csi
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: monitoring
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate   # RWO volume — old pod must release it first
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      serviceAccountName: prometheus
+      securityContext:
+        fsGroup: 65534    # nobody — prometheus image runs unprivileged
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v2.53.0
+          args:
+            - --config.file=/etc/prometheus/prometheus.yml
+            - --storage.tsdb.path=/prometheus
+            - --storage.tsdb.retention.time=7d
+          ports:
+            - containerPort: 9090
+          resources:
+            requests: { cpu: 50m, memory: 256Mi }
+            limits: { cpu: 500m, memory: 512Mi }
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus
+            - name: data
+              mountPath: /prometheus
+      volumes:
+        - name: config
+          configMap:
+            name: prometheus-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: prometheus-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: monitoring
+spec:
+  selector:
+    app: prometheus
+  ports:
+    - port: 9090
+      targetPort: 9090

--- a/k8s/qa/deployment.yaml
+++ b/k8s/qa/deployment.yaml
@@ -17,6 +17,10 @@ spec:
       labels:
         app: jcmcp-qa
         azure.workload.identity/use: "true"
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "8000"
     spec:
       serviceAccountName: jcmcp-workload-sa
       initContainers:

--- a/lib/metrics.py
+++ b/lib/metrics.py
@@ -1,0 +1,129 @@
+"""Telemetry P0: an in-process metrics registry with Prometheus exposition.
+
+Counters and duration summaries, thread-safe, zero dependencies — the same
+constraint as the control plane (this module ships inside the frozen desktop
+sidecar too). The cloud's AKS cluster already runs Azure Monitor's managed
+Prometheus agents (ama-metrics); GET /metrics exposes the standard text
+format so scraping is a pod-annotation away. Locally it's a debugging page.
+
+What gets instrumented where:
+  - HTTP requests   → transport/http/app.py MetricsMiddleware
+                      http_requests_total / http_request_seconds{method,route,status}
+  - Work items      → lib/work.py dispatcher
+                      work_items_total / work_item_seconds{kind,status}
+  - LLM calls       → lib/openai_calls.create_chat_completion
+                      llm_calls_total{label,model,outcome}
+                      llm_call_seconds{label,model}
+                      llm_tokens_total{label,model,direction}
+
+Aggregates only — never user content, URLs, or identifiers. Route labels are
+route *templates* (/api/work/{item_id}), not raw paths, to bound cardinality.
+"""
+from __future__ import annotations
+
+import threading
+import time
+
+_LabelKey = tuple[str, tuple[tuple[str, str], ...]]
+
+_LOCK = threading.Lock()
+_COUNTERS: dict[_LabelKey, float] = {}
+_SUMMARIES: dict[_LabelKey, list[float]] = {}  # [count, sum]
+_STARTED_AT = time.time()
+
+
+def _key(name: str, labels: dict[str, str]) -> _LabelKey:
+    return name, tuple(sorted((k, str(v)) for k, v in labels.items()))
+
+
+def inc(name: str, amount: float = 1.0, **labels: str) -> None:
+    """Increment a counter."""
+    key = _key(name, labels)
+    with _LOCK:
+        _COUNTERS[key] = _COUNTERS.get(key, 0.0) + amount
+
+
+def observe(name: str, value: float, **labels: str) -> None:
+    """Record one observation into a summary (exposed as _count and _sum)."""
+    key = _key(name, labels)
+    with _LOCK:
+        entry = _SUMMARIES.setdefault(key, [0.0, 0.0])
+        entry[0] += 1
+        entry[1] += value
+
+
+def snapshot() -> dict:
+    """Plain-dict view for tests and debugging: one entry per label set."""
+    with _LOCK:
+        counters = [
+            {"name": name, "labels": dict(labels), "value": v}
+            for (name, labels), v in sorted(_COUNTERS.items())
+        ]
+        summaries = [
+            {"name": name, "labels": dict(labels), "count": e[0], "sum": e[1]}
+            for (name, labels), e in sorted(_SUMMARIES.items())
+        ]
+    return {"counters": counters, "summaries": summaries}
+
+
+def reset() -> None:
+    """Test hook: clear all series."""
+    with _LOCK:
+        _COUNTERS.clear()
+        _SUMMARIES.clear()
+
+
+def _escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def _fmt_labels(labels: tuple[tuple[str, str], ...]) -> str:
+    if not labels:
+        return ""
+    inner = ",".join(f'{k}="{_escape(v)}"' for k, v in labels)
+    return "{" + inner + "}"
+
+
+def render_prometheus() -> str:
+    """Render every series in the Prometheus text exposition format."""
+    lines: list[str] = [
+        "# TYPE process_uptime_seconds gauge",
+        f"process_uptime_seconds {time.time() - _STARTED_AT:.1f}",
+    ]
+    with _LOCK:
+        counter_names = sorted({name for name, _ in _COUNTERS})
+        for name in counter_names:
+            lines.append(f"# TYPE {name} counter")
+            for (n, labels), value in sorted(_COUNTERS.items()):
+                if n == name:
+                    lines.append(f"{name}{_fmt_labels(labels)} {value:g}")
+        summary_names = sorted({name for name, _ in _SUMMARIES})
+        for name in summary_names:
+            lines.append(f"# TYPE {name} summary")
+            for (n, labels), (count, total) in sorted(_SUMMARIES.items()):
+                if n == name:
+                    lines.append(f"{name}_count{_fmt_labels(labels)} {count:g}")
+                    lines.append(f"{name}_sum{_fmt_labels(labels)} {total:g}")
+    return "\n".join(lines) + "\n"
+
+
+class timed:  # noqa: N801 — context manager reads like a keyword
+    """Measure a block and record it: ``with metrics.timed("x_seconds", k=v): ...``
+
+    The ``outcome`` label is added automatically ("ok" or "error" by whether
+    the block raised) unless the caller supplied one.
+    """
+
+    def __init__(self, name: str, **labels: str) -> None:
+        self._name = name
+        self._labels = labels
+        self._start = 0.0
+
+    def __enter__(self) -> "timed":
+        self._start = time.monotonic()
+        return self
+
+    def __exit__(self, exc_type, _exc, _tb) -> None:
+        labels = dict(self._labels)
+        labels.setdefault("outcome", "error" if exc_type else "ok")
+        observe(self._name, time.monotonic() - self._start, **labels)

--- a/lib/openai_calls.py
+++ b/lib/openai_calls.py
@@ -7,6 +7,8 @@ import time
 from random import SystemRandom
 from typing import Any
 
+from lib import metrics
+
 _LOG = logging.getLogger(__name__)
 # Cryptographically-seeded RNG used only for retry-backoff jitter. Avoids the
 # non-secure global PRNG so static analysers don't flag it (Sonar S2245 / B311).
@@ -104,6 +106,12 @@ def create_chat_completion(client: Any, *, label: str = "chat", max_attempts: in
             except Exception as exc:
                 _LAST_CHAT_CALL = time.monotonic()
                 status_code = getattr(getattr(exc, "response", None), "status_code", None)
+                metrics.inc(
+                    "llm_calls_total",
+                    label=label,
+                    model=str(kwargs.get("model")),
+                    outcome=f"error_{status_code or 'network'}",
+                )
                 payload = _error_payload(exc)
                 _LOG.warning(
                     "openai.chat error label=%s attempt=%s status=%s requested_max_tokens=%s payload=%s",
@@ -158,6 +166,16 @@ def create_chat_completion(client: Any, *, label: str = "chat", max_attempts: in
             prompt_tokens = getattr(usage, "prompt_tokens", None) if usage else None
             completion_tokens = getattr(usage, "completion_tokens", None) if usage else None
             total_tokens = getattr(usage, "total_tokens", None) if usage else None
+            model = str(kwargs.get("model"))
+            metrics.inc("llm_calls_total", label=label, model=model, outcome="ok")
+            metrics.observe(
+                "llm_call_seconds", time.monotonic() - started, label=label, model=model)
+            if prompt_tokens:
+                metrics.inc("llm_tokens_total", float(prompt_tokens),
+                            label=label, model=model, direction="prompt")
+            if completion_tokens:
+                metrics.inc("llm_tokens_total", float(completion_tokens),
+                            label=label, model=model, direction="completion")
             _LOG.info(
                 "openai.chat usage label=%s attempt=%s elapsed=%.2fs model=%s requested_max_tokens=%s prompt_tokens=%s completion_tokens=%s total_tokens=%s",
                 label,

--- a/lib/work.py
+++ b/lib/work.py
@@ -30,6 +30,7 @@ import traceback
 from pathlib import Path
 from typing import Any, Callable
 
+from lib import metrics
 from lib.db import get_connection
 from lib.user_context import (
     get_data_folder_override,
@@ -187,13 +188,17 @@ def _execute(partition: "str | None", item_id: int) -> None:
 
     if fn is None:
         _finish("failed", error=f"no executor registered for kind '{kind}'")
+        metrics.inc("work_items_total", kind=kind, status="failed")
         return
     try:
-        artifacts = _in_partition(partition, lambda: fn(inputs))
+        with metrics.timed("work_item_seconds", kind=kind):
+            artifacts = _in_partition(partition, lambda: fn(inputs))
         _finish("succeeded", artifacts=artifacts if isinstance(artifacts, dict) else None)
+        metrics.inc("work_items_total", kind=kind, status="succeeded")
     except Exception as exc:  # noqa: BLE001 — outcome is the record, never a crash
         _log.exception("work item %s (%s) failed", item_id, kind)
         _finish("failed", error=f"{exc}\n{traceback.format_exc(limit=8)}")
+        metrics.inc("work_items_total", kind=kind, status="failed")
 
 
 async def _worker_loop() -> None:

--- a/services/chat_service.py
+++ b/services/chat_service.py
@@ -146,10 +146,6 @@ def _save_message(
 def _history_as_openai_messages(session_id: int) -> list[dict]:
     """Rebuild the OpenAI-shaped message list from stored rows (capped)."""
     rows = list_messages(session_id)[-MAX_HISTORY_MESSAGES:]
-    # Never start history with orphaned tool results (their assistant row was
-    # capped away) — providers reject tool messages with no matching call.
-    while rows and rows[0]["role"] == "tool":
-        rows.pop(0)
     messages: list[dict] = []
     for row in rows:
         if row["role"] == "assistant" and row["tool_calls"]:
@@ -170,7 +166,49 @@ def _history_as_openai_messages(session_id: int) -> list[dict]:
             )
         else:
             messages.append({"role": row["role"], "content": row["content"]})
-    return messages
+    return _repair_tool_pairing(messages)
+
+
+def _repair_tool_pairing(messages: list[dict]) -> list[dict]:
+    """Make replayed history provider-legal, whatever state it was saved in.
+
+    Providers hard-reject (400) two shapes that real crashes produce:
+      - an assistant message with tool_calls not followed by a tool result for
+        EVERY tool_call_id (turn died mid-execution → results never saved;
+        the session is then permanently poisoned without this repair)
+      - a tool result with no preceding matching call (its assistant row was
+        capped away, or the same interrupted turn saved out of order)
+
+    Missing results are synthesized as interruption notes; orphaned results
+    are dropped.
+    """
+    repaired: list[dict] = []
+    pending: set[str] = set()  # ids from the last assistant tool_calls still unanswered
+
+    def _flush_pending() -> None:
+        repaired.extend(
+            {
+                "role": "tool",
+                "tool_call_id": missing_id,
+                "content": "(tool execution was interrupted — no result was recorded)",
+            }
+            for missing_id in sorted(pending)
+        )
+        pending.clear()
+
+    for msg in messages:
+        if msg["role"] == "tool":
+            if msg.get("tool_call_id") in pending:
+                pending.discard(msg["tool_call_id"])
+                repaired.append(msg)
+            # else: orphaned result — drop it
+            continue
+        _flush_pending()  # any non-tool message closes the response window
+        if msg["role"] == "assistant" and msg.get("tool_calls"):
+            pending.update(tc["id"] for tc in msg["tool_calls"] if tc.get("id"))
+        repaired.append(msg)
+    _flush_pending()
+    return repaired
 
 
 # ── tool surface ───────────────────────────────────────────────────────────────

--- a/templates/latex_assets/sections/experience.tex
+++ b/templates/latex_assets/sections/experience.tex
@@ -5,7 +5,7 @@
 \subsection{{\textbf{Senior Software Engineer} \textit{\ \ Contoso Cloud, Remote} \hfill 20XX --- Present}}
 \begin{zitemize}
 \item Led design and delivery of a customer-facing service from architecture through production and on-call; quantify the impact here (latency, scale, revenue, or adoption).
-\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1375 passing tests at 80\%+ line coverage through disciplined TDD.
+\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1386 passing tests at 80\%+ line coverage through disciplined TDD.
 \item Drove a cross-team win — a migration, a shared API pattern others adopted, or an SLA target consistently met.
 \end{zitemize}
 %====================

--- a/tests/test_chat_service.py
+++ b/tests/test_chat_service.py
@@ -198,6 +198,56 @@ def test_history_replays_into_next_turn(mcp_instance):
     assert sent[2]["content"] == "Hi!"
 
 
+def test_dangling_tool_calls_get_synthesized_results(mcp_instance):
+    """A turn that died between saving the assistant tool_calls row and its
+    tool results permanently poisoned the session: every later replay was a
+    provider 400 ('tool_call_ids did not have response messages'). The repair
+    synthesizes interruption results so the session stays usable."""
+    sid = chat_service.create_session()
+    chat_service._save_message(sid, "user", "run something")
+    chat_service._save_message(
+        sid, "assistant", "",
+        tool_calls=[{"id": "toolu_dead", "type": "function",
+                     "function": {"name": "applications", "arguments": "{}"}}],
+    )
+    # no tool result row — the crash
+
+    client = FakeClient([_response(content="Recovered.")])
+    events = _run_turn(mcp_instance, sid, "Hello?", client)
+
+    assert any(e.type == "message" for e in events)
+    sent = client.requests[0]["messages"]
+    idx = next(i for i, m in enumerate(sent) if m["role"] == "assistant" and m.get("tool_calls"))
+    follow = sent[idx + 1]
+    assert follow["role"] == "tool" and follow["tool_call_id"] == "toolu_dead"
+    assert "interrupted" in follow["content"]
+
+
+def test_orphaned_tool_results_are_dropped():
+    """Tool results whose calls were capped away (or saved out of order) are
+    removed anywhere in history, not only at the head."""
+    messages = [
+        {"role": "tool", "tool_call_id": "gone", "content": "stale"},
+        {"role": "user", "content": "hi"},
+        {"role": "tool", "tool_call_id": "also-gone", "content": "stale"},
+        {"role": "assistant", "content": "hello"},
+    ]
+    repaired = chat_service._repair_tool_pairing(messages)
+    assert [m["role"] for m in repaired] == ["user", "assistant"]
+
+
+def test_well_formed_history_passes_through_unchanged():
+    messages = [
+        {"role": "user", "content": "go"},
+        {"role": "assistant", "content": None,
+         "tool_calls": [{"id": "a", "type": "function",
+                         "function": {"name": "x", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "a", "content": "done"},
+        {"role": "assistant", "content": "all set"},
+    ]
+    assert chat_service._repair_tool_pairing(list(messages)) == messages
+
+
 # ── HTTP endpoints (desktop-gated) ─────────────────────────────────────────────
 
 def test_chat_routes_absent_outside_desktop_mode(http_client_noauth):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,148 @@
+"""Telemetry P0 (lib/metrics.py + instrumentation + exposition).
+
+Covers the registry itself, the Prometheus text rendering, the HTTP
+middleware labels (route templates, not raw paths), work-dispatcher
+instrumentation, and the /api/work/stats aggregate surface.
+"""
+from __future__ import annotations
+
+import pytest
+
+from lib import metrics
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    metrics.reset()
+    yield
+    metrics.reset()
+
+
+def test_counters_accumulate_by_label_set():
+    metrics.inc("jobs_total", kind="a", status="ok")
+    metrics.inc("jobs_total", kind="a", status="ok")
+    metrics.inc("jobs_total", kind="b", status="failed")
+    text = metrics.render_prometheus()
+    assert 'jobs_total{kind="a",status="ok"} 2' in text
+    assert 'jobs_total{kind="b",status="failed"} 1' in text
+    assert "# TYPE jobs_total counter" in text
+
+
+def test_summaries_render_count_and_sum():
+    metrics.observe("x_seconds", 1.5, op="scan")
+    metrics.observe("x_seconds", 2.5, op="scan")
+    text = metrics.render_prometheus()
+    assert 'x_seconds_count{op="scan"} 2' in text
+    assert 'x_seconds_sum{op="scan"} 4' in text
+    assert "# TYPE x_seconds summary" in text
+
+
+def test_timed_records_outcome_label():
+    with metrics.timed("op_seconds", kind="k"):
+        pass
+    with pytest.raises(ValueError):  # noqa: PT012
+        with metrics.timed("op_seconds", kind="k"):
+            raise ValueError("boom")
+    text = metrics.render_prometheus()
+    assert 'op_seconds_count{kind="k",outcome="ok"} 1' in text
+    assert 'op_seconds_count{kind="k",outcome="error"} 1' in text
+
+
+def test_label_values_escaped():
+    metrics.inc("weird_total", path='say "hi"\nthere')
+    text = metrics.render_prometheus()
+    assert 'weird_total{path="say \\"hi\\"\\nthere"} 1' in text
+
+
+def test_work_execution_is_instrumented(tmp_path, monkeypatch):
+    import lib.config as cfg
+    from lib import work
+
+    monkeypatch.setattr(cfg, "DATA_FOLDER", str(tmp_path), raising=False)
+    saved = dict(work._KINDS)
+    try:
+        work.register_kind("noop", lambda i: {})
+        work.register_kind("bad", lambda i: (_ for _ in ()).throw(RuntimeError("x")))
+        ok_id = work.enqueue("noop", {})
+        bad_id = work.enqueue("bad", {})
+        work._execute(None, ok_id)
+        work._execute(None, bad_id)
+    finally:
+        work._KINDS.clear()
+        work._KINDS.update(saved)
+    text = metrics.render_prometheus()
+    assert 'work_items_total{kind="noop",status="succeeded"} 1' in text
+    assert 'work_items_total{kind="bad",status="failed"} 1' in text
+    assert 'work_item_seconds_count{kind="noop",outcome="ok"} 1' in text
+
+
+# ── HTTP surface ───────────────────────────────────────────────────────────────
+
+@pytest.fixture()
+def app_client(monkeypatch, tmp_path):
+    import lib.config as cfg_mod
+    from lib.user_provisioning import provision_user_data
+
+    root = tmp_path / "data"
+    root.mkdir()
+    monkeypatch.setattr(cfg_mod, "DATA_FOLDER", str(root), raising=False)
+    provision_user_data(root)
+    monkeypatch.delenv("API_KEY", raising=False)
+    from fastapi.testclient import TestClient
+    from transport.http.app import create_app
+    from transport.http.config import reset_settings_cache
+
+    reset_settings_cache()
+    with TestClient(create_app()) as client:
+        yield client
+    reset_settings_cache()
+
+
+def test_metrics_endpoint_exposes_request_series(app_client):
+    app_client.get("/api/work")           # counted, route template label
+    app_client.get("/api/work/424242")    # 404s also counted
+    text = app_client.get("/metrics").text
+    assert "# TYPE http_requests_total counter" in text
+    assert 'route="/api/work"' in text
+    # route template, never the raw path (cardinality + privacy)
+    assert 'route="/api/work/{item_id}"' in text
+    assert "424242" not in text
+    assert "process_uptime_seconds" in text
+
+
+def test_metrics_endpoint_does_not_count_itself(app_client):
+    app_client.get("/metrics")
+    text = app_client.get("/metrics").text
+    assert 'route="/metrics"' not in text
+
+
+def test_work_stats_aggregates(app_client, monkeypatch):
+    import time
+
+    from lib import work
+
+    monkeypatch.setitem(work._KINDS, "capture_url", lambda inputs: {})
+    ok = app_client.post("/api/capture", json={"url": "https://jobs.example.com/1"})
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        item = app_client.get(f"/api/work/{ok.json()['work_id']}").json()
+        if item["status"] == "succeeded":
+            break
+        time.sleep(0.05)
+    monkeypatch.setitem(
+        work._KINDS, "capture_url",
+        lambda inputs: (_ for _ in ()).throw(RuntimeError("scrape wall")),
+    )
+    bad = app_client.post("/api/capture", json={"url": "https://jobs.example.com/2"})
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        item = app_client.get(f"/api/work/{bad.json()['work_id']}").json()
+        if item["status"] == "failed":
+            break
+        time.sleep(0.05)
+
+    stats = app_client.get("/api/work/stats").json()
+    rows = {(r["kind"], r["status"]): r["count"] for r in stats["by_kind_status"]}
+    assert rows[("capture_url", "succeeded")] == 1
+    assert rows[("capture_url", "failed")] == 1
+    assert stats["recent_failures"][0]["error_head"].startswith("scrape wall")

--- a/transport/http/app.py
+++ b/transport/http/app.py
@@ -12,13 +12,14 @@ can connect to the remote server via type:"http" in mcp.json).
 """
 
 import logging
+import time
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, AsyncGenerator
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, HTMLResponse, RedirectResponse
+from fastapi.responses import FileResponse, HTMLResponse, PlainTextResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request as StarletteRequest
@@ -87,6 +88,33 @@ def _mount_spa(app: FastAPI) -> None:
     _logger.info("React SPA mounted at /app (dist=%s)", spa_dist)
 
 
+class MetricsMiddleware(BaseHTTPMiddleware):
+    """Time every request; label by method + route TEMPLATE (bounded
+    cardinality) + status. /metrics and /health are excluded as self-noise."""
+
+    async def dispatch(self, request: StarletteRequest, call_next):
+        from lib import metrics
+
+        path = request.url.path
+        if path in ("/metrics", "/health", "/healthz"):
+            return await call_next(request)
+        started = time.monotonic()
+        status = "500"  # if call_next raises, record the request as a 500
+        try:
+            response = await call_next(request)
+            status = str(response.status_code)
+            return response
+        finally:
+            route = request.scope.get("route")
+            route_path = getattr(route, "path", None) or "(unrouted)"
+            labels = {"method": request.method, "route": route_path, "status": status}
+            metrics.inc("http_requests_total", **labels)
+            metrics.observe(
+                "http_request_seconds", time.monotonic() - started,
+                method=request.method, route=route_path,
+            )
+
+
 class UserDataContextMiddleware(BaseHTTPMiddleware):
     """Starlette middleware that routes each authenticated request to the
     requesting user's own data partition under DATA_FOLDER/users/{oid}/.
@@ -121,6 +149,7 @@ class UserDataContextMiddleware(BaseHTTPMiddleware):
         _PUBLIC_PREFIXES = (
             "/.well-known/",
             "/health",
+            "/metrics",       # aggregate counters only — no user data (scraped by ama-metrics)
             "/oauth/",
             "/logout",
             "/setup",
@@ -245,6 +274,7 @@ def create_app(mcp: "FastMCP | None" = None) -> FastAPI:
     # Per-user data isolation for every authenticated request.
     # Registered first so it sits inside CORS (CORS must be outermost).
     app.add_middleware(UserDataContextMiddleware)
+    app.add_middleware(MetricsMiddleware)
 
     if settings.cors_origins:
         app.add_middleware(
@@ -282,6 +312,12 @@ def create_app(mcp: "FastMCP | None" = None) -> FastAPI:
     app.include_router(personas_routes.router)
     app.include_router(dashboard_api_router)  # /api/dashboard/* JSON for the React SPA
     app.include_router(dashboard_router)
+
+    @app.get("/metrics", include_in_schema=False)
+    async def _metrics() -> PlainTextResponse:
+        from lib import metrics
+
+        return PlainTextResponse(metrics.render_prometheus(), media_type="text/plain; version=0.0.4")
 
     @app.get("/", include_in_schema=False)
     async def _root_landing() -> HTMLResponse:

--- a/transport/http/routes/work.py
+++ b/transport/http/routes/work.py
@@ -28,6 +28,38 @@ async def work_list(
     return {"items": work.list_items(status=status, limit=limit)}
 
 
+@router.get("/stats")
+async def work_stats(
+    user: Annotated[User, Depends(require_authenticated_user)],  # noqa: ARG001
+) -> dict:
+    """Aggregates over the caller's work: counts, durations, recent failures.
+    Everything here is a GROUP BY over work_items — the control plane doubles
+    as its own telemetry source."""
+    from lib.db import get_connection
+
+    work._ensure_schema()
+    with get_connection() as con:
+        by_kind_status = [
+            dict(r)
+            for r in con.execute(
+                "SELECT kind, status, COUNT(*) AS count, "
+                "ROUND(AVG((julianday(finished_at) - julianday(started_at)) * 86400.0), 2) "
+                "  AS avg_seconds "
+                "FROM work_items GROUP BY kind, status ORDER BY kind, status"
+            ).fetchall()
+        ]
+        recent_failures = [
+            dict(r)
+            for r in con.execute(
+                "SELECT id, kind, finished_at, "
+                "substr(COALESCE(error, ''), 1, 200) AS error_head "
+                "FROM work_items WHERE status = 'failed' "
+                "ORDER BY id DESC LIMIT 5"
+            ).fetchall()
+        ]
+    return {"by_kind_status": by_kind_status, "recent_failures": recent_failures}
+
+
 @router.get("/{item_id}")
 async def work_get(
     item_id: int,


### PR DESCRIPTION
Promotes #101 (the combined train) to production:
- Telemetry P0 — /metrics (Prometheus format), request/work/LLM instrumentation, /api/work/stats, pod scrape annotations
- Desktop chat fix — histories poisoned by interrupted tool turns repair on replay; wedged sessions recover on next message (ships to desktop in beta.18)
- k8s/monitoring — in-cluster Prometheus + Grafana, dashboards as code (applied manually post-merge; commands in #100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)