### PR TITLE
Capture: failed imports become failed work rows with diagnosable reasons

### DIFF
--- a/tests/test_mobile_api.py
+++ b/tests/test_mobile_api.py
@@ -103,3 +103,80 @@ def test_capture_worker_failure_sends_push(monkeypatch):
     with _pytest.raises(RuntimeError):
         mobile_mod._capture_and_assess({"url": "https://jobs.example.com/9"})
     assert pushes and pushes[0][1]["type"] == "capture_failed"
+
+
+def test_failed_import_fails_work_row_with_one_push(monkeypatch):
+    """An unreadable posting must fail the work row with a diagnosable
+    one-liner (path + text length + scraper reason) — and send exactly ONE
+    push, not 'Import failed' followed by 'Assessment failed'."""
+    import pytest as _pytest
+
+    import tools.job_scraper as scraper_mod
+    import transport.http.routes.mobile as mobile_mod
+
+    pushes = []
+    monkeypatch.setattr(
+        mobile_mod, "send_push", lambda title, body, data=None: pushes.append(title)
+    )
+    monkeypatch.setattr(
+        scraper_mod, "scrape_job_url",
+        lambda url, auto_queue=True, page_text="": "LinkedIn blocked automated access to https://x",
+    )
+    with _pytest.raises(mobile_mod.CaptureImportError) as exc:
+        mobile_mod._capture_and_assess({"url": "https://www.linkedin.com/jobs/view/1"})
+    assert pushes == ["Import failed"]
+    msg = str(exc.value)
+    assert msg.startswith("import failed for https://www.linkedin.com/jobs/view/1")
+    assert "path=server-fetch" in msg and "page_text_len=0" in msg
+    assert "LinkedIn blocked" in msg
+
+
+def test_failed_import_records_client_text_path(monkeypatch):
+    import pytest as _pytest
+
+    import tools.job_scraper as scraper_mod
+    import transport.http.routes.mobile as mobile_mod
+
+    monkeypatch.setattr(mobile_mod, "send_push", lambda *a, **k: None)
+    monkeypatch.setattr(
+        scraper_mod, "scrape_job_url",
+        lambda url, auto_queue=True, page_text="": "Could not extract a job title from https://x.",
+    )
+    with _pytest.raises(mobile_mod.CaptureImportError) as exc:
+        mobile_mod._capture_and_assess(
+            {"url": "https://www.linkedin.com/jobs/view/2", "text": "junk " * 50}
+        )
+    assert "path=client-text" in str(exc.value)
+    assert "page_text_len=250" in str(exc.value)
+
+
+def test_failed_import_visible_in_work_api(mobile_client, monkeypatch):
+    """End to end: authwalled share → failed work row with readable error_head
+    in /api/work/stats. The row is the diagnosis; no log archaeology."""
+    import time
+
+    import transport.http.routes.mobile as mobile_mod
+
+    monkeypatch.setattr(mobile_mod, "send_push", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "httpx.get",
+        lambda *a, **kw: type("R", (), {"text": "<html>authwall</html>", "status_code": 200,
+                                        "raise_for_status": lambda self: None})(),
+    )
+    resp = mobile_client.post(
+        "/api/capture", json={"url": "https://www.linkedin.com/jobs/view/3"}
+    )
+    work_id = resp.json()["work_id"]
+    deadline = time.time() + 5
+    item = {}
+    while time.time() < deadline:
+        item = mobile_client.get(f"/api/work/{work_id}").json()
+        if item.get("status") in ("failed", "succeeded"):
+            break
+        time.sleep(0.05)
+    assert item["status"] == "failed"
+    assert item["error"].startswith("import failed for https://www.linkedin.com/jobs/view/3")
+
+    stats = mobile_client.get("/api/work/stats").json()
+    heads = [f["error_head"] for f in stats["recent_failures"]]
+    assert any(h.startswith("import failed for") for h in heads)

--- a/transport/http/routes/mobile.py
+++ b/transport/http/routes/mobile.py
@@ -176,6 +176,11 @@ class CaptureRequest(BaseModel):
     text: str = ""   # client-extracted page content (or pasted JD text)
 
 
+class CaptureImportError(Exception):
+    """Import produced no usable posting — raised so the work row records a
+    diagnosable failure instead of a 'succeeded' row with imported=False."""
+
+
 def _capture_and_assess(inputs: dict) -> dict:
     """Work executor (kind=capture_url): import → queue → assess → push.
 
@@ -187,6 +192,8 @@ def _capture_and_assess(inputs: dict) -> dict:
     url = inputs["url"]
     try:
         return _capture_and_assess_inner(url, inputs.get("text", ""))
+    except CaptureImportError:
+        raise  # "Import failed" push already sent — no second push
     except Exception:  # noqa: BLE001 — the user is waiting on a push either way
         _log.exception("capture worker failed for %s", url)
         send_push(
@@ -211,7 +218,12 @@ def _capture_and_assess_inner(url: str, text: str = "") -> dict:
             role = line.split(":", 1)[1].strip()
     if not company:
         send_push("Import failed", "Couldn't read that job posting.", {"type": "capture_failed"})
-        return {"imported": False}
+        # The scraper result is a status/error string (never page content).
+        reason = (str(result).strip().splitlines() or ["scraper returned empty result"])[0][:200]
+        path = "client-text" if text.strip() else "server-fetch"
+        raise CaptureImportError(
+            f"import failed for {url}: path={path}, page_text_len={len(text)}, reason: {reason}"
+        )
 
     from lib.db import get_connection
 


### PR DESCRIPTION
Backend half of the approved LinkedIn-capture fix plan (mobile half ships on feat/mobile-app as the next TestFlight build).

**Problem:** an unreadable posting pushed "Import failed" but recorded a *succeeded* work item (`{"imported": False}`), so the work table couldn't answer the one question that mattered during this week's two LinkedIn incidents: did the phone send extracted text, and what exactly did the scraper say?

**Fix:** `CaptureImportError` raised after the single failure push. The work row fails with a one-liner at the top of `error` — `import failed for <url>: path=client-text|server-fetch, page_text_len=N, reason: <scraper status line>` — surfaced verbatim by `/api/work/stats` as `error_head`. Except-ordering in `_capture_and_assess` guarantees no second push. Reason strings are scraper status messages, never page content.

**Semantics note:** capture failures now count as `failed` in `/api/work/stats` and Grafana `work_items_total` — an intended step change; nothing consumes `artifacts.imported == False` (grep-verified).

Tests: one-push guarantee, both path labels, end-to-end authwalled share → failed row → readable `error_head`. Full suite **1406 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)