### PR TITLE
Promote qa → main: capture failure diagnostics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,92 @@
+# jobContextMCP — working notes for Claude
+
+Job-search copilot: Python MCP server (FastAPI + FastMCP, SQLite, React
+dashboard) shipping three ways — **cloud** (multi-tenant on AKS,
+jobcontext.ai), **desktop** (Tauri 2 shell + PyInstaller sidecar, BYOK), and
+**mobile** (Expo companion app in `mobile/`, share-sheet capture). Philosophy:
+*desktop creates knowledge, mobile captures reality, cloud synchronizes.*
+
+## Process (non-negotiable)
+
+Feature work goes **branch → PR → qa → main**. Never commit directly to main;
+promotion is a `qa → main` PR after the qa deploy is green. Direct-to-main
+only when Frank explicitly says so for that specific change. Frank merges PRs
+unless he delegates it in the moment.
+
+CI triggers: Desktop CI (build matrix) runs on push to `feat/*` and `fix/*` —
+**a renamed branch fires no push event** (use `gh workflow run` to dispatch).
+`deploy.yml` runs on qa/main pushes (tests + Sonar + AKS deploy);
+paths-ignore includes `**.md` and `mobile/**`. Desktop releases: tag
+`desktop-v*` **on the exact tested main SHA** (badge-bot pushes `[skip ci]`
+commits — never tag those) → desktop-release workflow → rolling
+`desktop-latest` release hosts the updater's latest.json.
+
+## Architecture landmarks
+
+- **Partitioning**: every tenant's data lives under `DATA_FOLDER/users/{oid}`.
+  Per-request routing via contextvars (`lib/user_context.py`, middleware in
+  `transport/http/app.py`). NEVER offload work with bare `run_in_executor` —
+  contextvars don't propagate (caused a prod incident). Background work goes
+  through the control plane.
+- **Control plane** (`lib/work.py`, docs/control-plane.md): durable
+  `work_items` rows + in-process dispatcher; executors get partition context
+  FROM THE ROW. Status: `GET /api/work`, `/api/work/stats`. First kind:
+  `capture_url`. P1 (route doc generation through it) is task backlog.
+- **Sync**: journal-based bidirectional (lib/sync.py), AFTER-triggers into
+  `sync_log`; upsert tables LWW by ts; file sync by sha256 manifest.
+- **Telemetry**: `lib/metrics.py` (no deps) → `GET /metrics` (Prometheus);
+  in-cluster Prometheus+Grafana under `k8s/monitoring/` (dashboards as code).
+- **LLM calls** all funnel through `lib/openai_calls.create_chat_completion`
+  (rate-spacing, 429/400 retries, thinking-budget empty-at-cap retry).
+  Provider resolution: `lib/config.get_llm_client()`; status surfaces use
+  `llm_generation_status()` — keep them in lockstep.
+- **MCP surface**: 11 consolidated domain tools (`tools/consolidated.py`).
+  The facade-coverage test fails if an underlying tool grows a param the
+  facade doesn't expose — update the facade signature.
+
+## Test & CI gotchas
+
+- `tests/conftest.py` autouse fixture stubs `lib.config.get_llm_client` to
+  `(None, None)` — code needing real key-resolution truth in tests must not
+  call it.
+- CI's test env sets `LLM_PROVIDER=foundry` — provider-sensitive tests must
+  `monkeypatch.delenv("LLM_PROVIDER")`. Run suites both ways when touching
+  provider logic.
+- `isolated_server` fixture is canonical isolation; static module-level path
+  constants (e.g. `INTERVIEWS_FILE`) are computed at import — repoint them.
+- Sonar quality gate: ≥80% coverage on new code; S107 excluded for
+  tools/consolidated.py (wide signatures ARE the schema).
+
+## Desktop specifics
+
+- Frozen processes NEVER write beside the executable; config lives in
+  app-data (`JOBCONTEXT_CONFIG` env / `desktop_data_dir()`); read paths must
+  match write paths (two incidents from this).
+- macOS: rcodesign two-pass (sidecar with runtime+entitlements, then whole
+  app with --exclude), notarize via rcodesign; updater `.app.tar.gz` built
+  AFTER signing; TAURI_SIGNING_* env-only.
+- Windows: sidecar is console-subsystem (stdout carries the port handshake) —
+  spawn with `CREATE_NO_WINDOW`. Installer is unsigned → SmartScreen warning
+  (task: Azure Trusted Signing). Windows-illegal filename chars (`|` etc.)
+  from Mac-created files break sync file-pull (open task).
+
+## Mobile specifics (mobile/, branch feat/mobile-app)
+
+- Expo SDK 57 / RN 0.86; `eas init/build` sometimes re-adds a duplicate
+  ShareExtension block under `app.json` `extra.eas.build` — strip it.
+  eas-cli must NOT be a project dep (`npx eas-cli`). ascAppId pinned in
+  eas.json. Build from feat/mobile-app so eas.json is correct.
+- Share capture: on-device page extraction (`src/pageExtract.ts`) — the phone
+  reads pages that authwall datacenter IPs; server fallback in
+  tools/job_scraper.py (jobs-guest fragment). LinkedIn dropped JSON-LD from
+  many job pages; the parser reads top-card markup. Raw linkedin.com URLs
+  can still extract empty on-device (WebView escalation is the next step).
+- Auth: Entra via the cloud's own OAuth proxy (dynamic client registration,
+  PKCE); refresh is single-flight (rotating refresh tokens).
+
+## Where the history lives
+
+Design docs in `docs/` (control-plane.md is the roadmap). PR descriptions
+carry incident post-mortems (#90 partition escape, #99 chat poisoning,
+#108 capture success-detection). The work_items table + Grafana are the
+first stops for "what happened" — not pod logs.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/version-1.2.0-blue" alt="Version 1.2.0"/>
-  <img src="https://img.shields.io/badge/tests-1389%20passing-brightgreen" alt="1389 tests passing"/>
+  <img src="https://img.shields.io/badge/tests-1395%20passing-brightgreen" alt="1395 tests passing"/>
   <a href="https://sonarcloud.io/component_measures?id=JustLikeFrank3_jobContextMCP&metric=coverage"><img src="https://sonarcloud.io/api/project_badges/measure?project=JustLikeFrank3_jobContextMCP&metric=coverage" alt="Coverage"/></a>
   <img src="https://img.shields.io/badge/tools-11%20domains%20%C2%B7%2085%20actions-informational" alt="11 domain tools, 85 actions"/>
   <img src="https://img.shields.io/badge/license-MIT-lightgrey" alt="MIT License"/>
@@ -35,7 +35,7 @@ Available as a **double-clickable desktop app** (macOS · Windows · Linux), a l
 | | |
 |---|---|
 | 11 domain tools (85 actions) | Resume + cover letter generation |
-| 1389 passing tests | Job fitment analysis with persona lenses |
+| 1395 passing tests | Job fitment analysis with persona lenses |
 | SQLite persistence + JSON fallback | Interview prep + debrief logging |
 | Local RAG semantic search | Outreach + relationship tracking |
 | Azure AKS deployment | Microsoft Entra ID authentication |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/version-1.2.0-blue" alt="Version 1.2.0"/>
-  <img src="https://img.shields.io/badge/tests-1386%20passing-brightgreen" alt="1386 tests passing"/>
+  <img src="https://img.shields.io/badge/tests-1389%20passing-brightgreen" alt="1389 tests passing"/>
   <a href="https://sonarcloud.io/component_measures?id=JustLikeFrank3_jobContextMCP&metric=coverage"><img src="https://sonarcloud.io/api/project_badges/measure?project=JustLikeFrank3_jobContextMCP&metric=coverage" alt="Coverage"/></a>
   <img src="https://img.shields.io/badge/tools-11%20domains%20%C2%B7%2085%20actions-informational" alt="11 domain tools, 85 actions"/>
   <img src="https://img.shields.io/badge/license-MIT-lightgrey" alt="MIT License"/>
@@ -35,7 +35,7 @@ Available as a **double-clickable desktop app** (macOS · Windows · Linux), a l
 | | |
 |---|---|
 | 11 domain tools (85 actions) | Resume + cover letter generation |
-| 1386 passing tests | Job fitment analysis with persona lenses |
+| 1389 passing tests | Job fitment analysis with persona lenses |
 | SQLite persistence + JSON fallback | Interview prep + debrief logging |
 | Local RAG semantic search | Outreach + relationship tracking |
 | Azure AKS deployment | Microsoft Entra ID authentication |

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -59,11 +59,20 @@ fn spawn_backend(app: &tauri::AppHandle) -> Result<Backend, String> {
     // --parent-watchdog exits on stdin EOF, so even a SIGKILL to this shell
     // (which fires no Tauri exit event) can't orphan the backend against the
     // SQLite file.
-    let mut child = Command::new(&bin)
-        .arg("--parent-watchdog")
+    let mut cmd = Command::new(&bin);
+    cmd.arg("--parent-watchdog")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    // The sidecar is a console-subsystem exe (its stdout carries the port
+    // handshake). Without CREATE_NO_WINDOW, Windows materializes a visible
+    // terminal alongside the app.
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+    }
+    let mut child = cmd
         .spawn()
         .map_err(|e| format!("failed to spawn {bin:?}: {e}"))?;
 

--- a/frontend/src/screens/Settings.jsx
+++ b/frontend/src/screens/Settings.jsx
@@ -766,7 +766,7 @@ export default function Settings() {
       <SectionHead title="Integrations" />
       <Panel style={{ marginBottom: 20 }}>
         <div style={{ display: 'grid', gap: 10 }}>
-          <StatusRow label="AI generation (OpenAI key)" ok={data?.openaiKeySet} okText="configured" offText="not set">
+          <StatusRow label={`AI generation${data?.aiProvider ? ` (${data.aiProvider})` : ''}`} ok={data?.openaiKeySet} okText="configured" offText="not set">
             Enables resume generation, cover letter drafting, and semantic search.
           </StatusRow>
           <StatusRow label="Oura Ring" ok={data?.ouraConnected} okText="connected" offText="not connected">

--- a/lib/config.py
+++ b/lib/config.py
@@ -363,12 +363,15 @@ def get_active_master_resume_path() -> Path:
 
 # ── LLM client factory ────────────────────────────────────────────────────────
 
-def llm_generation_status() -> "tuple[str, bool]":
+def llm_generation_status(cfg: "dict | None" = None) -> "tuple[str, bool]":
     """(provider, ready) — mirrors get_llm_client()'s per-provider key
     resolution WITHOUT constructing a client, for status surfaces (Settings
     badge, check_workspace). Keep in lockstep with get_llm_client below.
+    Pass *cfg* to report on a specific config dict (e.g. a file being
+    described) instead of the active runtime config.
     """
-    cfg = get_active_config()
+    if cfg is None:
+        cfg = get_active_config()
     provider = str(cfg.get("llm_provider", "openai")).lower()
     provider = os.environ.get("LLM_PROVIDER", provider).lower()
     env_key = str(os.environ.get("LLM_API_KEY", "") or "").strip()

--- a/lib/config.py
+++ b/lib/config.py
@@ -363,6 +363,26 @@ def get_active_master_resume_path() -> Path:
 
 # ── LLM client factory ────────────────────────────────────────────────────────
 
+def llm_generation_status() -> "tuple[str, bool]":
+    """(provider, ready) — mirrors get_llm_client()'s per-provider key
+    resolution WITHOUT constructing a client, for status surfaces (Settings
+    badge, check_workspace). Keep in lockstep with get_llm_client below.
+    """
+    cfg = get_active_config()
+    provider = str(cfg.get("llm_provider", "openai")).lower()
+    provider = os.environ.get("LLM_PROVIDER", provider).lower()
+    env_key = str(os.environ.get("LLM_API_KEY", "") or "").strip()
+    if provider == "ollama":
+        return provider, True  # local endpoint, no key needed
+    if provider == "anthropic":
+        return provider, bool(env_key or str(cfg.get("anthropic_api_key", "") or "").strip())
+    if provider == "foundry":
+        # Endpoint is the hard requirement; the key can come from workload
+        # identity (DefaultAzureCredential) in AKS.
+        return provider, bool(str(cfg.get("azure_foundry_endpoint", "") or "").strip())
+    return provider, bool(env_key or str(cfg.get("openai_api_key", "") or "").strip())
+
+
 def get_llm_client(task: str = "") -> tuple[Any, str]:  # NOSONAR
     """Return (openai_client, model_name) for the configured LLM provider.
 

--- a/packaging/pyinstaller/jobcontext-backend.spec
+++ b/packaging/pyinstaller/jobcontext-backend.spec
@@ -29,6 +29,10 @@ ROOT = os.path.abspath(os.path.join(SPECPATH, "..", ".."))  # noqa: F821 — SPE
 datas = [
     (os.path.join(ROOT, "templates"), "templates"),
     (os.path.join(ROOT, "frontend", "dist"), os.path.join("frontend", "dist")),
+    # Favicons/og-images served by transport/http/app.py from a path relative
+    # to the module — must travel into the bundle or every browser/webview
+    # favicon request errors in the frozen app (Windows field report).
+    (os.path.join(ROOT, "transport", "http", "static"), os.path.join("transport", "http", "static")),
 ]
 
 hiddenimports = [

--- a/templates/latex_assets/sections/experience.tex
+++ b/templates/latex_assets/sections/experience.tex
@@ -5,7 +5,7 @@
 \subsection{{\textbf{Senior Software Engineer} \textit{\ \ Contoso Cloud, Remote} \hfill 20XX --- Present}}
 \begin{zitemize}
 \item Led design and delivery of a customer-facing service from architecture through production and on-call; quantify the impact here (latency, scale, revenue, or adoption).
-\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1386 passing tests at 80\%+ line coverage through disciplined TDD.
+\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1389 passing tests at 80\%+ line coverage through disciplined TDD.
 \item Drove a cross-team win — a migration, a shared API pattern others adopted, or an SLA target consistently met.
 \end{zitemize}
 %====================

--- a/templates/latex_assets/sections/experience.tex
+++ b/templates/latex_assets/sections/experience.tex
@@ -5,7 +5,7 @@
 \subsection{{\textbf{Senior Software Engineer} \textit{\ \ Contoso Cloud, Remote} \hfill 20XX --- Present}}
 \begin{zitemize}
 \item Led design and delivery of a customer-facing service from architecture through production and on-call; quantify the impact here (latency, scale, revenue, or adoption).
-\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1389 passing tests at 80\%+ line coverage through disciplined TDD.
+\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1395 passing tests at 80\%+ line coverage through disciplined TDD.
 \item Drove a cross-team win — a migration, a shared API pattern others adopted, or an SLA target consistently met.
 \end{zitemize}
 %====================

--- a/tests/test_dashboard_coverage.py
+++ b/tests/test_dashboard_coverage.py
@@ -842,12 +842,14 @@ class TestDashboardSettingsApiCoverage:
         monkeypatch.setattr(
             dashboard_api_routes, "_load_oura", lambda: {"readiness_score": 70}
         )
+        monkeypatch.delenv("LLM_PROVIDER", raising=False)  # CI sets foundry
 
         response = http_client_noauth.get("/api/dashboard/settings")
         assert response.status_code == 200
         assert response.json() == {
             "isOwner": True,
             "openaiKeySet": True,
+            "aiProvider": "openai",
             "ouraConfigured": True,
             "ouraConnected": True,
             "ouraViaSync": False,
@@ -911,6 +913,7 @@ class TestOpenAiKeySetHelper:
         import lib.config as config
 
         monkeypatch.delenv("LLM_API_KEY", raising=False)
+        monkeypatch.delenv("LLM_PROVIDER", raising=False)  # CI sets foundry
         monkeypatch.setattr(config, "get_active_config", lambda: {"openai_api_key": "sk-abc"})
         assert dashboard_api_routes._openai_key_set() is True
 
@@ -918,6 +921,7 @@ class TestOpenAiKeySetHelper:
         import lib.config as config
 
         monkeypatch.setenv("LLM_API_KEY", "env-provided-key")
+        monkeypatch.delenv("LLM_PROVIDER", raising=False)  # CI sets foundry
         monkeypatch.setattr(config, "get_active_config", lambda: {})
         assert dashboard_api_routes._openai_key_set() is True
 
@@ -925,6 +929,7 @@ class TestOpenAiKeySetHelper:
         import lib.config as config
 
         monkeypatch.delenv("LLM_API_KEY", raising=False)
+        monkeypatch.delenv("LLM_PROVIDER", raising=False)  # CI sets foundry
         monkeypatch.setattr(config, "get_active_config", lambda: {"openai_api_key": "   "})
         assert dashboard_api_routes._openai_key_set() is False
 

--- a/tests/test_dashboard_coverage.py
+++ b/tests/test_dashboard_coverage.py
@@ -933,6 +933,37 @@ class TestOpenAiKeySetHelper:
         monkeypatch.setattr(config, "get_active_config", lambda: {"openai_api_key": "   "})
         assert dashboard_api_routes._openai_key_set() is False
 
+    def test_provider_branches(self, monkeypatch):
+        """llm_generation_status must report each provider's own readiness:
+        anthropic by anthropic_api_key, ollama always (local endpoint),
+        foundry by endpoint (key may come from workload identity)."""
+        import lib.config as config
+
+        monkeypatch.delenv("LLM_API_KEY", raising=False)
+        monkeypatch.delenv("LLM_PROVIDER", raising=False)
+
+        cases = [
+            ({"llm_provider": "anthropic", "anthropic_api_key": "sk-ant"}, ("anthropic", True)),
+            ({"llm_provider": "anthropic", "openai_api_key": "sk-abc"}, ("anthropic", False)),
+            ({"llm_provider": "ollama"}, ("ollama", True)),
+            ({"llm_provider": "foundry", "azure_foundry_endpoint": "https://x.ai"}, ("foundry", True)),
+            ({"llm_provider": "foundry"}, ("foundry", False)),
+        ]
+        for cfg, expected in cases:
+            monkeypatch.setattr(config, "get_active_config", lambda c=cfg: c)
+            assert config.llm_generation_status() == expected, cfg
+
+    def test_env_provider_overrides_config(self, monkeypatch):
+        import lib.config as config
+
+        monkeypatch.delenv("LLM_API_KEY", raising=False)
+        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+        monkeypatch.setattr(
+            config, "get_active_config",
+            lambda: {"llm_provider": "openai", "anthropic_api_key": "sk-ant"},
+        )
+        assert config.llm_generation_status() == ("anthropic", True)
+
     def test_false_and_safe_on_config_error(self, monkeypatch):
         import lib.config as config
 

--- a/tests/test_mobile_api.py
+++ b/tests/test_mobile_api.py
@@ -180,3 +180,77 @@ def test_failed_import_visible_in_work_api(mobile_client, monkeypatch):
     stats = mobile_client.get("/api/work/stats").json()
     heads = [f["error_head"] for f in stats["recent_failures"]]
     assert any(h.startswith("import failed for") for h in heads)
+
+
+def test_successful_import_parses_queue_result(monkeypatch):
+    """Regression for the never-worked success path: queue_job returns
+    "Scraped <url>\n→ Queued: {company} — {role}. Run evaluate_queued_job…"
+    and the worker must extract company/role from THAT (it used to scan for
+    "company:"/"role:" lines that never existed, so every good import pushed
+    "Import failed" and skipped its assessment — 2026-07-10 field report,
+    verified against real work rows)."""
+    import tools.job_scraper as scraper_mod
+    import transport.http.routes.mobile as mobile_mod
+
+    pushes = []
+    monkeypatch.setattr(
+        mobile_mod, "send_push", lambda title, body, data=None: pushes.append(title)
+    )
+    monkeypatch.setattr(
+        scraper_mod, "scrape_job_url",
+        lambda url, auto_queue=True, page_text="": (
+            "Scraped " + url + "\n"
+            "→ Queued: Elevance Health — Senior AI Solutions Engineer (Engineer Senior). "
+            "Run evaluate_queued_job to assess fitment before deciding."
+        ),
+    )
+    ran = {}
+
+    def fake_assess(company, role, jd):
+        ran.update(company=company, role=role)
+        return "## Fitment: 8/10"
+
+    monkeypatch.setattr("tools.fitment.run_job_assessment", fake_assess)
+    monkeypatch.setattr(
+        "lib.db.get_connection",
+        lambda: __import__("contextlib").nullcontext(
+            type("C", (), {"execute": lambda self, *a: type("R", (), {"fetchone": lambda s: None})()})()
+        ),
+    )
+
+    out = mobile_mod._capture_and_assess(
+        {"url": "https://careers.elevancehealth.com/x/job/ABC?source=LinkedIn", "text": "# jd"}
+    )
+    assert out["imported"] is True
+    assert out["company"] == "Elevance Health"
+    assert out["role"] == "Senior AI Solutions Engineer (Engineer Senior)"
+    assert ran["company"] == "Elevance Health"  # assessment actually ran
+    assert len(pushes) == 1
+    assert pushes[0].startswith("Assessment complete") and "8/10" in pushes[0]
+
+
+def test_already_queued_variant_still_assesses(monkeypatch):
+    """Re-sharing a job (dedupe path) must also read as success and re-assess."""
+    import tools.job_scraper as scraper_mod
+    import transport.http.routes.mobile as mobile_mod
+
+    monkeypatch.setattr(mobile_mod, "send_push", lambda *a, **k: None)
+    monkeypatch.setattr(
+        scraper_mod, "scrape_job_url",
+        lambda url, auto_queue=True, page_text="": (
+            "Scraped " + url + "\n"
+            "→ Already queued: Cox Automotive — Senior Platform Engineer (status: pending). "
+            "Use evaluate_queued_job to assess it."
+        ),
+    )
+    monkeypatch.setattr(
+        "tools.fitment.run_job_assessment", lambda c, r, jd: "Score: 9/10 overall"
+    )
+    monkeypatch.setattr(
+        "lib.db.get_connection",
+        lambda: __import__("contextlib").nullcontext(
+            type("C", (), {"execute": lambda self, *a: type("R", (), {"fetchone": lambda s: None})()})()
+        ),
+    )
+    out = mobile_mod._capture_and_assess({"url": "https://x.example/1"})
+    assert out["imported"] is True and out["company"] == "Cox Automotive"

--- a/tests/test_mobile_api.py
+++ b/tests/test_mobile_api.py
@@ -103,3 +103,80 @@ def test_capture_worker_failure_sends_push(monkeypatch):
     with _pytest.raises(RuntimeError):
         mobile_mod._capture_and_assess({"url": "https://jobs.example.com/9"})
     assert pushes and pushes[0][1]["type"] == "capture_failed"
+
+
+def test_failed_import_fails_work_row_with_one_push(monkeypatch):
+    """An unreadable posting must fail the work row with a diagnosable
+    one-liner (path + text length + scraper reason) — and send exactly ONE
+    push, not 'Import failed' followed by 'Assessment failed'."""
+    import pytest as _pytest
+
+    import tools.job_scraper as scraper_mod
+    import transport.http.routes.mobile as mobile_mod
+
+    pushes = []
+    monkeypatch.setattr(
+        mobile_mod, "send_push", lambda title, body, data=None: pushes.append(title)
+    )
+    monkeypatch.setattr(
+        scraper_mod, "scrape_job_url",
+        lambda url, auto_queue=True, page_text="": "LinkedIn blocked automated access to https://x",
+    )
+    with _pytest.raises(mobile_mod.CaptureImportError) as exc:
+        mobile_mod._capture_and_assess({"url": "https://www.linkedin.com/jobs/view/1"})
+    assert pushes == ["Import failed"]
+    msg = str(exc.value)
+    assert msg.startswith("import failed for https://www.linkedin.com/jobs/view/1")
+    assert "path=server-fetch" in msg and "page_text_len=0" in msg
+    assert "LinkedIn blocked" in msg
+
+
+def test_failed_import_records_client_text_path(monkeypatch):
+    import pytest as _pytest
+
+    import tools.job_scraper as scraper_mod
+    import transport.http.routes.mobile as mobile_mod
+
+    monkeypatch.setattr(mobile_mod, "send_push", lambda *a, **k: None)
+    monkeypatch.setattr(
+        scraper_mod, "scrape_job_url",
+        lambda url, auto_queue=True, page_text="": "Could not extract a job title from https://x.",
+    )
+    with _pytest.raises(mobile_mod.CaptureImportError) as exc:
+        mobile_mod._capture_and_assess(
+            {"url": "https://www.linkedin.com/jobs/view/2", "text": "junk " * 50}
+        )
+    assert "path=client-text" in str(exc.value)
+    assert "page_text_len=250" in str(exc.value)
+
+
+def test_failed_import_visible_in_work_api(mobile_client, monkeypatch):
+    """End to end: authwalled share → failed work row with readable error_head
+    in /api/work/stats. The row is the diagnosis; no log archaeology."""
+    import time
+
+    import transport.http.routes.mobile as mobile_mod
+
+    monkeypatch.setattr(mobile_mod, "send_push", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "httpx.get",
+        lambda *a, **kw: type("R", (), {"text": "<html>authwall</html>", "status_code": 200,
+                                        "raise_for_status": lambda self: None})(),
+    )
+    resp = mobile_client.post(
+        "/api/capture", json={"url": "https://www.linkedin.com/jobs/view/3"}
+    )
+    work_id = resp.json()["work_id"]
+    deadline = time.time() + 5
+    item = {}
+    while time.time() < deadline:
+        item = mobile_client.get(f"/api/work/{work_id}").json()
+        if item.get("status") in ("failed", "succeeded"):
+            break
+        time.sleep(0.05)
+    assert item["status"] == "failed"
+    assert item["error"].startswith("import failed for https://www.linkedin.com/jobs/view/3")
+
+    stats = mobile_client.get("/api/work/stats").json()
+    heads = [f["error_head"] for f in stats["recent_failures"]]
+    assert any(h.startswith("import failed for") for h in heads)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -257,6 +257,7 @@ def test_check_workspace_shows_no_openai_when_missing(monkeypatch, tmp_path):
 def test_check_workspace_shows_openai_when_key_set(monkeypatch, tmp_path):
     import tools.setup as s
     _patch_here(monkeypatch, tmp_path, s)
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)  # CI sets foundry
     s.setup_workspace(**_MINIMAL, openai_api_key="sk-abc")
     result = s.check_workspace()
     assert "auto-generation enabled" in result

--- a/tests/test_setup_desktop.py
+++ b/tests/test_setup_desktop.py
@@ -85,3 +85,48 @@ def test_setup_leaves_live_data_folder_alone(desktop_workspace):
     from tools.job_queue import get_job_queue
 
     assert "KeepCo" in get_job_queue()
+
+
+def test_check_workspace_reads_appdata_config_on_desktop(desktop_workspace, monkeypatch):
+    """check_workspace must report from the SAME config setup writes to
+    (JOBCONTEXT_CONFIG in app-data) — never _HERE inside the signed bundle —
+    and its AI line must be provider-aware (anthropic key counts)."""
+    import tools.setup as s
+
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)  # CI sets foundry
+    from lib.app_dirs import is_desktop_mode
+    assert is_desktop_mode()  # DEPLOY_MODE=desktop via fixture
+
+    s.setup_workspace(
+        name="Frank Test",
+        email="f@example.com",
+        phone="555-000-0000",
+        linkedin="linkedin.com/in/franktest",
+        city_state="Atlanta, GA",
+        master_resume_content="EXPERIENCE\nEngineer | Acme | 2020 - 2026\n",
+    )
+    report = s.check_workspace()
+    assert "Frank Test" in report            # read the app-data config
+    assert "anthropic key configured" in report  # provider-aware AI line
+
+
+def test_check_workspace_desktop_data_dir_fallback(desktop_workspace, monkeypatch, tmp_path):
+    """Without JOBCONTEXT_CONFIG, the frozen/desktop path falls back to
+    desktop_data_dir()/config.json."""
+    import json as _json
+
+    import tools.setup as s
+
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.delenv("JOBCONTEXT_CONFIG", raising=False)
+    fallback_dir = tmp_path / "appdata"
+    fallback_dir.mkdir()
+    (fallback_dir / "config.json").write_text(_json.dumps({
+        "contact": {"name": "Fallback Frank", "email": "fb@example.com"},
+        "llm_provider": "anthropic",
+    }))
+    import lib.app_dirs as app_dirs
+    monkeypatch.setattr(app_dirs, "desktop_data_dir", lambda: fallback_dir)
+
+    report = s.check_workspace()
+    assert "Fallback Frank" in report

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -259,9 +259,23 @@ def check_workspace() -> str:  # NOSONAR
     # data partition, not at the repo root (which holds the shared base config
     # injected via ConfigMap). Resolve the right one before reading contact /
     # language details, otherwise every tenant sees the owner's values.
+    from lib.app_dirs import is_desktop_mode
     from lib.user_context import get_data_folder_override
     _override = get_data_folder_override()
-    config_path = (_override / _CONFIG_FILENAME) if _override is not None else (_HERE / _CONFIG_FILENAME)
+    if _override is not None:
+        config_path = _override / _CONFIG_FILENAME
+    elif is_desktop_mode() or getattr(sys, "frozen", False):
+        # Desktop / frozen: the real config lives in app-data, never beside
+        # the executable (same resolution as setup_workspace's write path).
+        env_cfg = os.environ.get("JOBCONTEXT_CONFIG", "").strip()
+        if env_cfg:
+            config_path = Path(env_cfg)
+        else:
+            from lib.app_dirs import desktop_data_dir
+
+            config_path = desktop_data_dir() / _CONFIG_FILENAME
+    else:
+        config_path = _HERE / _CONFIG_FILENAME
     if config_path.exists():
         lines.append("✓ config.json — present")
         try:
@@ -269,10 +283,18 @@ def check_workspace() -> str:  # NOSONAR
             contact = cfg.get("contact", {})
             lines.append(f"  Name:    {contact.get('name', '(missing)')}")
             lines.append(f"  Email:   {contact.get('email', '(missing)')}")
-            if cfg.get("openai_api_key"):
-                lines.append("  OpenAI:  key configured (auto-generation enabled)")
+            # Provider-aware: same resolution the Settings badge and
+            # generation itself use, so the three never contradict.
+            try:
+                from lib.config import llm_generation_status
+
+                _provider, _ready = llm_generation_status()
+            except Exception:
+                _provider, _ready = "unknown", False
+            if _ready:
+                lines.append(f"  AI:      {_provider} key configured (auto-generation enabled)")
             else:
-                lines.append("  OpenAI:  no key — Copilot-assisted generation mode")
+                lines.append("  AI:      no usable key — Copilot-assisted generation mode")
             lines.append(f"  LeetCode language: {cfg.get('leetcode_language', '(not set)')}")
         except Exception as e:
             lines.append(f"  ⚠ Could not parse config.json: {e}")

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -288,7 +288,7 @@ def check_workspace() -> str:  # NOSONAR
             try:
                 from lib.config import llm_generation_status
 
-                _provider, _ready = llm_generation_status()
+                _provider, _ready = llm_generation_status(cfg)
             except Exception:
                 _provider, _ready = "unknown", False
             if _ready:

--- a/transport/http/routes/dashboard/api.py
+++ b/transport/http/routes/dashboard/api.py
@@ -310,25 +310,22 @@ def _is_owner() -> bool:
         return False
 
 
-def _openai_key_set() -> bool:
-    """Whether AI generation has a usable key for the active request/tenant.
-
-    Mirrors the exact resolution used by lib.config.get_llm_client() so the
-    Settings screen reports the same truth generation will actually see:
-    the LLM_API_KEY env var (global override) or the active tenant's merged
-    config.json openai_api_key. Works for single-tenant/local runs and the
-    owner session, not just when a per-user data-folder override is active.
-    """
+def _ai_generation_status() -> "tuple[str, bool]":
+    """Provider-aware AI readiness for the active request/tenant. The old
+    check only looked at openai_api_key and lied in both directions once
+    other providers existed (field report: badge said configured while the
+    chat said not)."""
     try:
-        import os
-        from lib.config import get_active_config
+        from lib.config import llm_generation_status
 
-        api_key = os.environ.get("LLM_API_KEY") or get_active_config().get(
-            "openai_api_key", ""
-        )
-        return bool(str(api_key or "").strip())
+        return llm_generation_status()
     except Exception:
-        return False
+        return "unknown", False
+
+
+def _openai_key_set() -> bool:
+    """Back-compat shim for existing callers/tests."""
+    return _ai_generation_status()[1]
 
 
 def _oura_settings_payload(oura: "dict | None") -> "dict | None":
@@ -388,7 +385,8 @@ async def settings_summary(
     return JSONResponse(
         {
             "isOwner": _is_owner(),
-            "openaiKeySet": _openai_key_set(),
+            "openaiKeySet": _openai_key_set(),  # legacy field name; provider-aware
+            "aiProvider": _ai_generation_status()[0],
             "ouraConfigured": bool(status.get("configured")),
             "ouraConnected": bool(status.get("connected")) or _oura_via_sync(),
             "ouraViaSync": not status.get("connected") and _oura_via_sync(),

--- a/transport/http/routes/mobile.py
+++ b/transport/http/routes/mobile.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -204,18 +205,27 @@ def _capture_and_assess(inputs: dict) -> dict:
         raise  # the work row records the failure + traceback
 
 
+# queue_job's success formats (tools/job_queue.py): the em-dash separated
+# "Queued: {company} — {role}. Run evaluate_queued_job…" and its
+# "Already queued: … (status: …)" dedupe variant. The worker previously
+# scanned for "company:"/"role:" lines that NEVER existed in either format —
+# every successful import was misread as a failure (pushed "Import failed",
+# skipped the assessment) while the job silently landed in the queue.
+_QUEUED_RE = re.compile(
+    r"(?:Already )?[Qq]ueued: (?P<company>.+?) — (?P<role>.+?)"
+    r"(?:\. Run evaluate_queued_job| \(status:)"
+)
+
+
 def _capture_and_assess_inner(url: str, text: str = "") -> dict:
     from tools.job_scraper import scrape_job_url
 
     # text = client-extracted page content (the phone can read pages that
     # block our datacenter IPs — e.g. LinkedIn's authwall).
     result = scrape_job_url(url, auto_queue=True, page_text=text)
-    company = role = ""
-    for line in str(result).splitlines():
-        if line.lower().startswith("company:"):
-            company = line.split(":", 1)[1].strip()
-        elif line.lower().startswith("role:"):
-            role = line.split(":", 1)[1].strip()
+    m = _QUEUED_RE.search(str(result))
+    company = m.group("company").strip() if m else ""
+    role = m.group("role").strip() if m else ""
     if not company:
         send_push("Import failed", "Couldn't read that job posting.", {"type": "capture_failed"})
         # The scraper result is a status/error string (never page content).

--- a/transport/http/routes/mobile.py
+++ b/transport/http/routes/mobile.py
@@ -176,6 +176,11 @@ class CaptureRequest(BaseModel):
     text: str = ""   # client-extracted page content (or pasted JD text)
 
 
+class CaptureImportError(Exception):
+    """Import produced no usable posting — raised so the work row records a
+    diagnosable failure instead of a 'succeeded' row with imported=False."""
+
+
 def _capture_and_assess(inputs: dict) -> dict:
     """Work executor (kind=capture_url): import → queue → assess → push.
 
@@ -187,6 +192,8 @@ def _capture_and_assess(inputs: dict) -> dict:
     url = inputs["url"]
     try:
         return _capture_and_assess_inner(url, inputs.get("text", ""))
+    except CaptureImportError:
+        raise  # "Import failed" push already sent — no second push
     except Exception:  # noqa: BLE001 — the user is waiting on a push either way
         _log.exception("capture worker failed for %s", url)
         send_push(
@@ -211,7 +218,12 @@ def _capture_and_assess_inner(url: str, text: str = "") -> dict:
             role = line.split(":", 1)[1].strip()
     if not company:
         send_push("Import failed", "Couldn't read that job posting.", {"type": "capture_failed"})
-        return {"imported": False}
+        # The scraper result is a status/error string (never page content).
+        reason = (str(result).strip().splitlines() or ["scraper returned empty result"])[0][:200]
+        path = "client-text" if text.strip() else "server-fetch"
+        raise CaptureImportError(
+            f"import failed for {url}: path={path}, page_text_len={len(text)}, reason: {reason}"
+        )
 
     from lib.db import get_connection
 


### PR DESCRIPTION
Promotes #103: failed imports become failed work rows with a one-line diagnosis (path, page_text_len, scraper reason) surfaced by /api/work/stats. Pairs with the mobile fix package (LinkedIn markup parser, single-flight auth refresh, timeouts) already submitted to TestFlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)