### PR TITLE
AI status: provider-aware, consistent across Settings badge and chat

### DIFF
--- a/frontend/src/screens/Settings.jsx
+++ b/frontend/src/screens/Settings.jsx
@@ -766,7 +766,7 @@ export default function Settings() {
       <SectionHead title="Integrations" />
       <Panel style={{ marginBottom: 20 }}>
         <div style={{ display: 'grid', gap: 10 }}>
-          <StatusRow label="AI generation (OpenAI key)" ok={data?.openaiKeySet} okText="configured" offText="not set">
+          <StatusRow label={`AI generation${data?.aiProvider ? ` (${data.aiProvider})` : ''}`} ok={data?.openaiKeySet} okText="configured" offText="not set">
             Enables resume generation, cover letter drafting, and semantic search.
           </StatusRow>
           <StatusRow label="Oura Ring" ok={data?.ouraConnected} okText="connected" offText="not connected">

--- a/lib/config.py
+++ b/lib/config.py
@@ -363,6 +363,26 @@ def get_active_master_resume_path() -> Path:
 
 # ── LLM client factory ────────────────────────────────────────────────────────
 
+def llm_generation_status() -> "tuple[str, bool]":
+    """(provider, ready) — mirrors get_llm_client()'s per-provider key
+    resolution WITHOUT constructing a client, for status surfaces (Settings
+    badge, check_workspace). Keep in lockstep with get_llm_client below.
+    """
+    cfg = get_active_config()
+    provider = str(cfg.get("llm_provider", "openai")).lower()
+    provider = os.environ.get("LLM_PROVIDER", provider).lower()
+    env_key = str(os.environ.get("LLM_API_KEY", "") or "").strip()
+    if provider == "ollama":
+        return provider, True  # local endpoint, no key needed
+    if provider == "anthropic":
+        return provider, bool(env_key or str(cfg.get("anthropic_api_key", "") or "").strip())
+    if provider == "foundry":
+        # Endpoint is the hard requirement; the key can come from workload
+        # identity (DefaultAzureCredential) in AKS.
+        return provider, bool(str(cfg.get("azure_foundry_endpoint", "") or "").strip())
+    return provider, bool(env_key or str(cfg.get("openai_api_key", "") or "").strip())
+
+
 def get_llm_client(task: str = "") -> tuple[Any, str]:  # NOSONAR
     """Return (openai_client, model_name) for the configured LLM provider.
 

--- a/tests/test_dashboard_coverage.py
+++ b/tests/test_dashboard_coverage.py
@@ -842,12 +842,14 @@ class TestDashboardSettingsApiCoverage:
         monkeypatch.setattr(
             dashboard_api_routes, "_load_oura", lambda: {"readiness_score": 70}
         )
+        monkeypatch.delenv("LLM_PROVIDER", raising=False)  # CI sets foundry
 
         response = http_client_noauth.get("/api/dashboard/settings")
         assert response.status_code == 200
         assert response.json() == {
             "isOwner": True,
             "openaiKeySet": True,
+            "aiProvider": "openai",
             "ouraConfigured": True,
             "ouraConnected": True,
             "ouraViaSync": False,
@@ -911,6 +913,7 @@ class TestOpenAiKeySetHelper:
         import lib.config as config
 
         monkeypatch.delenv("LLM_API_KEY", raising=False)
+        monkeypatch.delenv("LLM_PROVIDER", raising=False)  # CI sets foundry
         monkeypatch.setattr(config, "get_active_config", lambda: {"openai_api_key": "sk-abc"})
         assert dashboard_api_routes._openai_key_set() is True
 
@@ -918,6 +921,7 @@ class TestOpenAiKeySetHelper:
         import lib.config as config
 
         monkeypatch.setenv("LLM_API_KEY", "env-provided-key")
+        monkeypatch.delenv("LLM_PROVIDER", raising=False)  # CI sets foundry
         monkeypatch.setattr(config, "get_active_config", lambda: {})
         assert dashboard_api_routes._openai_key_set() is True
 
@@ -925,6 +929,7 @@ class TestOpenAiKeySetHelper:
         import lib.config as config
 
         monkeypatch.delenv("LLM_API_KEY", raising=False)
+        monkeypatch.delenv("LLM_PROVIDER", raising=False)  # CI sets foundry
         monkeypatch.setattr(config, "get_active_config", lambda: {"openai_api_key": "   "})
         assert dashboard_api_routes._openai_key_set() is False
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -257,6 +257,7 @@ def test_check_workspace_shows_no_openai_when_missing(monkeypatch, tmp_path):
 def test_check_workspace_shows_openai_when_key_set(monkeypatch, tmp_path):
     import tools.setup as s
     _patch_here(monkeypatch, tmp_path, s)
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)  # CI sets foundry
     s.setup_workspace(**_MINIMAL, openai_api_key="sk-abc")
     result = s.check_workspace()
     assert "auto-generation enabled" in result

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -259,9 +259,23 @@ def check_workspace() -> str:  # NOSONAR
     # data partition, not at the repo root (which holds the shared base config
     # injected via ConfigMap). Resolve the right one before reading contact /
     # language details, otherwise every tenant sees the owner's values.
+    from lib.app_dirs import is_desktop_mode
     from lib.user_context import get_data_folder_override
     _override = get_data_folder_override()
-    config_path = (_override / _CONFIG_FILENAME) if _override is not None else (_HERE / _CONFIG_FILENAME)
+    if _override is not None:
+        config_path = _override / _CONFIG_FILENAME
+    elif is_desktop_mode() or getattr(sys, "frozen", False):
+        # Desktop / frozen: the real config lives in app-data, never beside
+        # the executable (same resolution as setup_workspace's write path).
+        env_cfg = os.environ.get("JOBCONTEXT_CONFIG", "").strip()
+        if env_cfg:
+            config_path = Path(env_cfg)
+        else:
+            from lib.app_dirs import desktop_data_dir
+
+            config_path = desktop_data_dir() / _CONFIG_FILENAME
+    else:
+        config_path = _HERE / _CONFIG_FILENAME
     if config_path.exists():
         lines.append("✓ config.json — present")
         try:
@@ -269,10 +283,18 @@ def check_workspace() -> str:  # NOSONAR
             contact = cfg.get("contact", {})
             lines.append(f"  Name:    {contact.get('name', '(missing)')}")
             lines.append(f"  Email:   {contact.get('email', '(missing)')}")
-            if cfg.get("openai_api_key"):
-                lines.append("  OpenAI:  key configured (auto-generation enabled)")
+            # Provider-aware: same resolution the Settings badge and
+            # generation itself use, so the three never contradict.
+            try:
+                from lib.config import llm_generation_status
+
+                _provider, _ready = llm_generation_status()
+            except Exception:
+                _provider, _ready = "unknown", False
+            if _ready:
+                lines.append(f"  AI:      {_provider} key configured (auto-generation enabled)")
             else:
-                lines.append("  OpenAI:  no key — Copilot-assisted generation mode")
+                lines.append("  AI:      no usable key — Copilot-assisted generation mode")
             lines.append(f"  LeetCode language: {cfg.get('leetcode_language', '(not set)')}")
         except Exception as e:
             lines.append(f"  ⚠ Could not parse config.json: {e}")

--- a/transport/http/routes/dashboard/api.py
+++ b/transport/http/routes/dashboard/api.py
@@ -310,25 +310,22 @@ def _is_owner() -> bool:
         return False
 
 
-def _openai_key_set() -> bool:
-    """Whether AI generation has a usable key for the active request/tenant.
-
-    Mirrors the exact resolution used by lib.config.get_llm_client() so the
-    Settings screen reports the same truth generation will actually see:
-    the LLM_API_KEY env var (global override) or the active tenant's merged
-    config.json openai_api_key. Works for single-tenant/local runs and the
-    owner session, not just when a per-user data-folder override is active.
-    """
+def _ai_generation_status() -> "tuple[str, bool]":
+    """Provider-aware AI readiness for the active request/tenant. The old
+    check only looked at openai_api_key and lied in both directions once
+    other providers existed (field report: badge said configured while the
+    chat said not)."""
     try:
-        import os
-        from lib.config import get_active_config
+        from lib.config import llm_generation_status
 
-        api_key = os.environ.get("LLM_API_KEY") or get_active_config().get(
-            "openai_api_key", ""
-        )
-        return bool(str(api_key or "").strip())
+        return llm_generation_status()
     except Exception:
-        return False
+        return "unknown", False
+
+
+def _openai_key_set() -> bool:
+    """Back-compat shim for existing callers/tests."""
+    return _ai_generation_status()[1]
 
 
 def _oura_settings_payload(oura: "dict | None") -> "dict | None":
@@ -388,7 +385,8 @@ async def settings_summary(
     return JSONResponse(
         {
             "isOwner": _is_owner(),
-            "openaiKeySet": _openai_key_set(),
+            "openaiKeySet": _openai_key_set(),  # legacy field name; provider-aware
+            "aiProvider": _ai_generation_status()[0],
             "ouraConfigured": bool(status.get("configured")),
             "ouraConnected": bool(status.get("connected")) or _oura_via_sync(),
             "ouraViaSync": not status.get("connected") and _oura_via_sync(),


### PR DESCRIPTION
Field report: Settings badge claimed "AI generation (OpenAI key): configured" while desktop chat's workspace check said OpenAI wasn't configured — with provider=anthropic actually working the whole time.

- **`lib/config.llm_generation_status()`** — one shared (provider, ready) helper mirroring `get_llm_client()`'s key resolution per provider (openai/anthropic/ollama/foundry), no client construction
- **Settings** badge is provider-aware and labeled honestly ("AI generation (anthropic)"); payload keeps `openaiKeySet` for compat + adds `aiProvider`
- **check_workspace** (the chat's status tool) uses the same helper — and now resolves the desktop/frozen config from app-data instead of the signed bundle (`_HERE`), the read-side sibling of the setup_workspace write-path bug fixed in #87
- Tests pin `LLM_PROVIDER` where CI's `foundry` env would flip results; full suite verified green under `LLM_PROVIDER=foundry` too (1403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)