### PR TITLE
Quality gate: cover AI-status provider branches + desktop path

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -363,12 +363,15 @@ def get_active_master_resume_path() -> Path:
 
 # ── LLM client factory ────────────────────────────────────────────────────────
 
-def llm_generation_status() -> "tuple[str, bool]":
+def llm_generation_status(cfg: "dict | None" = None) -> "tuple[str, bool]":
     """(provider, ready) — mirrors get_llm_client()'s per-provider key
     resolution WITHOUT constructing a client, for status surfaces (Settings
     badge, check_workspace). Keep in lockstep with get_llm_client below.
+    Pass *cfg* to report on a specific config dict (e.g. a file being
+    described) instead of the active runtime config.
     """
-    cfg = get_active_config()
+    if cfg is None:
+        cfg = get_active_config()
     provider = str(cfg.get("llm_provider", "openai")).lower()
     provider = os.environ.get("LLM_PROVIDER", provider).lower()
     env_key = str(os.environ.get("LLM_API_KEY", "") or "").strip()

--- a/tests/test_dashboard_coverage.py
+++ b/tests/test_dashboard_coverage.py
@@ -933,6 +933,37 @@ class TestOpenAiKeySetHelper:
         monkeypatch.setattr(config, "get_active_config", lambda: {"openai_api_key": "   "})
         assert dashboard_api_routes._openai_key_set() is False
 
+    def test_provider_branches(self, monkeypatch):
+        """llm_generation_status must report each provider's own readiness:
+        anthropic by anthropic_api_key, ollama always (local endpoint),
+        foundry by endpoint (key may come from workload identity)."""
+        import lib.config as config
+
+        monkeypatch.delenv("LLM_API_KEY", raising=False)
+        monkeypatch.delenv("LLM_PROVIDER", raising=False)
+
+        cases = [
+            ({"llm_provider": "anthropic", "anthropic_api_key": "sk-ant"}, ("anthropic", True)),
+            ({"llm_provider": "anthropic", "openai_api_key": "sk-abc"}, ("anthropic", False)),
+            ({"llm_provider": "ollama"}, ("ollama", True)),
+            ({"llm_provider": "foundry", "azure_foundry_endpoint": "https://x.ai"}, ("foundry", True)),
+            ({"llm_provider": "foundry"}, ("foundry", False)),
+        ]
+        for cfg, expected in cases:
+            monkeypatch.setattr(config, "get_active_config", lambda c=cfg: c)
+            assert config.llm_generation_status() == expected, cfg
+
+    def test_env_provider_overrides_config(self, monkeypatch):
+        import lib.config as config
+
+        monkeypatch.delenv("LLM_API_KEY", raising=False)
+        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+        monkeypatch.setattr(
+            config, "get_active_config",
+            lambda: {"llm_provider": "openai", "anthropic_api_key": "sk-ant"},
+        )
+        assert config.llm_generation_status() == ("anthropic", True)
+
     def test_false_and_safe_on_config_error(self, monkeypatch):
         import lib.config as config
 

--- a/tests/test_setup_desktop.py
+++ b/tests/test_setup_desktop.py
@@ -85,3 +85,48 @@ def test_setup_leaves_live_data_folder_alone(desktop_workspace):
     from tools.job_queue import get_job_queue
 
     assert "KeepCo" in get_job_queue()
+
+
+def test_check_workspace_reads_appdata_config_on_desktop(desktop_workspace, monkeypatch):
+    """check_workspace must report from the SAME config setup writes to
+    (JOBCONTEXT_CONFIG in app-data) — never _HERE inside the signed bundle —
+    and its AI line must be provider-aware (anthropic key counts)."""
+    import tools.setup as s
+
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)  # CI sets foundry
+    from lib.app_dirs import is_desktop_mode
+    assert is_desktop_mode()  # DEPLOY_MODE=desktop via fixture
+
+    s.setup_workspace(
+        name="Frank Test",
+        email="f@example.com",
+        phone="555-000-0000",
+        linkedin="linkedin.com/in/franktest",
+        city_state="Atlanta, GA",
+        master_resume_content="EXPERIENCE\nEngineer | Acme | 2020 - 2026\n",
+    )
+    report = s.check_workspace()
+    assert "Frank Test" in report            # read the app-data config
+    assert "anthropic key configured" in report  # provider-aware AI line
+
+
+def test_check_workspace_desktop_data_dir_fallback(desktop_workspace, monkeypatch, tmp_path):
+    """Without JOBCONTEXT_CONFIG, the frozen/desktop path falls back to
+    desktop_data_dir()/config.json."""
+    import json as _json
+
+    import tools.setup as s
+
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.delenv("JOBCONTEXT_CONFIG", raising=False)
+    fallback_dir = tmp_path / "appdata"
+    fallback_dir.mkdir()
+    (fallback_dir / "config.json").write_text(_json.dumps({
+        "contact": {"name": "Fallback Frank", "email": "fb@example.com"},
+        "llm_provider": "anthropic",
+    }))
+    import lib.app_dirs as app_dirs
+    monkeypatch.setattr(app_dirs, "desktop_data_dir", lambda: fallback_dir)
+
+    report = s.check_workspace()
+    assert "Fallback Frank" in report

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -288,7 +288,7 @@ def check_workspace() -> str:  # NOSONAR
             try:
                 from lib.config import llm_generation_status
 
-                _provider, _ready = llm_generation_status()
+                _provider, _ready = llm_generation_status(cfg)
             except Exception:
                 _provider, _ready = "unknown", False
             if _ready:


### PR DESCRIPTION
Sonar failed the promotion PR (#104) on new-code coverage: 76.2% vs 80% — 10 uncovered lines from #105 (`llm_generation_status` provider branches, `check_workspace` desktop config-path resolution).

- Provider-branch matrix: anthropic (ready/not), ollama (always ready), foundry (endpoint-gated), env `LLM_PROVIDER` override
- Desktop tests exercising the exact read-path fix: `check_workspace` reads the JOBCONTEXT_CONFIG app-data file setup wrote, plus the `desktop_data_dir()` fallback
- Small refinement while testing: `llm_generation_status(cfg=...)` — check_workspace reports on the file it parsed, not the runtime config, so the AI line can't contradict the Name/Email lines above it

Full suite green under default env AND `LLM_PROVIDER=foundry` (CI's setting). Once merged, #104's Sonar analysis refreshes and the gate should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)