### PR TITLE
Desktop/Windows: no console window; bundle static assets

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -59,11 +59,20 @@ fn spawn_backend(app: &tauri::AppHandle) -> Result<Backend, String> {
     // --parent-watchdog exits on stdin EOF, so even a SIGKILL to this shell
     // (which fires no Tauri exit event) can't orphan the backend against the
     // SQLite file.
-    let mut child = Command::new(&bin)
-        .arg("--parent-watchdog")
+    let mut cmd = Command::new(&bin);
+    cmd.arg("--parent-watchdog")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    // The sidecar is a console-subsystem exe (its stdout carries the port
+    // handshake). Without CREATE_NO_WINDOW, Windows materializes a visible
+    // terminal alongside the app.
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+    }
+    let mut child = cmd
         .spawn()
         .map_err(|e| format!("failed to spawn {bin:?}: {e}"))?;
 

--- a/packaging/pyinstaller/jobcontext-backend.spec
+++ b/packaging/pyinstaller/jobcontext-backend.spec
@@ -29,6 +29,10 @@ ROOT = os.path.abspath(os.path.join(SPECPATH, "..", ".."))  # noqa: F821 — SPE
 datas = [
     (os.path.join(ROOT, "templates"), "templates"),
     (os.path.join(ROOT, "frontend", "dist"), os.path.join("frontend", "dist")),
+    # Favicons/og-images served by transport/http/app.py from a path relative
+    # to the module — must travel into the bundle or every browser/webview
+    # favicon request errors in the frozen app (Windows field report).
+    (os.path.join(ROOT, "transport", "http", "static"), os.path.join("transport", "http", "static")),
 ]
 
 hiddenimports = [


### PR DESCRIPTION
Windows field report: installing the beta opened a terminal window alongside the app, scrolling server logs including "favicon-16 doesn't exist".

1. **Console window**: `spawn_backend` in desktop/src-tauri/src/main.rs passed no Windows creation flags, so the console-subsystem sidecar (deliberately `console=True` — stdout carries the `JOBCONTEXT_PORT` handshake) got a visible terminal. Now spawns with `CREATE_NO_WINDOW`; piped stdout is unaffected. (macOS never showed this — no console subsystem.)
2. **Missing static assets**: `transport/http/static/` (favicon-16/32/ico/svg, og-images) was absent from the PyInstaller `datas`, so the frozen app errored on every favicon request — on all platforms, it just was only *visible* on Windows thanks to bug #1. Bundled now.

`cargo check` clean locally; the windows-x64 CI job compiles the cfg(windows) block for real. Ships in the next desktop beta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)