### PR TITLE
Capture: fix success detection — the happy path never worked

### DIFF
--- a/tests/test_mobile_api.py
+++ b/tests/test_mobile_api.py
@@ -180,3 +180,77 @@ def test_failed_import_visible_in_work_api(mobile_client, monkeypatch):
     stats = mobile_client.get("/api/work/stats").json()
     heads = [f["error_head"] for f in stats["recent_failures"]]
     assert any(h.startswith("import failed for") for h in heads)
+
+
+def test_successful_import_parses_queue_result(monkeypatch):
+    """Regression for the never-worked success path: queue_job returns
+    "Scraped <url>\n→ Queued: {company} — {role}. Run evaluate_queued_job…"
+    and the worker must extract company/role from THAT (it used to scan for
+    "company:"/"role:" lines that never existed, so every good import pushed
+    "Import failed" and skipped its assessment — 2026-07-10 field report,
+    verified against real work rows)."""
+    import tools.job_scraper as scraper_mod
+    import transport.http.routes.mobile as mobile_mod
+
+    pushes = []
+    monkeypatch.setattr(
+        mobile_mod, "send_push", lambda title, body, data=None: pushes.append(title)
+    )
+    monkeypatch.setattr(
+        scraper_mod, "scrape_job_url",
+        lambda url, auto_queue=True, page_text="": (
+            "Scraped " + url + "\n"
+            "→ Queued: Elevance Health — Senior AI Solutions Engineer (Engineer Senior). "
+            "Run evaluate_queued_job to assess fitment before deciding."
+        ),
+    )
+    ran = {}
+
+    def fake_assess(company, role, jd):
+        ran.update(company=company, role=role)
+        return "## Fitment: 8/10"
+
+    monkeypatch.setattr("tools.fitment.run_job_assessment", fake_assess)
+    monkeypatch.setattr(
+        "lib.db.get_connection",
+        lambda: __import__("contextlib").nullcontext(
+            type("C", (), {"execute": lambda self, *a: type("R", (), {"fetchone": lambda s: None})()})()
+        ),
+    )
+
+    out = mobile_mod._capture_and_assess(
+        {"url": "https://careers.elevancehealth.com/x/job/ABC?source=LinkedIn", "text": "# jd"}
+    )
+    assert out["imported"] is True
+    assert out["company"] == "Elevance Health"
+    assert out["role"] == "Senior AI Solutions Engineer (Engineer Senior)"
+    assert ran["company"] == "Elevance Health"  # assessment actually ran
+    assert len(pushes) == 1
+    assert pushes[0].startswith("Assessment complete") and "8/10" in pushes[0]
+
+
+def test_already_queued_variant_still_assesses(monkeypatch):
+    """Re-sharing a job (dedupe path) must also read as success and re-assess."""
+    import tools.job_scraper as scraper_mod
+    import transport.http.routes.mobile as mobile_mod
+
+    monkeypatch.setattr(mobile_mod, "send_push", lambda *a, **k: None)
+    monkeypatch.setattr(
+        scraper_mod, "scrape_job_url",
+        lambda url, auto_queue=True, page_text="": (
+            "Scraped " + url + "\n"
+            "→ Already queued: Cox Automotive — Senior Platform Engineer (status: pending). "
+            "Use evaluate_queued_job to assess it."
+        ),
+    )
+    monkeypatch.setattr(
+        "tools.fitment.run_job_assessment", lambda c, r, jd: "Score: 9/10 overall"
+    )
+    monkeypatch.setattr(
+        "lib.db.get_connection",
+        lambda: __import__("contextlib").nullcontext(
+            type("C", (), {"execute": lambda self, *a: type("R", (), {"fetchone": lambda s: None})()})()
+        ),
+    )
+    out = mobile_mod._capture_and_assess({"url": "https://x.example/1"})
+    assert out["imported"] is True and out["company"] == "Cox Automotive"

--- a/transport/http/routes/mobile.py
+++ b/transport/http/routes/mobile.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -204,18 +205,27 @@ def _capture_and_assess(inputs: dict) -> dict:
         raise  # the work row records the failure + traceback
 
 
+# queue_job's success formats (tools/job_queue.py): the em-dash separated
+# "Queued: {company} — {role}. Run evaluate_queued_job…" and its
+# "Already queued: … (status: …)" dedupe variant. The worker previously
+# scanned for "company:"/"role:" lines that NEVER existed in either format —
+# every successful import was misread as a failure (pushed "Import failed",
+# skipped the assessment) while the job silently landed in the queue.
+_QUEUED_RE = re.compile(
+    r"(?:Already )?[Qq]ueued: (?P<company>.+?) — (?P<role>.+?)"
+    r"(?:\. Run evaluate_queued_job| \(status:)"
+)
+
+
 def _capture_and_assess_inner(url: str, text: str = "") -> dict:
     from tools.job_scraper import scrape_job_url
 
     # text = client-extracted page content (the phone can read pages that
     # block our datacenter IPs — e.g. LinkedIn's authwall).
     result = scrape_job_url(url, auto_queue=True, page_text=text)
-    company = role = ""
-    for line in str(result).splitlines():
-        if line.lower().startswith("company:"):
-            company = line.split(":", 1)[1].strip()
-        elif line.lower().startswith("role:"):
-            role = line.split(":", 1)[1].strip()
+    m = _QUEUED_RE.search(str(result))
+    company = m.group("company").strip() if m else ""
+    role = m.group("role").strip() if m else ""
     if not company:
         send_push("Import failed", "Couldn't read that job posting.", {"type": "capture_failed"})
         # The scraper result is a status/error string (never page content).


### PR DESCRIPTION
**The** bug of the capture saga. Frank's work rows showed the phone sending a *perfect* extraction (title, company, full JD for the Elevance posting) and the server still recording `imported: false`.

**Root cause:** `_capture_and_assess_inner` scanned the scraper result for `company:` / `role:` lines. `queue_job` has always returned `"Queued: {company} — {role}. Run evaluate_queued_job…"` (or `"Already queued: … (status: …)"`). **The success detector and the success format never matched** — every good import: job queued ✓, "Import failed" pushed ✗, assessment skipped ✗. This explains Aderant appearing in the pipeline unscored next to a failure push, and why no mobile capture has ever produced a score push.

**Fix:** parse both real formats (anchored on the fixed suffixes so roles containing periods survive the non-greedy match). `Already queued` re-shares count as success and re-assess.

**Tests:** exact strings from the real prod work rows; the success test asserts the assessment executes and the score push fires — the first test ever to exercise the capture happy path end to end. Full suite **1408 green**.

With this + the phone's working extractor (proven by the rows), share→assess→push should finally close. Remaining known gap: pure `linkedin.com/jobs/view` URLs still sometimes extract empty on-device (row 2) — WebView escalation tracked separately; external ATS links like the Elevance one work now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)