### PR TITLE
Fix train: quality-gate coverage + Windows desktop + capture success parse

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -59,11 +59,20 @@ fn spawn_backend(app: &tauri::AppHandle) -> Result<Backend, String> {
     // --parent-watchdog exits on stdin EOF, so even a SIGKILL to this shell
     // (which fires no Tauri exit event) can't orphan the backend against the
     // SQLite file.
-    let mut child = Command::new(&bin)
-        .arg("--parent-watchdog")
+    let mut cmd = Command::new(&bin);
+    cmd.arg("--parent-watchdog")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    // The sidecar is a console-subsystem exe (its stdout carries the port
+    // handshake). Without CREATE_NO_WINDOW, Windows materializes a visible
+    // terminal alongside the app.
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+    }
+    let mut child = cmd
         .spawn()
         .map_err(|e| format!("failed to spawn {bin:?}: {e}"))?;
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -363,12 +363,15 @@ def get_active_master_resume_path() -> Path:
 
 # ── LLM client factory ────────────────────────────────────────────────────────
 
-def llm_generation_status() -> "tuple[str, bool]":
+def llm_generation_status(cfg: "dict | None" = None) -> "tuple[str, bool]":
     """(provider, ready) — mirrors get_llm_client()'s per-provider key
     resolution WITHOUT constructing a client, for status surfaces (Settings
     badge, check_workspace). Keep in lockstep with get_llm_client below.
+    Pass *cfg* to report on a specific config dict (e.g. a file being
+    described) instead of the active runtime config.
     """
-    cfg = get_active_config()
+    if cfg is None:
+        cfg = get_active_config()
     provider = str(cfg.get("llm_provider", "openai")).lower()
     provider = os.environ.get("LLM_PROVIDER", provider).lower()
     env_key = str(os.environ.get("LLM_API_KEY", "") or "").strip()

--- a/packaging/pyinstaller/jobcontext-backend.spec
+++ b/packaging/pyinstaller/jobcontext-backend.spec
@@ -29,6 +29,10 @@ ROOT = os.path.abspath(os.path.join(SPECPATH, "..", ".."))  # noqa: F821 — SPE
 datas = [
     (os.path.join(ROOT, "templates"), "templates"),
     (os.path.join(ROOT, "frontend", "dist"), os.path.join("frontend", "dist")),
+    # Favicons/og-images served by transport/http/app.py from a path relative
+    # to the module — must travel into the bundle or every browser/webview
+    # favicon request errors in the frozen app (Windows field report).
+    (os.path.join(ROOT, "transport", "http", "static"), os.path.join("transport", "http", "static")),
 ]
 
 hiddenimports = [

--- a/tests/test_dashboard_coverage.py
+++ b/tests/test_dashboard_coverage.py
@@ -933,6 +933,37 @@ class TestOpenAiKeySetHelper:
         monkeypatch.setattr(config, "get_active_config", lambda: {"openai_api_key": "   "})
         assert dashboard_api_routes._openai_key_set() is False
 
+    def test_provider_branches(self, monkeypatch):
+        """llm_generation_status must report each provider's own readiness:
+        anthropic by anthropic_api_key, ollama always (local endpoint),
+        foundry by endpoint (key may come from workload identity)."""
+        import lib.config as config
+
+        monkeypatch.delenv("LLM_API_KEY", raising=False)
+        monkeypatch.delenv("LLM_PROVIDER", raising=False)
+
+        cases = [
+            ({"llm_provider": "anthropic", "anthropic_api_key": "sk-ant"}, ("anthropic", True)),
+            ({"llm_provider": "anthropic", "openai_api_key": "sk-abc"}, ("anthropic", False)),
+            ({"llm_provider": "ollama"}, ("ollama", True)),
+            ({"llm_provider": "foundry", "azure_foundry_endpoint": "https://x.ai"}, ("foundry", True)),
+            ({"llm_provider": "foundry"}, ("foundry", False)),
+        ]
+        for cfg, expected in cases:
+            monkeypatch.setattr(config, "get_active_config", lambda c=cfg: c)
+            assert config.llm_generation_status() == expected, cfg
+
+    def test_env_provider_overrides_config(self, monkeypatch):
+        import lib.config as config
+
+        monkeypatch.delenv("LLM_API_KEY", raising=False)
+        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+        monkeypatch.setattr(
+            config, "get_active_config",
+            lambda: {"llm_provider": "openai", "anthropic_api_key": "sk-ant"},
+        )
+        assert config.llm_generation_status() == ("anthropic", True)
+
     def test_false_and_safe_on_config_error(self, monkeypatch):
         import lib.config as config
 

--- a/tests/test_mobile_api.py
+++ b/tests/test_mobile_api.py
@@ -180,3 +180,77 @@ def test_failed_import_visible_in_work_api(mobile_client, monkeypatch):
     stats = mobile_client.get("/api/work/stats").json()
     heads = [f["error_head"] for f in stats["recent_failures"]]
     assert any(h.startswith("import failed for") for h in heads)
+
+
+def test_successful_import_parses_queue_result(monkeypatch):
+    """Regression for the never-worked success path: queue_job returns
+    "Scraped <url>\n→ Queued: {company} — {role}. Run evaluate_queued_job…"
+    and the worker must extract company/role from THAT (it used to scan for
+    "company:"/"role:" lines that never existed, so every good import pushed
+    "Import failed" and skipped its assessment — 2026-07-10 field report,
+    verified against real work rows)."""
+    import tools.job_scraper as scraper_mod
+    import transport.http.routes.mobile as mobile_mod
+
+    pushes = []
+    monkeypatch.setattr(
+        mobile_mod, "send_push", lambda title, body, data=None: pushes.append(title)
+    )
+    monkeypatch.setattr(
+        scraper_mod, "scrape_job_url",
+        lambda url, auto_queue=True, page_text="": (
+            "Scraped " + url + "\n"
+            "→ Queued: Elevance Health — Senior AI Solutions Engineer (Engineer Senior). "
+            "Run evaluate_queued_job to assess fitment before deciding."
+        ),
+    )
+    ran = {}
+
+    def fake_assess(company, role, jd):
+        ran.update(company=company, role=role)
+        return "## Fitment: 8/10"
+
+    monkeypatch.setattr("tools.fitment.run_job_assessment", fake_assess)
+    monkeypatch.setattr(
+        "lib.db.get_connection",
+        lambda: __import__("contextlib").nullcontext(
+            type("C", (), {"execute": lambda self, *a: type("R", (), {"fetchone": lambda s: None})()})()
+        ),
+    )
+
+    out = mobile_mod._capture_and_assess(
+        {"url": "https://careers.elevancehealth.com/x/job/ABC?source=LinkedIn", "text": "# jd"}
+    )
+    assert out["imported"] is True
+    assert out["company"] == "Elevance Health"
+    assert out["role"] == "Senior AI Solutions Engineer (Engineer Senior)"
+    assert ran["company"] == "Elevance Health"  # assessment actually ran
+    assert len(pushes) == 1
+    assert pushes[0].startswith("Assessment complete") and "8/10" in pushes[0]
+
+
+def test_already_queued_variant_still_assesses(monkeypatch):
+    """Re-sharing a job (dedupe path) must also read as success and re-assess."""
+    import tools.job_scraper as scraper_mod
+    import transport.http.routes.mobile as mobile_mod
+
+    monkeypatch.setattr(mobile_mod, "send_push", lambda *a, **k: None)
+    monkeypatch.setattr(
+        scraper_mod, "scrape_job_url",
+        lambda url, auto_queue=True, page_text="": (
+            "Scraped " + url + "\n"
+            "→ Already queued: Cox Automotive — Senior Platform Engineer (status: pending). "
+            "Use evaluate_queued_job to assess it."
+        ),
+    )
+    monkeypatch.setattr(
+        "tools.fitment.run_job_assessment", lambda c, r, jd: "Score: 9/10 overall"
+    )
+    monkeypatch.setattr(
+        "lib.db.get_connection",
+        lambda: __import__("contextlib").nullcontext(
+            type("C", (), {"execute": lambda self, *a: type("R", (), {"fetchone": lambda s: None})()})()
+        ),
+    )
+    out = mobile_mod._capture_and_assess({"url": "https://x.example/1"})
+    assert out["imported"] is True and out["company"] == "Cox Automotive"

--- a/tests/test_setup_desktop.py
+++ b/tests/test_setup_desktop.py
@@ -85,3 +85,48 @@ def test_setup_leaves_live_data_folder_alone(desktop_workspace):
     from tools.job_queue import get_job_queue
 
     assert "KeepCo" in get_job_queue()
+
+
+def test_check_workspace_reads_appdata_config_on_desktop(desktop_workspace, monkeypatch):
+    """check_workspace must report from the SAME config setup writes to
+    (JOBCONTEXT_CONFIG in app-data) — never _HERE inside the signed bundle —
+    and its AI line must be provider-aware (anthropic key counts)."""
+    import tools.setup as s
+
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)  # CI sets foundry
+    from lib.app_dirs import is_desktop_mode
+    assert is_desktop_mode()  # DEPLOY_MODE=desktop via fixture
+
+    s.setup_workspace(
+        name="Frank Test",
+        email="f@example.com",
+        phone="555-000-0000",
+        linkedin="linkedin.com/in/franktest",
+        city_state="Atlanta, GA",
+        master_resume_content="EXPERIENCE\nEngineer | Acme | 2020 - 2026\n",
+    )
+    report = s.check_workspace()
+    assert "Frank Test" in report            # read the app-data config
+    assert "anthropic key configured" in report  # provider-aware AI line
+
+
+def test_check_workspace_desktop_data_dir_fallback(desktop_workspace, monkeypatch, tmp_path):
+    """Without JOBCONTEXT_CONFIG, the frozen/desktop path falls back to
+    desktop_data_dir()/config.json."""
+    import json as _json
+
+    import tools.setup as s
+
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.delenv("JOBCONTEXT_CONFIG", raising=False)
+    fallback_dir = tmp_path / "appdata"
+    fallback_dir.mkdir()
+    (fallback_dir / "config.json").write_text(_json.dumps({
+        "contact": {"name": "Fallback Frank", "email": "fb@example.com"},
+        "llm_provider": "anthropic",
+    }))
+    import lib.app_dirs as app_dirs
+    monkeypatch.setattr(app_dirs, "desktop_data_dir", lambda: fallback_dir)
+
+    report = s.check_workspace()
+    assert "Fallback Frank" in report

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -288,7 +288,7 @@ def check_workspace() -> str:  # NOSONAR
             try:
                 from lib.config import llm_generation_status
 
-                _provider, _ready = llm_generation_status()
+                _provider, _ready = llm_generation_status(cfg)
             except Exception:
                 _provider, _ready = "unknown", False
             if _ready:

--- a/transport/http/routes/mobile.py
+++ b/transport/http/routes/mobile.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -204,18 +205,27 @@ def _capture_and_assess(inputs: dict) -> dict:
         raise  # the work row records the failure + traceback
 
 
+# queue_job's success formats (tools/job_queue.py): the em-dash separated
+# "Queued: {company} — {role}. Run evaluate_queued_job…" and its
+# "Already queued: … (status: …)" dedupe variant. The worker previously
+# scanned for "company:"/"role:" lines that NEVER existed in either format —
+# every successful import was misread as a failure (pushed "Import failed",
+# skipped the assessment) while the job silently landed in the queue.
+_QUEUED_RE = re.compile(
+    r"(?:Already )?[Qq]ueued: (?P<company>.+?) — (?P<role>.+?)"
+    r"(?:\. Run evaluate_queued_job| \(status:)"
+)
+
+
 def _capture_and_assess_inner(url: str, text: str = "") -> dict:
     from tools.job_scraper import scrape_job_url
 
     # text = client-extracted page content (the phone can read pages that
     # block our datacenter IPs — e.g. LinkedIn's authwall).
     result = scrape_job_url(url, auto_queue=True, page_text=text)
-    company = role = ""
-    for line in str(result).splitlines():
-        if line.lower().startswith("company:"):
-            company = line.split(":", 1)[1].strip()
-        elif line.lower().startswith("role:"):
-            role = line.split(":", 1)[1].strip()
+    m = _QUEUED_RE.search(str(result))
+    company = m.group("company").strip() if m else ""
+    role = m.group("role").strip() if m else ""
     if not company:
         send_push("Import failed", "Couldn't read that job posting.", {"type": "capture_failed"})
         # The scraper result is a status/error string (never page content).


### PR DESCRIPTION
Consolidates #106 + #107 + #108 into one merge (octopus, zero conflicts, full suite 1412 green on the combined tree):

- **#106** — coverage for the AI-status provider branches + desktop config-path (unblocks the Sonar gate failing on promotion PR #104)
- **#107** — Windows: CREATE_NO_WINDOW on the sidecar spawn (no more terminal); transport/http/static bundled (favicon errors)
- **#108** — capture success detection parses queue_job's actual result format; the share→assess→push happy path works for the first time

After this merges: Sonar re-evaluates #104 → merge #104 → prod gets the whole batch (incl. #103/#105 already on qa). Then desktop beta.19 off the promoted commit. No mobile build needed — the capture fix is server-side; build 12 on the phone is already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)