### PR TITLE
fix(sync): sanitize filenames at creation; skip-and-report bad files in sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,13 @@ commits — never tag those) → desktop-release workflow → rolling
   (`lib.helpers.sanitize_filename`) and sync file transfers skip-and-report
   per file (`last_summary.files.errors`) — but the cloud has no file-delete
   propagation, so a bad-named file already in a partition must be renamed
-  there by hand (kubectl exec + mv).
+  there by hand (kubectl exec + mv). Sync manifest rels are POSIX
+  (`rel.as_posix()`) — `str(rel)` forked every key on Windows and
+  re-transferred the whole workspace both ways, littering the cloud with
+  flat literal-backslash files (2026-07-13 incident; peers on old builds
+  can re-push that junk until updated). Case-fold collisions (two cloud
+  files differing only in case) also wedge Windows into a re-pull loop —
+  resolve by renaming one at source.
 
 ## Mobile specifics (mobile/)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,15 +67,18 @@ commits — never tag those) → desktop-release workflow → rolling
   AFTER signing; TAURI_SIGNING_* env-only.
 - Windows: sidecar is console-subsystem (stdout carries the port handshake) —
   spawn with `CREATE_NO_WINDOW`. Installer is unsigned → SmartScreen warning
-  (task: Azure Trusted Signing). Windows-illegal filename chars (`|` etc.)
-  from Mac-created files break sync file-pull (open task).
+  (task: Azure Trusted Signing). Filenames are sanitized at creation
+  (`lib.helpers.sanitize_filename`) and sync file transfers skip-and-report
+  per file (`last_summary.files.errors`) — but the cloud has no file-delete
+  propagation, so a bad-named file already in a partition must be renamed
+  there by hand (kubectl exec + mv).
 
-## Mobile specifics (mobile/, branch feat/mobile-app)
+## Mobile specifics (mobile/)
 
 - Expo SDK 57 / RN 0.86; `eas init/build` sometimes re-adds a duplicate
   ShareExtension block under `app.json` `extra.eas.build` — strip it.
   eas-cli must NOT be a project dep (`npx eas-cli`). ascAppId pinned in
-  eas.json. Build from feat/mobile-app so eas.json is correct.
+  eas.json. Mobile is merged to main; build from main.
 - Share capture: on-device page extraction (`src/pageExtract.ts`) — the phone
   reads pages that authwall datacenter IPs; server fallback in
   tools/job_scraper.py (jobs-guest fragment). LinkedIn dropped JSON-LD from

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -1,6 +1,18 @@
 import datetime
+import re
 
 from lib import config
+
+# Windows-illegal filename characters plus control chars; macOS/Linux allow
+# these, so files named there can be unwritable on a Windows sync peer.
+_ILLEGAL_FILENAME_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+
+
+def sanitize_filename(name: str) -> str:
+    """Make a single filename component safe on every supported platform."""
+    cleaned = _ILLEGAL_FILENAME_CHARS.sub("-", name)
+    cleaned = re.sub(r"\s{2,}", " ", cleaned).strip().rstrip(". ")
+    return cleaned or "untitled"
 
 
 def _build_story_entry(stories: list, story: str, tags: list, people: list, title: str) -> dict:

--- a/lib/sync.py
+++ b/lib/sync.py
@@ -391,7 +391,10 @@ def file_manifest(root: Path) -> dict[str, dict]:
             continue
         digest = hashlib.sha256(path.read_bytes()).hexdigest()
         stat = path.stat()
-        manifest[str(rel)] = {"size": stat.st_size, "mtime": stat.st_mtime, "sha256": digest}
+        # Manifest keys are the sync wire format: always POSIX-separated, or a
+        # Windows peer forks every key ("a\\b.md" vs "a/b.md") and re-transfers
+        # the whole workspace both ways on every pass.
+        manifest[rel.as_posix()] = {"size": stat.st_size, "mtime": stat.st_mtime, "sha256": digest}
     return manifest
 
 

--- a/lib/sync.py
+++ b/lib/sync.py
@@ -360,6 +360,26 @@ def set_cursor(con, key: str, value: int) -> None:
     con.commit()
 
 
+# ── contact block exchange ─────────────────────────────────────────────────────
+
+def merge_contact(base: dict, incoming: dict) -> tuple[dict, int]:
+    """Fill empty fields of `base` from `incoming`; never overwrite non-empty.
+
+    config.json itself is machine-local (holds API keys, PAT, paths), so the
+    contact block is exchanged separately — a fresh peer would otherwise
+    generate documents with blank headers. Returns (merged, filled_count).
+    """
+    merged = dict(base)
+    filled = 0
+    for key in set(base) | set(incoming):
+        current = str(merged.get(key, "") or "").strip()
+        candidate = str(incoming.get(key, "") or "").strip()
+        if not current and candidate:
+            merged[key] = candidate
+            filled += 1
+    return merged, filled
+
+
 # ── workspace file sync ────────────────────────────────────────────────────────
 
 # Everything document-like syncs; databases, config, backups, and index

--- a/lib/sync_client.py
+++ b/lib/sync_client.py
@@ -6,6 +6,8 @@ resolves to the owner's partition. One `run_sync()` pass:
 
   1. pull rows:  cloud journal since our cursor → apply locally
   2. push rows:  local journal since our cursor → cloud applies
+     (then the config.json contact block is exchanged fill-empty-only —
+     config itself is machine-local and never file-syncs)
   3. files:      manifest diff (lib.sync.plan_file_sync) → transfer both ways;
                  true conflicts keep the remote copy as a " (sync conflict…)"
                  sibling instead of overwriting local work
@@ -147,6 +149,10 @@ def run_sync() -> dict:
                     break
             summary["rows_pushed"] = pushed
 
+            # 2b. contact block (config.json is machine-local; exchange just
+            # the contact dict so a fresh peer doesn't generate blank headers)
+            summary["contact"] = _sync_contact(http)
+
             # 3. files
             local = file_manifest(root)
             resp = http.post("/api/sync/files/manifest", json={})
@@ -241,6 +247,53 @@ def last_summary() -> "dict | None":
             "SELECT value FROM sync_meta WHERE key = ?", (_LAST_SUMMARY,)
         ).fetchone()
     return json.loads(row[0]) if row else None
+
+
+def _desktop_config_path() -> Path:
+    env_cfg = os.environ.get("JOBCONTEXT_CONFIG", "").strip()
+    if env_cfg:
+        return Path(env_cfg).expanduser()
+    from lib.app_dirs import desktop_data_dir
+
+    return desktop_data_dir() / "config.json"
+
+
+def _sync_contact(http) -> dict:
+    """Exchange the contact block with the cloud; fill-empty-only both ways.
+
+    Non-fatal by design: an older cloud without the endpoint (404) or any
+    other failure is reported in the summary and the pass continues.
+    """
+    from lib.config import update_runtime_config
+    from lib.sync import merge_contact
+
+    try:
+        config_path = _desktop_config_path()
+        try:
+            cfg = json.loads(config_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            cfg = {}
+        local_contact = cfg.get("contact", {}) or {}
+        resp = http.post("/api/sync/contact", json={"contact": local_contact})
+        if getattr(resp, "status_code", 200) == 404:
+            return {"status": "unsupported"}
+        resp.raise_for_status()
+        data = resp.json()
+        merged, filled_local = merge_contact(local_contact, data.get("contact", {}) or {})
+        if filled_local:
+            cfg["contact"] = merged
+            config_path.write_text(
+                json.dumps(cfg, indent=2, ensure_ascii=False), encoding="utf-8"
+            )
+            update_runtime_config({"contact": merged})
+        return {
+            "status": "ok",
+            "filled_local": filled_local,
+            "filled_cloud": data.get("filled", 0),
+        }
+    except Exception as exc:  # noqa: BLE001 — reported in the summary
+        _LOG.warning("contact sync failed: %s", exc)
+        return {"status": "error", "error": str(exc)[:200]}
 
 
 def _conflict_name(rel: str) -> str:

--- a/lib/sync_client.py
+++ b/lib/sync_client.py
@@ -248,7 +248,15 @@ def _conflict_name(rel: str) -> str:
     return str(p.with_name(f"{p.stem}{CONFLICT_TAG}{p.suffix}"))
 
 
+_IS_WINDOWS = os.name == "nt"
+
+
 def _pull_file(http, root: Path, rel: str, conflict: bool = False) -> None:
+    if _IS_WINDOWS and "\\" in rel:
+        # Rels are POSIX-separated; a backslash means a filename literally
+        # containing one (legal on macOS/Linux). Windows would reinterpret it
+        # as a separator and write to the wrong nested path — skip instead.
+        raise ValueError(f"filename not representable on Windows: {rel!r}")
     resp = http.post("/api/sync/files/get", json={"rel": rel})
     resp.raise_for_status()
     data = resp.json()

--- a/lib/sync_client.py
+++ b/lib/sync_client.py
@@ -11,9 +11,11 @@ resolves to the owner's partition. One `run_sync()` pass:
                  sibling instead of overwriting local work
 
 Cursors and the file baseline live in the local sync_meta table, a summary
-of the last run in sync_meta['last_summary'] for the Settings UI. Sync is
-deliberately conservative: any transport error aborts the pass with the
-cursors untouched, so a retry just resumes.
+of the last run in sync_meta['last_summary'] for the Settings UI. Row sync
+is deliberately conservative: any transport error aborts the pass with the
+cursors untouched, so a retry just resumes. File transfers skip-and-report
+per file (summary['files']['errors']) so one bad file — e.g. a
+Windows-illegal filename created on another OS — can't wedge sync forever.
 """
 from __future__ import annotations
 
@@ -157,19 +159,55 @@ def run_sync() -> dict:
             baseline = json.loads(row[0]) if row else {}
             plan = plan_file_sync(local, remote, baseline)
 
+            file_errors: list[dict] = []
+            files_skipped = 0
+            failed_pushes: set[str] = set()
+
+            def _record_failure(op: str, rel: str, exc: Exception) -> None:
+                nonlocal files_skipped
+                files_skipped += 1
+                _LOG.warning("file sync %s failed for %r: %s", op, rel, exc)
+                if len(file_errors) < 20:
+                    file_errors.append({"op": op, "rel": rel, "error": str(exc)[:200]})
+
+            # Skip-and-report per file: one bad filename (e.g. Windows-illegal
+            # chars in a Mac-created name) must not wedge the whole pass.
             for rel in plan["pull"]:
-                _pull_file(http, root, rel)
+                try:
+                    _pull_file(http, root, rel)
+                except Exception as exc:  # noqa: BLE001
+                    _record_failure("pull", rel, exc)
             for rel in plan["push"]:
-                _push_file(http, root, rel, local[rel])
+                try:
+                    _push_file(http, root, rel, local[rel])
+                except Exception as exc:  # noqa: BLE001
+                    _record_failure("push", rel, exc)
+                    failed_pushes.add(rel)
             for rel in plan["conflict"]:
                 # Keep local work; land the cloud version alongside it.
-                _pull_file(http, root, rel, conflict=True)
+                try:
+                    _pull_file(http, root, rel, conflict=True)
+                except Exception as exc:  # noqa: BLE001
+                    _record_failure("conflict", rel, exc)
             summary["files"] = {k: len(v) for k, v in plan.items()}
+            if files_skipped:
+                summary["files"]["skipped"] = files_skipped
+                summary["files"]["errors"] = file_errors
 
             # New baseline = post-sync local state.
-            baseline = file_manifest(root)
+            new_baseline = file_manifest(root)
             # Conflict copies are local-only working files, not sync state.
-            baseline = {k: v for k, v in baseline.items() if CONFLICT_TAG not in k}
+            new_baseline = {k: v for k, v in new_baseline.items() if CONFLICT_TAG not in k}
+            # A failed push never reached the cloud: keep the last agreed
+            # baseline entry so the next pass retries the push instead of
+            # mistaking the cloud's stale copy for an update and pulling it
+            # over the local work.
+            for rel in failed_pushes:
+                if rel in baseline:
+                    new_baseline[rel] = baseline[rel]
+                else:
+                    new_baseline.pop(rel, None)
+            baseline = new_baseline
             with get_connection() as con:
                 con.execute(
                     "INSERT INTO sync_meta (key, value) VALUES (?, ?) "

--- a/tests/test_fitment.py
+++ b/tests/test_fitment.py
@@ -219,6 +219,30 @@ class TestFitmentCoverageExtras:
         assert "Referral-Team/summary.md" in out
         assert saved.read_text(encoding="utf-8") == "Line one\nLine two"
 
+    def test_save_job_assessment_sanitizes_windows_illegal_chars(self, isolated_server):
+        fitment.save_job_assessment(
+            "Coke",
+            "content",
+            filename="Coke Senior Software Engineer | Atlanta, GA US | Coca-Cola - Fitment Assessment.md",
+            source="run_job_assessment",
+        )
+
+        saved = (
+            fitment.config.get_active_job_assessments_dir()
+            / "run_job_assessment"
+            / "Coke Senior Software Engineer - Atlanta, GA US - Coca-Cola - Fitment Assessment.md"
+        )
+        assert saved.is_file()
+
+    def test_save_job_assessment_default_filename_is_sanitized(self, isolated_server):
+        fitment.save_job_assessment('Acme <Labs>: "AI"', "content")
+
+        folder = fitment.config.get_active_job_assessments_dir()
+        names = [p.name for p in folder.glob("*.md")]
+        assert names, "assessment file was not saved"
+        for name in names:
+            assert not set('<>:"/\\|?*') & set(name), name
+
     def test_run_job_assessment_handles_llm_client_boot_failure(self, isolated_server):
         with patch("lib.config.get_llm_client", side_effect=RuntimeError("boom")):
             out = fitment.run_job_assessment("Stripe", "Staff Engineer", JD)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -85,3 +85,41 @@ class TestNow:
         assert re.match(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}", result), (
             f"_now() returned unexpected format: {result}"
         )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# lib.helpers.sanitize_filename
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestSanitizeFilename:
+    def test_replaces_windows_illegal_chars(self):
+        from lib.helpers import sanitize_filename
+
+        assert sanitize_filename(r'a<b>c:d"e/f\g|h?i*j') == "a-b-c-d-e-f-g-h-i-j"
+
+    def test_pipe_separated_job_title(self):
+        from lib.helpers import sanitize_filename
+
+        assert (
+            sanitize_filename(
+                "Coke Senior Software Engineer | Atlanta, GA US | Coca-Cola - Fitment Assessment.md"
+            )
+            == "Coke Senior Software Engineer - Atlanta, GA US - Coca-Cola - Fitment Assessment.md"
+        )
+
+    def test_strips_control_chars_and_trailing_dots(self):
+        from lib.helpers import sanitize_filename
+
+        assert sanitize_filename("report\x07.") == "report-"
+        assert sanitize_filename("name.md ") == "name.md"
+
+    def test_collapses_repeat_whitespace(self):
+        from lib.helpers import sanitize_filename
+
+        assert sanitize_filename("a   b") == "a b"
+
+    def test_empty_or_dot_only_falls_back(self):
+        from lib.helpers import sanitize_filename
+
+        assert sanitize_filename("   ") == "untitled"
+        assert sanitize_filename("...") == "untitled"

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -319,3 +319,123 @@ def test_sync_url_normalization():
     assert _normalize_url("http://127.0.0.1:8801") == "http://127.0.0.1:8801"
     assert _normalize_url("http://localhost:8801") == "http://localhost:8801"
     assert _normalize_url("  ") == ""
+
+
+# ── file sync execution: skip-and-report ──────────────────────────────────────
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._payload
+
+
+class _FakeHttp:
+    """Stands in for the httpx client run_sync opens against the cloud."""
+
+    def __init__(self, remote_files: dict[str, bytes], fail_put_rel: str = ""):
+        self.remote_files = remote_files
+        self.fail_put_rel = fail_put_rel
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def post(self, path, json=None):
+        import base64
+        import hashlib
+
+        if path == "/api/sync/changes":
+            return _FakeResp({"changes": [], "last_id": 0})
+        if path == "/api/sync/apply":
+            return _FakeResp({"applied": len(json["changes"])})
+        if path == "/api/sync/files/manifest":
+            manifest = {
+                rel: {"size": len(data), "mtime": 1.0, "sha256": hashlib.sha256(data).hexdigest()}
+                for rel, data in self.remote_files.items()
+            }
+            return _FakeResp({"manifest": manifest})
+        if path == "/api/sync/files/get":
+            data = self.remote_files[json["rel"]]
+            return _FakeResp({
+                "rel": json["rel"],
+                "mtime": 1.0,
+                "content_b64": base64.b64encode(data).decode("ascii"),
+            })
+        if path == "/api/sync/files/put":
+            if json["rel"] == self.fail_put_rel:
+                raise RuntimeError("upload rejected")
+            return _FakeResp({"status": "stored", "rel": json["rel"]})
+        raise AssertionError(f"unexpected POST {path}")
+
+
+def _wire_fake_sync(monkeypatch, root, http):
+    from lib import sync_client
+
+    monkeypatch.setattr(
+        sync_client, "sync_settings",
+        lambda: {"url": "https://cloud.test", "pat": "pat", "auto": True},
+    )
+    monkeypatch.setattr(sync_client, "_client", lambda url, pat: http)
+    monkeypatch.setattr(sync_client, "_local_root", lambda: root)
+    return sync_client
+
+
+def _stored_baseline():
+    rows = _rows("SELECT value FROM sync_meta WHERE key = 'file_sync_baseline'")
+    return json.loads(rows[0]["value"]) if rows else {}
+
+
+def test_run_sync_skips_unwritable_pull_and_reports(replicas, monkeypatch):
+    desktop, _ = replicas
+    with desktop:
+        http = _FakeHttp({"good.md": b"good", "bad | name.md": b"bad"})
+        sync_client = _wire_fake_sync(monkeypatch, desktop.root, http)
+
+        real_pull = sync_client._pull_file
+
+        def pull(http_, root_, rel, conflict=False):
+            if "|" in rel:  # deterministic stand-in for the Windows EINVAL
+                raise OSError(22, "Invalid argument", rel)
+            return real_pull(http_, root_, rel, conflict)
+
+        monkeypatch.setattr(sync_client, "_pull_file", pull)
+        summary = sync_client.run_sync()
+
+        assert summary["status"] == "ok", summary
+        assert (desktop.root / "good.md").read_bytes() == b"good"
+        assert summary["files"]["skipped"] == 1
+        [err] = summary["files"]["errors"]
+        assert err["op"] == "pull"
+        assert err["rel"] == "bad | name.md"
+        assert "Invalid argument" in err["error"]
+        # Skipped pull stays out of the baseline so the next pass retries it.
+        baseline = _stored_baseline()
+        assert "good.md" in baseline
+        assert "bad | name.md" not in baseline
+
+
+def test_run_sync_failed_push_keeps_rel_out_of_baseline(replicas, monkeypatch):
+    desktop, _ = replicas
+    with desktop:
+        (desktop.root / "note.md").write_text("local work", encoding="utf-8")
+        http = _FakeHttp({}, fail_put_rel="note.md")
+        sync_client = _wire_fake_sync(monkeypatch, desktop.root, http)
+
+        summary = sync_client.run_sync()
+
+        assert summary["status"] == "ok", summary
+        assert summary["files"]["skipped"] == 1
+        assert summary["files"]["errors"][0]["op"] == "push"
+        # note.md never reached the cloud: it must not enter the baseline,
+        # otherwise the next pass would misread the cloud copy as an update.
+        baseline = _stored_baseline()
+        assert "note.md" not in baseline
+        plan = sync.plan_file_sync(sync.file_manifest(desktop.root), {}, baseline)
+        assert "note.md" in plan["push"]

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -344,8 +344,9 @@ def test_sync_url_normalization():
 # ── file sync execution: skip-and-report ──────────────────────────────────────
 
 class _FakeResp:
-    def __init__(self, payload):
+    def __init__(self, payload, status_code=200):
         self._payload = payload
+        self.status_code = status_code
 
     def raise_for_status(self):
         pass
@@ -357,9 +358,18 @@ class _FakeResp:
 class _FakeHttp:
     """Stands in for the httpx client run_sync opens against the cloud."""
 
-    def __init__(self, remote_files: dict[str, bytes], fail_put_rel: str = ""):
+    def __init__(
+        self,
+        remote_files: dict[str, bytes],
+        fail_put_rel: str = "",
+        cloud_contact: dict | None = None,
+        contact_404: bool = False,
+    ):
         self.remote_files = remote_files
         self.fail_put_rel = fail_put_rel
+        self.cloud_contact = dict(cloud_contact or {})
+        self.contact_404 = contact_404
+        self.contact_posts: list[dict] = []
 
     def __enter__(self):
         return self
@@ -375,6 +385,15 @@ class _FakeHttp:
             return _FakeResp({"changes": [], "last_id": 0})
         if path == "/api/sync/apply":
             return _FakeResp({"applied": len(json["changes"])})
+        if path == "/api/sync/contact":
+            if self.contact_404:
+                return _FakeResp({"detail": "Not Found"}, status_code=404)
+            posted = dict(json.get("contact") or {})
+            self.contact_posts.append(posted)
+            from lib.sync import merge_contact
+
+            self.cloud_contact, filled = merge_contact(self.cloud_contact, posted)
+            return _FakeResp({"contact": self.cloud_contact, "filled": filled})
         if path == "/api/sync/files/manifest":
             manifest = {
                 rel: {"size": len(data), "mtime": 1.0, "sha256": hashlib.sha256(data).hexdigest()}
@@ -459,3 +478,121 @@ def test_run_sync_failed_push_keeps_rel_out_of_baseline(replicas, monkeypatch):
         assert "note.md" not in baseline
         plan = sync.plan_file_sync(sync.file_manifest(desktop.root), {}, baseline)
         assert "note.md" in plan["push"]
+
+
+# ── contact block exchange ─────────────────────────────────────────────────────
+
+def test_merge_contact_fill_empty_only():
+    base = {"name": "Frank", "email": "", "phone": "  ", "github": "gh"}
+    incoming = {"name": "Other", "email": "f@x.com", "phone": "555", "city": "Atlanta"}
+    merged, filled = sync.merge_contact(base, incoming)
+    assert merged == {
+        "name": "Frank",       # non-empty never overwritten
+        "email": "f@x.com",    # empty filled
+        "phone": "555",        # whitespace-only counts as empty
+        "github": "gh",        # keys missing from incoming survive
+        "city": "Atlanta",     # union of keys
+    }
+    assert filled == 3
+    assert sync.merge_contact({"name": "A"}, {"name": ""}) == ({"name": "A"}, 0)
+
+
+def _write_desktop_config(root, contact, monkeypatch):
+    config_path = root / "config.json"
+    config_path.write_text(
+        json.dumps({"contact": contact, "cloud_sync_pat": "keep-me"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("JOBCONTEXT_CONFIG", str(config_path))
+    return config_path
+
+
+def test_run_sync_contact_pull_fills_local_config(replicas, monkeypatch):
+    desktop, _ = replicas
+    with desktop:
+        config_path = _write_desktop_config(
+            desktop.root, {"name": "", "email": ""}, monkeypatch
+        )
+        monkeypatch.setattr(cfg, "_cfg", dict(cfg._cfg))  # runtime refresh, no leak
+        http = _FakeHttp({}, cloud_contact={"name": "Frank MacBride", "email": "f@x.com"})
+        sync_client = _wire_fake_sync(monkeypatch, desktop.root, http)
+
+        summary = sync_client.run_sync()
+
+        assert summary["contact"] == {"status": "ok", "filled_local": 2, "filled_cloud": 0}
+        saved = json.loads(config_path.read_text(encoding="utf-8"))
+        assert saved["contact"] == {"name": "Frank MacBride", "email": "f@x.com"}
+        assert saved["cloud_sync_pat"] == "keep-me"  # machine-local keys survive
+        assert cfg._cfg["contact"]["name"] == "Frank MacBride"  # live without restart
+
+
+def test_run_sync_contact_pushes_local_fields(replicas, monkeypatch):
+    desktop, _ = replicas
+    with desktop:
+        _write_desktop_config(desktop.root, {"name": "Frank", "email": ""}, monkeypatch)
+        http = _FakeHttp({}, cloud_contact={"name": "", "email": "f@x.com"})
+        sync_client = _wire_fake_sync(monkeypatch, desktop.root, http)
+
+        summary = sync_client.run_sync()
+
+        assert http.contact_posts == [{"name": "Frank", "email": ""}]
+        assert http.cloud_contact["name"] == "Frank"
+        assert summary["contact"] == {"status": "ok", "filled_local": 1, "filled_cloud": 1}
+
+
+def test_run_sync_contact_404_is_nonfatal(replicas, monkeypatch):
+    """An older cloud without the endpoint must not break the pass."""
+    desktop, _ = replicas
+    with desktop:
+        _write_desktop_config(desktop.root, {"name": ""}, monkeypatch)
+        http = _FakeHttp({"doc.md": b"hello"}, contact_404=True)
+        sync_client = _wire_fake_sync(monkeypatch, desktop.root, http)
+
+        summary = sync_client.run_sync()
+
+        assert summary["status"] == "ok", summary
+        assert summary["contact"] == {"status": "unsupported"}
+        assert (desktop.root / "doc.md").read_bytes() == b"hello"  # files still sync
+
+
+def test_sync_contact_endpoint_merges_and_persists(tmp_path, monkeypatch):
+    import asyncio
+
+    from transport.http.routes import sync as sync_routes
+
+    monkeypatch.setattr(sync_routes, "_user_root", lambda: tmp_path)
+    (tmp_path / "config.json").write_text(
+        json.dumps({"contact": {"name": "", "email": "cloud@x.com"}, "openai_api_key": "sk-keep"}),
+        encoding="utf-8",
+    )
+
+    out = asyncio.run(
+        sync_routes.sync_contact(
+            sync_routes.ContactExchange(contact={"name": "Frank", "email": "peer@x.com"}),
+            user=None,
+        )
+    )
+
+    assert out["filled"] == 1
+    assert out["contact"] == {"name": "Frank", "email": "cloud@x.com"}
+    saved = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
+    assert saved["contact"] == {"name": "Frank", "email": "cloud@x.com"}
+    assert saved["openai_api_key"] == "sk-keep"  # other keys preserved
+
+
+def test_sync_contact_endpoint_tolerates_missing_config(tmp_path, monkeypatch):
+    import asyncio
+
+    from transport.http.routes import sync as sync_routes
+
+    monkeypatch.setattr(sync_routes, "_user_root", lambda: tmp_path)
+
+    out = asyncio.run(
+        sync_routes.sync_contact(
+            sync_routes.ContactExchange(contact={"name": "Frank"}), user=None
+        )
+    )
+
+    assert out == {"contact": {"name": "Frank"}, "filled": 1}
+    saved = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
+    assert saved["contact"] == {"name": "Frank"}

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -300,6 +300,26 @@ def test_plan_respects_deletions_via_baseline():
     assert plan == {"pull": [], "push": [], "conflict": []}
 
 
+def test_file_manifest_keys_are_posix(tmp_path):
+    """Manifest keys are the sync wire format — POSIX-separated on every OS,
+    or a Windows peer forks each key and re-transfers the whole workspace."""
+    nested = tmp_path / "07-Job-Assessments" / "run_job_assessment"
+    nested.mkdir(parents=True)
+    (nested / "note.md").write_text("x")
+    manifest = sync.file_manifest(tmp_path)
+    assert list(manifest) == ["07-Job-Assessments/run_job_assessment/note.md"]
+
+
+def test_pull_file_rejects_backslash_rel_on_windows(tmp_path, monkeypatch):
+    """A rel with a literal backslash (legal filename on macOS/Linux) must be
+    skipped on Windows, not reinterpreted as a path separator."""
+    from lib import sync_client
+
+    monkeypatch.setattr(sync_client, "_IS_WINDOWS", True)
+    with pytest.raises(ValueError, match="not representable"):
+        sync_client._pull_file(None, tmp_path, r"weird\name.md")
+
+
 def test_file_manifest_excludes_machine_local(tmp_path):
     (tmp_path / "db").mkdir()
     (tmp_path / "db" / "jobcontextmcp.db").write_bytes(b"x")

--- a/tools/fitment.py
+++ b/tools/fitment.py
@@ -4,6 +4,7 @@ import re
 
 from lib.io import _load_master_context
 from lib import config
+from lib.helpers import sanitize_filename
 from lib.openai_calls import create_chat_completion
 from tools.interviews import get_interview_context
 
@@ -214,12 +215,13 @@ def save_job_assessment(company: str, content: str, filename: str = "", source: 
 
     If `source` is provided (e.g. 'Miguel Referral', 'AirBnb', 'Cold Apply'), the file is
     saved into a subfolder of that name under 07-Job-Assessments/ for organisation.
-    Filename defaults to {Company} - Fitment Assessment.md.
+    Filename defaults to {Company} - Fitment Assessment.md. Illegal filename
+    characters are replaced so saved files sync to Windows peers.
     Always use this tool to save assessments instead of creating files directly.
     """
     if not filename:
-        slug = company.strip().replace("/", "-")
-        filename = f"{slug} - Fitment Assessment.md"
+        filename = f"{company.strip()} - Fitment Assessment.md"
+    filename = sanitize_filename(filename)
     if not filename.endswith(".md"):
         filename += ".md"
 
@@ -228,15 +230,13 @@ def save_job_assessment(company: str, content: str, filename: str = "", source: 
     _assessments_folder = config.get_active_job_assessments_dir()
     folder = _assessments_folder
     if source:
-        # Sanitise source into a safe folder name
-        safe_source = source.strip().replace("/", "-").replace("\\", "-")
-        folder = folder / safe_source
+        folder = folder / sanitize_filename(source)
 
     target = folder / filename
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(cleaned, encoding="utf-8")
 
-    relative = target.relative_to(_assessments_folder)
+    relative = target.relative_to(_assessments_folder).as_posix()
     return f"\u2713 Saved job assessment: {relative}"
 
 
@@ -320,7 +320,7 @@ def run_job_assessment(company: str, role: str, job_description: str, persona: s
         cost_note = f"  tokens: {usage.prompt_tokens} in / {usage.completion_tokens} out / est ${est:.4f}\n"
 
     if auto_save:
-        slug = f"{company} {role} - Fitment Assessment.md".replace("/", "-")
+        slug = f"{company} {role} - Fitment Assessment.md"
         save_result = save_job_assessment(company, content, slug, source="run_job_assessment")
     else:
         save_result = "(not saved — pass auto_save=True to persist)"

--- a/transport/http/routes/sync.py
+++ b/transport/http/routes/sync.py
@@ -68,6 +68,39 @@ async def sync_apply(
         return apply_changes(con, request.changes)
 
 
+class ContactExchange(BaseModel):
+    contact: dict = {}
+
+
+@router.post("/contact")
+async def sync_contact(
+    request: ContactExchange,
+    user: Annotated[User, Depends(require_authenticated_user)],  # noqa: ARG001
+) -> dict:
+    """Exchange the config.json contact block (fill-empty-only, both ways).
+
+    config.json stays out of file sync (machine-local keys), so a fresh peer
+    posts its contact block here: empty fields on this partition fill from
+    the peer, and the merged block returns for the peer to fill from.
+    """
+    import json
+
+    from lib.sync import merge_contact
+
+    config_path = _user_root() / "config.json"
+    try:
+        cfg = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        cfg = {}
+    merged, filled = merge_contact(cfg.get("contact", {}) or {}, request.contact)
+    if filled:
+        cfg["contact"] = merged
+        config_path.write_text(
+            json.dumps(cfg, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+    return {"contact": merged, "filled": filled}
+
+
 @router.post("/files/manifest")
 async def sync_files_manifest(
     user: Annotated[User, Depends(require_authenticated_user)],  # noqa: ARG001


### PR DESCRIPTION
## Summary
- **Root cause**: `run_job_assessment` built filenames from piped job titles ("Role | Location | Company") stripping only `/` — `|` and other Windows-illegal chars landed in filenames created on macOS/cloud (Linux), then `[Errno 22] Invalid argument` crashed the Windows desktop's sync file-pull. Because the file baseline persists only after a fully clean pass, sync was **permanently wedged** (the CLAUDE.md "open task").
- New `lib/helpers.sanitize_filename` replaces Windows-illegal chars (`<>:"/\|?*` + control chars), collapses whitespace, strips trailing dots/spaces. Applied in `tools/fitment.py` at creation (filename, default slug, and source subfolder).
- `lib/sync_client.run_sync` now skips-and-reports per file (`last_summary.files.errors` / `.skipped`) instead of aborting the whole pass. Failed **pushes** keep their last agreed baseline entry so the next pass retries the push rather than pulling the cloud's stale copy over local work (data-loss guard).
- `save_job_assessment` reports the saved path with posix separators on all platforms.
- Docs: CLAUDE.md open-task line updated; stale "mobile lives on feat/mobile-app" note fixed (mobile is merged to main).

## Remaining gap
The sync protocol has no file-delete propagation, so a bad-named file already in a partition must be renamed there manually (kubectl exec + mv). Frank's partition has one such file pending rename.

## Test plan
- [x] `sanitize_filename` unit tests (illegal chars, piped title, control chars, trailing dots, whitespace, empty fallback)
- [x] `save_job_assessment` with piped/illegal names produces legal filenames (tests/test_fitment.py)
- [x] `run_sync` skips an unwritable pull, reports it in summary, keeps it out of the baseline (retry next pass)
- [x] `run_sync` failed push stays out of the baseline; replans as push
- [x] Full suite: no new failures vs main (15 pre-existing Windows-env failures identical on clean tree; Linux CI is the gate)
- [ ] After cloud-side rename of the existing bad file: desktop sync completes with `status: ok`