### PR TITLE
feat(auth): configurable display name for the API-key identity

### DIFF
--- a/.env.pi.example
+++ b/.env.pi.example
@@ -27,3 +27,6 @@ PI_FOUNDRY_API_VERSION=
 PI_OURA_CLIENT_ID=
 PI_OURA_CLIENT_SECRET=
 PI_APP_ENCRYPTION_KEY=
+
+# Display name for the single API-key identity (default "Admin")
+PI_API_KEY_USER_NAME=

--- a/k8s/pi/deployment.yaml
+++ b/k8s/pi/deployment.yaml
@@ -75,6 +75,13 @@ spec:
                   name: jcmcp-pi-app-secrets
                   key: api_key
                   optional: true
+            # Display name for the API-key identity ("Admin" when unset).
+            - name: API_KEY_USER_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: jcmcp-pi-app-secrets
+                  key: api_key_user_name
+                  optional: true
             - name: LLM_PROVIDER
               valueFrom:
                 secretKeyRef:

--- a/scripts/pi-deploy.sh
+++ b/scripts/pi-deploy.sh
@@ -77,6 +77,7 @@ apply_all() {
     printf 'entra_client_id=%s\n' "${PI_ENTRA_CLIENT_ID:-}"
     printf 'entra_client_secret=%s\n' "${PI_ENTRA_CLIENT_SECRET:-}"
     printf 'api_key=%s\n' "${PI_API_KEY:-}"
+    printf 'api_key_user_name=%s\n' "${PI_API_KEY_USER_NAME:-}"
     printf 'llm_provider=%s\n' "${PI_LLM_PROVIDER:-}"
     printf 'llm_api_key=%s\n' "${PI_LLM_API_KEY:-}"
     printf 'oura_client_id=%s\n' "${PI_OURA_CLIENT_ID:-}"

--- a/tests/test_entra_auth.py
+++ b/tests/test_entra_auth.py
@@ -391,6 +391,27 @@ class TestApiKeyAuthProvider:
         assert user is None
         reset_settings_cache()
 
+    def test_display_name_defaults_to_admin(self, monkeypatch):
+        monkeypatch.delenv("API_KEY", raising=False)
+        monkeypatch.delenv("API_KEY_USER_NAME", raising=False)
+        from transport.http.config import reset_settings_cache
+        reset_settings_cache()
+        user = self._provider().authenticate_request(None, None)
+        assert user.name == "Admin"
+        reset_settings_cache()
+
+    def test_display_name_configurable_but_id_stable(self, monkeypatch):
+        # id is load-bearing (data partitions to users/{id}) — only the
+        # greeting name may change with API_KEY_USER_NAME.
+        monkeypatch.delenv("API_KEY", raising=False)
+        monkeypatch.setenv("API_KEY_USER_NAME", "Frank")
+        from transport.http.config import reset_settings_cache
+        reset_settings_cache()
+        user = self._provider().authenticate_request(None, None)
+        assert user.name == "Frank"
+        assert user.id == "admin"
+        reset_settings_cache()
+
 
 # ===========================================================================
 # transport/http/security.py — get_auth_provider factory

--- a/transport/http/security.py
+++ b/transport/http/security.py
@@ -26,7 +26,18 @@ class User:
     roles: tuple[str, ...] = ("admin",)
 
 
-_SYSTEM_USER = User(id="admin", name="Admin", roles=("admin",))
+def _system_user() -> User:
+    """The single identity behind API-key / no-auth mode.
+
+    The id is load-bearing — data partitions to users/{id} — so only the
+    display name is configurable (API_KEY_USER_NAME, e.g. self-hosted
+    single-user deployments that would rather not be greeted as "Admin").
+    """
+    return User(
+        id="admin",
+        name=os.environ.get("API_KEY_USER_NAME", "Admin"),
+        roles=("admin",),
+    )
 
 
 def _normalize_bearer(raw: str | None) -> str | None:
@@ -77,20 +88,20 @@ class ApiKeyAuthProvider(AuthProvider):
     def authenticate_request(self, authorization: str | None, session_token: str | None) -> User | None:
         settings = get_settings()
         if not settings.auth_enabled:
-            return _SYSTEM_USER
+            return _system_user()
 
         token = _normalize_bearer(authorization) or (session_token.strip() if session_token else None)
         if token and token == settings.api_key:
-            return _SYSTEM_USER
+            return _system_user()
         return None
 
     def authenticate_login(self, credential: str) -> tuple[User, str] | None:
         settings = get_settings()
         if not settings.auth_enabled:
-            return (_SYSTEM_USER, "")
+            return (_system_user(), "")
         if credential and credential.strip() == settings.api_key:
             # Session token is the same API key for the current provider.
-            return (_SYSTEM_USER, settings.api_key or "")
+            return (_system_user(), settings.api_key or "")
         return None
 
 


### PR DESCRIPTION
## Summary
- Adds `API_KEY_USER_NAME` env var to customize the display name shown for
  the single API-key/no-auth identity (defaults to "Admin" when unset).
- The user `id` stays `"admin"` regardless — it's load-bearing since data
  partitions to `users/{id}`. Only the greeting name is configurable.
- Wired through the Pi deploy path: `k8s/pi/deployment.yaml` reads it from
  the `jcmcp-pi-app-secrets` secret, `scripts/pi-deploy.sh` forwards
  `PI_API_KEY_USER_NAME` into that secret over stdin, and
  `.env.pi.example` documents the new var.

## Test plan
- `tests/test_entra_auth.py`: new cases cover the default ("Admin") and a
  configured name, asserting `id` stays `"admin"` either way.
- `.venv/bin/python -m pytest tests/test_entra_auth.py -q` — 53 passed.