### PR TITLE
fix(http): /health auth_enabled reflects active auth provider

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,14 +149,17 @@ def http_client_noauth(monkeypatch, isolated_server):
     from fastapi.testclient import TestClient
     from transport.http.app import create_app
     from transport.http.config import reset_settings_cache
+    from transport.http.security import reset_auth_provider_cache
 
     monkeypatch.delenv("API_KEY", raising=False)
     monkeypatch.delenv("ENABLE_REMOTE", raising=False)
     reset_settings_cache()
+    reset_auth_provider_cache()
     app = create_app()
     with TestClient(app) as client:
         yield client
     reset_settings_cache()
+    reset_auth_provider_cache()
 
 
 @pytest.fixture()
@@ -165,14 +168,17 @@ def http_client_authed(monkeypatch, isolated_server):
     from fastapi.testclient import TestClient
     from transport.http.app import create_app
     from transport.http.config import reset_settings_cache
+    from transport.http.security import reset_auth_provider_cache
 
     monkeypatch.setenv("API_KEY", "test-key")
     monkeypatch.delenv("ENABLE_REMOTE", raising=False)
     reset_settings_cache()
+    reset_auth_provider_cache()
     app = create_app()
     with TestClient(app) as client:
         yield client
     reset_settings_cache()
+    reset_auth_provider_cache()
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/tests/test_entra_auth.py
+++ b/tests/test_entra_auth.py
@@ -276,6 +276,36 @@ class TestEntraAuthMiddleware:
 
 
 # ===========================================================================
+# transport/http/routes/health.py — auth_enabled reflects the active provider
+# ===========================================================================
+
+class TestHealthAuthEnabled:
+    def test_health_reports_auth_enabled_under_entra(self, monkeypatch, isolated_server):
+        """Entra deployments set ENTRA_* but no API_KEY; /health must still
+        report auth_enabled=true (regression: it read settings.auth_enabled,
+        which only reflects API_KEY)."""
+        from fastapi.testclient import TestClient
+        from transport.http.app import create_app
+        from transport.http.config import reset_settings_cache
+        from transport.http.security import reset_auth_provider_cache
+
+        monkeypatch.setenv("ENTRA_TENANT_ID", "tenant")
+        monkeypatch.setenv("ENTRA_CLIENT_ID", "client")
+        monkeypatch.delenv("API_KEY", raising=False)
+        reset_settings_cache()
+        reset_auth_provider_cache()
+        try:
+            app = create_app()
+            with TestClient(app) as client:
+                r = client.get("/health")
+            assert r.status_code == 200
+            assert r.json()["auth_enabled"] is True
+        finally:
+            reset_settings_cache()
+            reset_auth_provider_cache()
+
+
+# ===========================================================================
 # transport/http/security.py — EntraAuthProvider
 # ===========================================================================
 

--- a/transport/http/routes/health.py
+++ b/transport/http/routes/health.py
@@ -3,8 +3,8 @@
 from fastapi import APIRouter
 
 from lib.version import __version__ as _VERSION
-from transport.http.config import get_settings
 from transport.http.models import HealthResponse
+from transport.http.security import get_auth_provider
 
 
 router = APIRouter(tags=["health"])
@@ -13,8 +13,9 @@ router = APIRouter(tags=["health"])
 @router.get("/health")
 @router.get("/healthz", include_in_schema=False)  # desktop-shell / k8s probe alias
 async def health() -> HealthResponse:
-    settings = get_settings()
+    # Ask the active provider, not settings.auth_enabled — that flag only
+    # reflects API_KEY, so Entra deployments would report auth_enabled=false.
     return HealthResponse(
         version=_VERSION,
-        auth_enabled=settings.auth_enabled,
+        auth_enabled=get_auth_provider().auth_enabled,
     )


### PR DESCRIPTION
## Problem

`/health` reports `auth_enabled: settings.auth_enabled`, which is just `bool(API_KEY)` from `transport/http/config.py`. On Entra deployments (qa/prod set `ENTRA_TENANT_ID`/`ENTRA_CLIENT_ID`, no `API_KEY`), the endpoint reported `auth_enabled: false` while auth was actually enforced by `EntraAuthProvider`.

## Fix

The health route now asks `get_auth_provider().auth_enabled` (transport/http/security.py) instead of settings:
- `EntraAuthProvider.auth_enabled` is always `True` → Entra deployments now report correctly.
- `ApiKeyAuthProvider.auth_enabled` still reads settings fresh → API-key and no-auth modes unchanged.

## Tests

- New regression test `TestHealthAuthEnabled::test_health_reports_auth_enabled_under_entra` (ENTRA_* set, no API_KEY → `auth_enabled: true`). Verified it fails against the old route.
- `http_client_noauth`/`http_client_authed` fixtures now also clear the `lru_cache`d auth provider alongside the settings cache, since the health route now depends on it (guards against cross-test ordering with Entra tests).
- `tests/test_entra_auth.py` + `tests/test_http_api.py`: 100 passed. Other health-touching suites (mobile, desktop mode, dashboard, exports, coverage extras, nudge): 204 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)