### PR TITLE
Promote qa → main: MCP tool bug fixes, Pi kiosk watchdog, mobile EAS CI

### DIFF
--- a/.github/workflows/mobile-eas-build.yml
+++ b/.github/workflows/mobile-eas-build.yml
@@ -1,0 +1,76 @@
+name: Mobile EAS Build
+
+# Manual dispatch only — mobile ships on its own cadence, not on every push
+# to main (deploy.yml's paths-ignore already excludes mobile/** anyway).
+# Runs the actual native build on Expo's own cloud build infra via eas-cli;
+# this workflow just triggers/monitors it, it does not compile anything
+# itself. Submitting to TestFlight is opt-in and only valid for the
+# production profile on iOS — everything else is build-only by design
+# (a bad dev/preview build shouldn't ever reach App Store Connect).
+#
+# Requires an EXPO_TOKEN repo secret (an Expo access token, not a password
+# see https://expo.dev/accounts/[account]/settings/access-tokens) and, for
+# iOS builds/submits, Apple credentials already stored in EAS's own
+# credential service (`npx eas-cli credentials` from a local machine) —
+# this workflow supplies no Apple secrets itself.
+
+on:
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: "EAS build profile"
+        type: choice
+        options: [development, preview, production]
+        default: development
+      platform:
+        description: "Target platform"
+        type: choice
+        options: [ios, android, all]
+        default: ios
+      submit:
+        description: "Submit the build to TestFlight afterward (production + ios only)"
+        type: boolean
+        default: false
+
+concurrency:
+  group: mobile-eas-build-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: eas build (${{ inputs.profile }} / ${{ inputs.platform }})
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mobile
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: mobile/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: EAS build
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: |
+          npx eas-cli build \
+            --platform "${{ inputs.platform }}" \
+            --profile "${{ inputs.profile }}" \
+            --non-interactive
+
+      - name: Submit to TestFlight
+        if: ${{ inputs.submit == 'true' }}
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: |
+          if [ "${{ inputs.profile }}" != "production" ] || { [ "${{ inputs.platform }}" != "ios" ] && [ "${{ inputs.platform }}" != "all" ]; }; then
+            echo "::error::submit=true requires profile=production and platform=ios (or all) — refusing to submit a non-production/non-iOS build to TestFlight."
+            exit 1
+          fi
+          npx eas-cli submit --platform ios --latest --non-interactive

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/version-1.2.0-blue" alt="Version 1.2.0"/>
-  <img src="https://img.shields.io/badge/tests-1415%20passing-brightgreen" alt="1415 tests passing"/>
+  <img src="https://img.shields.io/badge/tests-1434%20passing-brightgreen" alt="1434 tests passing"/>
   <a href="https://sonarcloud.io/component_measures?id=JustLikeFrank3_jobContextMCP&metric=coverage"><img src="https://sonarcloud.io/api/project_badges/measure?project=JustLikeFrank3_jobContextMCP&metric=coverage" alt="Coverage"/></a>
   <img src="https://img.shields.io/badge/tools-11%20domains%20%C2%B7%2085%20actions-informational" alt="11 domain tools, 85 actions"/>
   <img src="https://img.shields.io/badge/license-MIT-lightgrey" alt="MIT License"/>
@@ -35,7 +35,7 @@ Available as a **double-clickable desktop app** (macOS · Windows · Linux), a l
 | | |
 |---|---|
 | 11 domain tools (85 actions) | Resume + cover letter generation |
-| 1415 passing tests | Job fitment analysis with persona lenses |
+| 1434 passing tests | Job fitment analysis with persona lenses |
 | SQLite persistence + JSON fallback | Interview prep + debrief logging |
 | Local RAG semantic search | Outreach + relationship tracking |
 | Azure AKS deployment | Microsoft Entra ID authentication |

--- a/scripts/pi-deploy.sh
+++ b/scripts/pi-deploy.sh
@@ -231,15 +231,42 @@ KC
   kiosk-setup)
     # TV kiosk on the Pi's own HDMI: waits for Grafana (slow k3s cold start
     # on the SD card) then runs chromium full-screen; fires via XDG autostart
-    # on the desktop auto-login. Verified to survive reboots unattended.
+    # on the desktop auto-login. Self-healing: the wait loop never gives up
+    # (a bounded 60-try/5min cap left chromium showing a permanent
+    # ERR_CONNECTION_TIMED_OUT blank-white page if Grafana wasn't up yet —
+    # e.g. wlan0 DHCP handing out a different lease than the hardcoded IP
+    # after a reboot, 2026-07-15 incident), and a watchdog keeps checking
+    # the URL after launch, relaunching chromium if it goes unreachable for
+    # ~90s so later network blips don't strand a dead page either.
     ssh "${PI}" 'sudo tee /usr/local/bin/wallboard-kiosk.sh >/dev/null << "EOF"
 #!/bin/bash
 URL="http://192.168.68.51:3000/playlists/play/afs4gyxml4uf4f?kiosk"
-for i in $(seq 1 60); do
-  curl -sf -o /dev/null --max-time 3 "$URL" && break
-  sleep 5
+
+wait_for_url() {
+  until curl -sf -o /dev/null --max-time 3 "$URL"; do
+    sleep 5
+  done
+}
+
+while true; do
+  wait_for_url
+  chromium --password-store=basic --kiosk --noerrdialogs --disable-infobars --disable-session-crashed-bubble "$URL" &
+  CHROME_PID=$!
+  fails=0
+  while kill -0 "$CHROME_PID" 2>/dev/null; do
+    sleep 30
+    if curl -sf -o /dev/null --max-time 5 "$URL"; then
+      fails=0
+    else
+      fails=$((fails + 1))
+    fi
+    if [ "$fails" -ge 3 ]; then
+      kill "$CHROME_PID" 2>/dev/null
+      wait "$CHROME_PID" 2>/dev/null
+      break
+    fi
+  done
 done
-exec chromium --password-store=basic --kiosk --noerrdialogs --disable-infobars --disable-session-crashed-bubble "$URL"
 EOF
       sudo chmod +x /usr/local/bin/wallboard-kiosk.sh
       mkdir -p ~/.config/autostart

--- a/server.py
+++ b/server.py
@@ -223,6 +223,8 @@ log_mental_health_checkin = health.log_mental_health_checkin
 get_mental_health_log = health.get_mental_health_log
 
 log_personal_story = context.log_personal_story
+update_personal_story = context.update_personal_story
+delete_personal_story = context.delete_personal_story
 get_personal_context = context.get_personal_context
 
 log_tone_sample = tone.log_tone_sample

--- a/templates/latex_assets/sections/experience.tex
+++ b/templates/latex_assets/sections/experience.tex
@@ -5,7 +5,7 @@
 \subsection{{\textbf{Senior Software Engineer} \textit{\ \ Contoso Cloud, Remote} \hfill 20XX --- Present}}
 \begin{zitemize}
 \item Led design and delivery of a customer-facing service from architecture through production and on-call; quantify the impact here (latency, scale, revenue, or adoption).
-\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1415 passing tests at 80\%+ line coverage through disciplined TDD.
+\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1434 passing tests at 80\%+ line coverage through disciplined TDD.
 \item Drove a cross-team win — a migration, a shared API pattern others adopted, or an SLA target consistently met.
 \end{zitemize}
 %====================

--- a/tests/test_consolidated_tools.py
+++ b/tests/test_consolidated_tools.py
@@ -1,6 +1,6 @@
 """Tests for the consolidated MCP tool surface (tools/consolidated.py).
 
-The 11 domain facades must expose every capability of the legacy 85-tool
+The 11 domain facades must expose every capability of the legacy 87-tool
 surface: each action maps to a real function, dispatch forwards exactly the
 parameters the target accepts, and errors are actionable strings (never
 tracebacks). The registered tool count is pinned so the surface can't
@@ -31,10 +31,12 @@ def test_every_action_targets_a_callable():
 
 
 def test_action_count_covers_legacy_surface():
-    # 84 actions ≙ the 85 legacy tools minus get_session_context's dual role
-    # (session startup is folded into insights.session_context).
+    # 86 actions ≙ the 87 legacy tools minus get_session_context's dual role
+    # (session startup is folded into insights.session_context). Bumped from
+    # 85/84 when stories gained update/delete (a wrong fact could only be
+    # superseded by a second entry before, never corrected in place).
     total = sum(len(a) for a in DOMAINS.values())
-    assert total == 85, f"action count changed: {total} — update this pin deliberately"
+    assert total == 87, f"action count changed: {total} — update this pin deliberately"
 
 
 def test_facade_params_cover_every_target_param():
@@ -144,9 +146,9 @@ def test_chat_allowlist_matches_domain_names():
     assert set(CHAT_TOOL_ALLOWLIST) == set(FACADES)
 
 
-@pytest.mark.parametrize("flag,expected", [("", 11), ("1", 85)])
+@pytest.mark.parametrize("flag,expected", [("", 11), ("1", 87)])
 def test_server_surface_size(flag, expected, tmp_path):
-    """server.py registers 11 consolidated tools by default, 85 legacy ones
+    """server.py registers 11 consolidated tools by default, 87 legacy ones
     behind JOBCONTEXT_LEGACY_TOOLS=1.
 
     Runs in a subprocess: re-importing server inside the test process would
@@ -167,3 +169,141 @@ def test_server_surface_size(flag, expected, tmp_path):
     )
     assert out.returncode == 0, out.stderr[-800:]
     assert int(out.stdout.strip().splitlines()[-1]) == expected
+
+
+# ── facade type coercion (str-schema -> real int/list/dict params) ────────────
+#
+# Facades intentionally expose plain strings for params whose real target
+# takes an int/list/dict (see module docstring) — not every MCP client
+# renders nested array/object schemas well. _coerce_param() bridges that gap.
+# These regression-test the bugs that existed before it did: a str/int
+# mismatch matched nothing with no error (post_metrics post_id), and a
+# comma-separated string handed straight to a list param got shredded into
+# single characters by downstream ', '.join() calls (people tags).
+
+from tools.consolidated import _coerce_param  # noqa: E402
+
+
+class TestCoerceParam:
+    def test_int_param_accepts_plain_numeric_string(self):
+        assert _coerce_param("post_id", "39", int | None) == 39
+
+    def test_int_param_strips_leading_hash(self):
+        """get_linkedin_posts() prints ids as '#39' — that exact string must
+        also work, not just the bare number."""
+        assert _coerce_param("post_id", "#39", int | None) == 39
+
+    def test_int_param_rejects_non_numeric_with_clean_error(self):
+        with pytest.raises(ValueError, match="post_id must be a number"):
+            _coerce_param("post_id", "not-a-number", int | None)
+
+    def test_list_param_splits_comma_separated_string(self):
+        assert _coerce_param("tags", "java, spring, sql", list[str] | None) == [
+            "java", "spring", "sql",
+        ]
+
+    def test_list_param_passthrough_when_already_a_list(self):
+        assert _coerce_param("tags", ["java", "spring"], list[str] | None) == [
+            "java", "spring",
+        ]
+
+    def test_dict_param_parses_json_string(self):
+        out = _coerce_param("audience_highlights", '{"top_job_title": "SWE"}', dict | None)
+        assert out == {"top_job_title": "SWE"}
+
+    def test_dict_param_rejects_non_json_with_clean_error(self):
+        with pytest.raises(ValueError, match="must be a JSON object"):
+            _coerce_param("audience_highlights", "not json", dict | None)
+
+    def test_dict_param_rejects_json_array_with_clean_error(self):
+        with pytest.raises(ValueError, match="must be a JSON object"):
+            _coerce_param("audience_highlights", "[1, 2]", dict | None)
+
+    def test_none_passes_through_untouched(self):
+        assert _coerce_param("post_id", None, int | None) is None
+
+
+def test_run_returns_actionable_error_instead_of_raising():
+    """A bad facade value must come back as a '✗ domain.action: ...' string,
+    never propagate as a raw exception through the MCP tool boundary."""
+    out = _run("brand", "post_metrics", {"post_id": "not-a-number"})
+    assert out.startswith("✗ brand.post_metrics:")
+    assert "post_id must be a number" in out
+
+
+class TestPostLogIdentityRegression:
+    """End-to-end regression for the bug where every log_linkedin_post() call
+    sharing the same `source` (e.g. 'linkedin') silently overwrote whichever
+    post happened to share it, and post_id (typed str on the facade but int
+    on the real function) never matched anything."""
+
+    def test_post_id_as_string_updates_the_right_post(self, isolated_server):
+        FACADES["brand"](action="post_log", text="First.", source="linkedin", auto_log_tone=False)
+        FACADES["brand"](action="post_log", text="Second.", source="linkedin", auto_log_tone=False)
+        FACADES["brand"](
+            action="post_log", text="Second, corrected.", source="linkedin",
+            post_id="2", auto_log_tone=False,
+        )
+        import server as srv
+        import json
+
+        posts = json.loads(srv.LINKEDIN_POSTS_FILE.read_text())["posts"]
+        assert [p["text"] for p in posts] == ["First.", "Second, corrected."]
+
+    def test_post_metrics_by_hash_prefixed_id(self, isolated_server):
+        FACADES["brand"](action="post_log", text="Hi.", source="linkedin", auto_log_tone=False)
+        out = FACADES["brand"](action="post_metrics", post_id="#1", reactions=10)
+        assert "✓" in out and "reactions=10" in out
+
+
+class TestPeopleTagsRegression:
+    """Regression for tags being shredded into individual characters when a
+    comma-separated string reached log_person()'s list[str] parameter."""
+
+    def test_comma_separated_tags_stored_as_a_real_list(self, isolated_server):
+        FACADES["people"](
+            action="log", name="Puja Priyadarshini", relationship="recruiter",
+            company="Acme", context="Met at a conference.",
+            tags="java, spring, sql, python",
+        )
+        import server as srv
+        import json
+
+        people = json.loads(srv.PEOPLE_FILE.read_text())["people"]
+        assert people[0]["tags"] == ["java", "spring", "sql", "python"]
+
+
+class TestStoriesUpdateDelete:
+    """Bug #6: a story with a wrong fact could previously only be
+    'superseded' by a second entry, leaving the wrong one retrievable."""
+
+    def test_update_corrects_story_in_place(self, isolated_server):
+        FACADES["stories"](action="log", story="Original wrong fact.", tags="testing")
+        FACADES["stories"](action="update", story_id="1", story="Corrected fact.")
+        import server as srv
+        import json
+
+        stories = json.loads(srv.PERSONAL_CONTEXT_FILE.read_text())["stories"]
+        assert len(stories) == 1
+        assert stories[0]["story"] == "Corrected fact."
+
+    def test_delete_removes_story(self, isolated_server):
+        FACADES["stories"](action="log", story="Duplicate entry.", tags="testing")
+        FACADES["stories"](action="delete", story_id="1")
+        import server as srv
+        import json
+
+        stories = json.loads(srv.PERSONAL_CONTEXT_FILE.read_text())["stories"]
+        assert stories == []
+
+    def test_update_unknown_id_returns_clean_error(self, isolated_server):
+        out = FACADES["stories"](action="update", story_id="999", story="X.")
+        assert "999" in out and "✗" in out
+
+
+def test_outreach_status_enum_choices_surfaced_in_generated_docs():
+    """Bug #7: an enum-typed param's allowed values must be discoverable
+    from the tool description, not only from the error after a bad guess."""
+    doc = _actions_doc("people")
+    assert "outreach_status (one of: none, drafted, sent, responded)" in doc
+

--- a/tests/test_posts.py
+++ b/tests/test_posts.py
@@ -96,22 +96,40 @@ class TestLogLinkedInPost:
         _seed(source="ah_init")
         assert _posts(isolated_server)[0]["audience_highlights"] == {}
 
-    def test_update_existing_post_by_source(self, isolated_server):
+    def test_update_existing_post_by_post_id(self, isolated_server):
         _seed(source="dup_test", text="Original.")
-        srv.log_linkedin_post(text="Updated.", source="dup_test", title="New Title", auto_log_tone=False)
+        post_id = _posts(isolated_server)[0]["id"]
+        srv.log_linkedin_post(text="Updated.", source="dup_test", title="New Title", auto_log_tone=False, post_id=post_id)
         posts = _posts(isolated_server)
         assert len(posts) == 1
         assert posts[0]["text"] == "Updated."
         assert posts[0]["title"] == "New Title"
 
+    def test_same_source_without_post_id_creates_new_post(self, isolated_server):
+        """Regression for the bug where every log_linkedin_post() call with a
+        repeated source (e.g. 'linkedin') silently overwrote the newest post
+        sharing that source instead of creating a new one."""
+        _seed(source="linkedin", text="First post.")
+        _seed(source="linkedin", text="Second post.")
+        posts = _posts(isolated_server)
+        assert len(posts) == 2
+        assert {p["text"] for p in posts} == {"First post.", "Second post."}
+
+    def test_post_id_for_nonexistent_post_errors(self, isolated_server):
+        result = srv.log_linkedin_post(text="X.", source="linkedin", auto_log_tone=False, post_id=999)
+        assert "999" in result
+        assert _posts(isolated_server) == []
+
     def test_update_returns_updated_confirmation(self, isolated_server):
         _seed(source="dup_confirm")
-        result = srv.log_linkedin_post(text="Updated.", source="dup_confirm", auto_log_tone=False)
+        post_id = _posts(isolated_server)[0]["id"]
+        result = srv.log_linkedin_post(text="Updated.", source="dup_confirm", auto_log_tone=False, post_id=post_id)
         assert "Updated" in result or "updated" in result or "✓" in result
 
     def test_hashtags_deduplicated_on_update(self, isolated_server):
         _seed(source="dedup_test", hashtags=["Python"])
-        srv.log_linkedin_post(text="T.", source="dedup_test", hashtags=["Python", "MCP"], auto_log_tone=False)
+        post_id = _posts(isolated_server)[0]["id"]
+        srv.log_linkedin_post(text="T.", source="dedup_test", hashtags=["Python", "MCP"], auto_log_tone=False, post_id=post_id)
         assert _posts(isolated_server)[0]["hashtags"].count("Python") == 1
 
     def test_links_deduplicated_on_update(self, isolated_server):

--- a/tools/consolidated.py
+++ b/tools/consolidated.py
@@ -22,7 +22,9 @@ actions' parameters. These functions are dispatch-only — no human call sites.
 from __future__ import annotations
 
 import inspect
-from typing import Literal
+import json
+import types
+from typing import Literal, get_args, get_origin, Union
 
 from tools import (
     compensation,
@@ -129,6 +131,8 @@ DOMAINS: dict[str, dict[str, tuple]] = {
     },
     "stories": {
         "log": (context.log_personal_story, "Log a personal story/anecdote."),
+        "update": (context.update_personal_story, "Correct a story in place (fix a wrong fact)."),
+        "delete": (context.delete_personal_story, "Delete a story (e.g. a duplicate)."),
         "ingest": (ingest.ingest_anecdote, "Ingest an anecdote (story + optional tone sample)."),
         "personal_context": (context.get_personal_context, "Retrieve personal context by tag/person."),
         "star_context": (star.get_star_story_context, "STAR stories for a company/role."),
@@ -171,13 +175,26 @@ DOMAINS: dict[str, dict[str, tuple]] = {
 }
 
 
+def _literal_choices(annotation) -> list | None:
+    """Return a Literal type's allowed values, unwrapping an `X | None`."""
+    target = _unwrap_optional(annotation)
+    if get_origin(target) is Literal:
+        return list(get_args(target))
+    return None
+
+
+def _param_label(p: inspect.Parameter) -> str:
+    choices = _literal_choices(p.annotation)
+    return f"{p.name} (one of: {', '.join(map(str, choices))})" if choices else p.name
+
+
 def _actions_doc(domain: str) -> str:
     """Generate per-action parameter docs from the real target signatures."""
     lines = ["", "Actions:"]
     for action, (fn, summary) in DOMAINS[domain].items():
         sig = inspect.signature(fn)
-        required = [p.name for p in sig.parameters.values() if p.default is inspect.Parameter.empty]
-        optional = [p.name for p in sig.parameters.values() if p.default is not inspect.Parameter.empty]
+        required = [_param_label(p) for p in sig.parameters.values() if p.default is inspect.Parameter.empty]
+        optional = [_param_label(p) for p in sig.parameters.values() if p.default is not inspect.Parameter.empty]
         parts = [f"  {action} — {summary}"]
         if required:
             parts.append(f" Requires: {', '.join(required)}.")
@@ -187,8 +204,57 @@ def _actions_doc(domain: str) -> str:
     return "\n".join(lines)
 
 
+def _unwrap_optional(annotation):
+    """Strip an ``X | None`` union down to X; pass through anything else.
+
+    ``X | None`` (PEP 604) and ``typing.Union[X, None]`` are two different
+    origins at runtime (``types.UnionType`` vs ``typing.Union``) — every
+    real target function in this codebase uses the former, so both must be
+    checked or this silently never unwraps anything.
+    """
+    origin = get_origin(annotation)
+    if origin is Union or origin is types.UnionType:
+        args = [a for a in get_args(annotation) if a is not type(None)]
+        if len(args) == 1:
+            return args[0]
+    return annotation
+
+
+def _coerce_param(name: str, value, annotation):
+    """Bridge the facade's simple-typed (str) schema to a real function's
+    richer type (int/list/dict) — facades intentionally expose plain
+    strings (see module docstring) since not every MCP client renders
+    nested array/object schemas well; something has to turn the string
+    back into what the target function actually wants.
+
+    Raises ValueError with a caller-facing message on bad input instead of
+    letting a raw TypeError (e.g. "'str' object is not a mapping") or a
+    silent str/int mismatch (matches nothing, no error) leak through.
+    """
+    if not isinstance(value, str):
+        return value
+    target = _unwrap_optional(annotation)
+    if target is int:
+        try:
+            return int(value.strip().lstrip("#"))
+        except ValueError:
+            raise ValueError(f"{name} must be a number, got {value!r}.") from None
+    if get_origin(target) is list:
+        return [v.strip() for v in value.split(",") if v.strip()]
+    if target is dict:
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            raise ValueError(f"{name} must be a JSON object, got {value!r}.") from None
+        if not isinstance(parsed, dict):
+            raise ValueError(f"{name} must be a JSON object, got {value!r}.")
+        return parsed
+    return value
+
+
 def _run(domain: str, action: str, params: dict) -> str:
-    """Dispatch a domain call: validate the action, pass only provided params."""
+    """Dispatch a domain call: validate the action, coerce facade-simple
+    values to each param's real type, pass only provided params."""
     actions = DOMAINS[domain]
     spec = actions.get(action)
     if spec is None:
@@ -198,10 +264,14 @@ def _run(domain: str, action: str, params: dict) -> str:
         )
     fn = spec[0]
     sig = inspect.signature(fn)
-    provided = {
-        k: v for k, v in params.items()
-        if k != "action" and v is not None and k in sig.parameters
-    }
+    provided = {}
+    for k, v in params.items():
+        if k == "action" or v is None or k not in sig.parameters:
+            continue
+        try:
+            provided[k] = _coerce_param(k, v, sig.parameters[k].annotation)
+        except ValueError as e:
+            return f"✗ {domain}.{action}: {e}"
     missing = [
         p.name for p in sig.parameters.values()
         if p.default is inspect.Parameter.empty and p.name not in provided
@@ -361,7 +431,8 @@ def people_tool(
 
 
 def stories(
-    action: Literal["log", "ingest", "personal_context", "star_context", "star_all", "tone_log", "tone_profile", "tone_scan"],
+    action: Literal["log", "update", "delete", "ingest", "personal_context", "star_context", "star_all", "tone_log", "tone_profile", "tone_scan"],
+    story_id: str | None = None,
     story: str | None = None,
     tags: str | None = None,
     people: str | None = None,

--- a/tools/context.py
+++ b/tools/context.py
@@ -18,6 +18,55 @@ def log_personal_story(
     return f"✓ Story logged (#{entry['id']}): {entry['title']}"
 
 
+def update_personal_story(
+    story_id: int,
+    story: str | None = None,
+    tags: list[str] | None = None,
+    people: list[str] | None = None,
+    title: str | None = None,
+) -> str:
+    """Correct a personal story in place. A wrong fact caught after logging
+    should be fixed here, not superseded by a second entry — a superseding
+    story just leaves the wrong one sitting in the story library where it
+    can still surface in generated documents.
+
+    Only the fields you pass are changed; omit any you want to leave alone.
+    """
+    data = _load_json(config.PERSONAL_CONTEXT_FILE, {"stories": []})
+    stories = data.get("stories", [])
+    entry = next((s for s in stories if s.get("id") == story_id), None)
+    if entry is None:
+        return f"✗ No story found with id={story_id}."
+
+    if story is not None:
+        entry["story"] = story
+    if tags is not None:
+        entry["tags"] = [t.lower().strip() for t in tags]
+    if people is not None:
+        entry["people"] = list(people)
+    if title is not None:
+        entry["title"] = title
+
+    _save_json(config.PERSONAL_CONTEXT_FILE, data)
+    return f"✓ Story #{story_id} updated: {entry['title']}"
+
+
+def delete_personal_story(story_id: int) -> str:
+    """Remove a personal story from the library entirely (e.g. a duplicate,
+    or one logged in error). For a story with a wrong fact, prefer
+    update_personal_story() so the corrected version keeps its id and
+    history instead of leaving a gap."""
+    data = _load_json(config.PERSONAL_CONTEXT_FILE, {"stories": []})
+    stories = data.get("stories", [])
+    entry = next((s for s in stories if s.get("id") == story_id), None)
+    if entry is None:
+        return f"✗ No story found with id={story_id}."
+
+    stories.remove(entry)
+    _save_json(config.PERSONAL_CONTEXT_FILE, data)
+    return f"✓ Story #{story_id} deleted: {entry.get('title', '')}"
+
+
 def get_personal_context(tag: str = "", person: str = "") -> str:
     """Retrieve stored personal stories, optionally filtered by tag or person's name. Returns all stories if no filters provided."""
     data = _load_json(config.PERSONAL_CONTEXT_FILE, {"stories": []})
@@ -33,4 +82,6 @@ def get_personal_context(tag: str = "", person: str = "") -> str:
 
 def register(mcp) -> None:
     mcp.tool()(log_personal_story)
+    mcp.tool()(update_personal_story)
+    mcp.tool()(delete_personal_story)
     mcp.tool()(get_personal_context)

--- a/tools/people.py
+++ b/tools/people.py
@@ -12,6 +12,9 @@ Tools:
 from lib import config
 from lib.io import _load_json, _save_json, _now
 from tools.tone import log_tone_sample as _log_tone_sample
+from typing import Literal
+
+_VALID_STATUSES = ("none", "drafted", "sent", "responded")
 
 
 def _next_id(people: list[dict]) -> int:
@@ -33,7 +36,7 @@ def log_person(  # NOSONAR
     context: str,
     tags: list[str] | None = None,
     contact_info: str = "",
-    outreach_status: str = "none",
+    outreach_status: Literal["none", "drafted", "sent", "responded"] = "none",
     notes: str = "",
     sent_message: str = "",
 ) -> str:
@@ -60,7 +63,6 @@ def log_person(  # NOSONAR
     Returns:
         Confirmation string with the person's name and assigned ID.
     """
-    _VALID_STATUSES = ("none", "drafted", "sent", "responded")
     if outreach_status not in _VALID_STATUSES:
         return f"✗ Invalid outreach_status '{outreach_status}'. Must be one of: {', '.join(_VALID_STATUSES)}"
     tags = tags or []

--- a/tools/posts.py
+++ b/tools/posts.py
@@ -22,9 +22,22 @@ def _next_id(posts: list[dict]) -> int:
     return max(p.get("id", 0) for p in posts) + 1
 
 
-def _find_post(posts: list[dict], post_id: int | None = None, source: str = "") -> dict | None:
+def _find_post(
+    posts: list[dict], post_id: int | None = None, url: str = "", source: str = ""
+) -> dict | None:
+    """Identity lookup for an existing post.
+
+    post_id and url are unambiguous identity; source is not (callers often
+    reuse the same value like 'linkedin' across many posts) so it is only
+    accepted here for update_post_metrics()'s documented "post_id or
+    source" contract — log_linkedin_post() never passes it, since matching
+    new/updated posts on source used to silently collide every call onto
+    whichever post happened to share it, overwriting it.
+    """
     if post_id is not None:
         return next((p for p in posts if p.get("id") == post_id), None)
+    if url:
+        return next((p for p in posts if p.get("url") == url), None)
     if source:
         sl = source.strip().lower()
         return next((p for p in posts if p.get("source", "").lower() == sl), None)
@@ -41,6 +54,7 @@ def log_linkedin_post(  # NOSONAR
     links: list[str] | None = None,
     title: str = "",
     auto_log_tone: bool = True,
+    post_id: int | None = None,
 ) -> str:
     """
     Add or update a LinkedIn post in the post database.
@@ -49,9 +63,17 @@ def log_linkedin_post(  # NOSONAR
     update_post_metrics(). Optionally ingests the post as a tone sample
     (default: True) so Frank's public voice calibrates future outreach drafts.
 
+    Identity: pass post_id (from get_linkedin_posts()'s #N) to update that
+    exact post, or an exact url match to update the post it belongs to.
+    Without either, this always creates a new post — source is a label, not
+    an id, and is never used to find an existing record. When updating,
+    text/context/title are fully replaced by whatever you pass (empty/omit
+    to keep the existing value); metrics are untouched here and only ever
+    change via update_post_metrics().
+
     Args:
         text:           Full post text.
-        source:         Unique slug label (e.g. 'linkedin_post_mcp_v4').
+        source:         Descriptive label (e.g. 'linkedin'). Not a unique id.
         context:        What the post is about / why it matters.
         posted_date:    ISO date string (YYYY-MM-DD). Defaults to today.
         url:            LinkedIn post URL or short link.
@@ -59,6 +81,8 @@ def log_linkedin_post(  # NOSONAR
         links:          List of external URLs included in the post.
         title:          Short human-readable title for the post.
         auto_log_tone:  If True, also ingest post text as a tone sample.
+        post_id:        Numeric id (from get_linkedin_posts()) to update an
+                         existing post instead of creating a new one.
 
     Returns:
         Confirmation string with post ID.
@@ -68,7 +92,10 @@ def log_linkedin_post(  # NOSONAR
     data = _load_json(config.LINKEDIN_POSTS_FILE, {"posts": []})
     posts = data.setdefault("posts", [])
 
-    existing = _find_post(posts, source=source)
+    if post_id is not None and _find_post(posts, post_id=post_id) is None:
+        return f"✗ No post found with id={post_id}. Omit post_id to create a new post."
+
+    existing = _find_post(posts, post_id=post_id, url=url)
     if existing:
         existing["text"] = text or existing.get("text", "")
         existing["context"] = context or existing.get("context", "")
@@ -177,6 +204,9 @@ def update_post_metrics(
         return f"✗ No post found with {ident}."
 
     m = post.setdefault("metrics", {})
+    if not isinstance(m, dict):
+        m = {}
+        post["metrics"] = m
     updates = {
         "impressions": impressions,
         "members_reached": members_reached,
@@ -194,7 +224,12 @@ def update_post_metrics(
     m["last_checked"] = _now()[:10]
 
     if audience_highlights:
-        post["audience_highlights"] = {**post.get("audience_highlights", {}), **audience_highlights}
+        if not isinstance(audience_highlights, dict):
+            return f"✗ audience_highlights must be a dict, got {type(audience_highlights).__name__}."
+        existing_ah = post.get("audience_highlights")
+        if not isinstance(existing_ah, dict):
+            existing_ah = {}
+        post["audience_highlights"] = {**existing_ah, **audience_highlights}
 
     _save_json(config.LINKEDIN_POSTS_FILE, data)
 


### PR DESCRIPTION
Promotion after all three PRs deployed clean to qa:

- #119 fix(infra): self-healing Pi kiosk wallboard watchdog
- #120 fix(tools): repair MCP facade type coercion; add story update/delete
- #121 ci(mobile): manual EAS build/TestFlight-submit workflow

Summary of what's shipping:
- Fixed 7 bugs reported from live Claude Desktop usage against the consolidated MCP tool surface: post overwrite-by-source, facade str→int/list/dict type coercion (post_id, tags), update_post_metrics crash guards, documented merge semantics, added stories.update/stories.delete, Literal enum hints on outreach_status.
- Along the way, found and fixed a real latent bug in the coercion fix itself (get_origin(x) is Union never matched PEP 604 `X | None` annotations — types.UnionType is a different object), caught by new regression tests rather than manual smoke testing.
- Self-healing Pi kiosk wallboard watchdog: unbounded wait-for-Grafana loop + relaunch watchdog, fixes the blank-white-screen-after-reboot bug.
- New manual (workflow_dispatch) EAS build pipeline for mobile dev/preview/production builds and gated TestFlight submission.

Full backend test suite green (1434 passed, 17 skipped) at each qa deploy.