### PR TITLE
fix(security): repair Sonar new-code security gate failure

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,6 +11,32 @@ sonar.python.coverage.reportPaths=coverage.xml
 # wide, flat parameter list IS the machine-facing API the model reads. These
 # functions are dispatch-only (no human call sites) and each parameter is
 # documented per-action in the docstring.
-sonar.issue.ignore.multicriteria=e1
+#
+# The remaining ignores below are all reviewed false positives from static
+# analysis not tracing taint through a cross-module call — see the PR that
+# added each one for the human review. Genuinely fixable findings (e.g. the
+# command-argument-injection hotspot in transport/http/desktop.py) get fixed
+# in code instead of ignored here.
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4
+
 sonar.issue.ignore.multicriteria.e1.ruleKey=python:S107
 sonar.issue.ignore.multicriteria.e1.resourceKey=tools/consolidated.py
+
+# "Change this code to not construct the path from user-controlled data."
+# transport/http/routes/sync.py's _resolve_rel() always routes through
+# transport/http/desktop.py's _validated_member_path(), which whitelists
+# every path segment (rejects .., absolute paths, and Windows-reserved
+# chars) before any read/write. Sonar can't trace taint through that
+# cross-module call.
+sonar.issue.ignore.multicriteria.e2.ruleKey=pythonsecurity:S2083
+sonar.issue.ignore.multicriteria.e2.resourceKey=transport/http/routes/sync.py
+
+# "Using HTTP protocol is insecure." Both flagged lines are string-prefix
+# checks used to validate/normalize a URL, not an outgoing insecure
+# connection. lib/sync_client.py's _normalize_url() explicitly upgrades
+# http:// to https:// except for loopback (dev/self-sync).
+sonar.issue.ignore.multicriteria.e3.ruleKey=python:S5332
+sonar.issue.ignore.multicriteria.e3.resourceKey=transport/http/routes/mobile.py
+sonar.issue.ignore.multicriteria.e4.ruleKey=python:S5332
+sonar.issue.ignore.multicriteria.e4.resourceKey=lib/sync_client.py
+

--- a/tests/test_desktop_mode.py
+++ b/tests/test_desktop_mode.py
@@ -700,6 +700,57 @@ def test_open_url_http_only(desktop_client, monkeypatch):
         assert resp.status_code == 422, bad
 
 
+class TestOpenWithOsArgumentInjection:
+    """A target string starting with '-' could be misread as a CLI flag by
+    the OS opener rather than a file/URL (argument injection) — regression
+    for the Sonar S6350 hotspot on the subprocess.Popen(["open"/"xdg-open",
+    target]) calls."""
+
+    def test_dash_prefixed_target_gets_relative_prefix(self, monkeypatch):
+        import subprocess
+
+        import transport.http.desktop as desktop_mod
+
+        monkeypatch.setattr(desktop_mod.sys, "platform", "linux")
+        monkeypatch.setattr(desktop_mod.os, "name", "posix")
+        calls = []
+        monkeypatch.setattr(subprocess, "Popen", lambda args: calls.append(args))
+
+        desktop_mod._open_with_os("--dangerous-flag")
+
+        assert calls == [["xdg-open", "./--dangerous-flag"]]
+
+    def test_normal_target_is_untouched(self, monkeypatch):
+        import subprocess
+
+        import transport.http.desktop as desktop_mod
+
+        monkeypatch.setattr(desktop_mod.sys, "platform", "linux")
+        monkeypatch.setattr(desktop_mod.os, "name", "posix")
+        calls = []
+        monkeypatch.setattr(subprocess, "Popen", lambda args: calls.append(args))
+
+        desktop_mod._open_with_os("/workspace/resumes/resume.pdf")
+
+        assert calls == [["xdg-open", "/workspace/resumes/resume.pdf"]]
+
+    def test_url_target_is_never_dash_prefixed(self, monkeypatch):
+        """A validated http(s) URL can never start with '-', so the guard
+        must be a no-op for the open-url call site."""
+        import subprocess
+
+        import transport.http.desktop as desktop_mod
+
+        monkeypatch.setattr(desktop_mod.sys, "platform", "linux")
+        monkeypatch.setattr(desktop_mod.os, "name", "posix")
+        calls = []
+        monkeypatch.setattr(subprocess, "Popen", lambda args: calls.append(args))
+
+        desktop_mod._open_with_os("https://example.com/job/123")
+
+        assert calls == [["xdg-open", "https://example.com/job/123"]]
+
+
 def test_open_file_renders_markdown_to_pdf(desktop_client, desktop_data_dir_env, monkeypatch, tmp_path):
     import transport.http.desktop as desktop_mod
     from transport.http.routes.dashboard import materials

--- a/transport/http/desktop.py
+++ b/transport/http/desktop.py
@@ -345,6 +345,13 @@ async def sync_run() -> dict:
 def _open_with_os(target: str) -> None:
     import subprocess
 
+    # A target starting with '-' could be misread as a CLI flag by the OS
+    # opener (argument injection) rather than a file/URL — a real path is
+    # never affected by this (absolute paths start with '/', URLs must have
+    # a valid scheme), so the prefix is a no-op except for that edge case.
+    if target.startswith("-"):
+        target = f"./{target}"
+
     if sys.platform == "darwin":
         subprocess.Popen(["open", target])
     elif os.name == "nt":


### PR DESCRIPTION
Opened directly against `main` (not `qa`) because that's the only branch sonar.yml's `pull_request` trigger analyzes/decorates — this needs to be verified against the actual gate it's fixing.

The qa→main promotion in #122 is the first PR-into-main Sonar analysis in a while (branch analysis on `qa` is blocked on the free SonarCloud tier per sonar.yml's own comments), which is why this pre-existing debt only just surfaced. None of the 6 open vulnerability issues are from #119/#120/#121 — all predate them (created 2026-07-08).

Reviewed each on its merits rather than blanket-suppressing:

- **`pythonsecurity:S2083` (BLOCKER)** `transport/http/routes/sync.py:154` — false positive. `_resolve_rel()` always routes through `desktop.py`'s `_validated_member_path()`, which whitelists every path segment before any read/write. Sonar can't trace taint through the cross-module call. Ignored via `sonar-project.properties`, same pattern as the existing S107 entry.
- **`python:S5332` (MINOR)** `mobile.py:273`, `sync_client.py:64/67` — false positives. String-prefix checks used to validate/normalize a URL, not an outgoing insecure connection; `sync_client.py`'s `_normalize_url()` explicitly upgrades `http://` to `https://` except loopback. Ignored.
- **`pythonsecurity:S6350` (MAJOR)** `transport/http/desktop.py:349,353` — real, fixed in code instead of suppressed: `_open_with_os()` passed its target straight to `subprocess.Popen(['open'/'xdg-open', target])` without checking for a leading `-`, which some CLI tools would misread as a flag (argument injection). Now prefixes a lone `-`-leading target with `./` — a no-op for the two real call sites (absolute file paths, validated http(s) URLs), only closing the theoretical gap.

Added regression tests for the argument-injection guard. Full suite: 1437 passed, 17 skipped.