### PR TITLE
fix(ci): TestFlight submit step always skipped regardless of input

### DIFF
--- a/.github/workflows/mobile-eas-build.yml
+++ b/.github/workflows/mobile-eas-build.yml
@@ -65,7 +65,7 @@ jobs:
             --non-interactive
 
       - name: Submit to TestFlight
-        if: ${{ inputs.submit == 'true' }}
+        if: ${{ inputs.submit }}
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: |


### PR DESCRIPTION
Root cause of the submit step being skipped on both of your last two TestFlight attempts:

`if: ${{ inputs.submit == 'true' }}` compares a real boolean (`type: boolean` workflow_dispatch inputs are already booleans in the `inputs` context, not strings) against the string `'true'`. GitHub Actions' `==` coerces mismatched-type operands via `ToNumber()`; `ToNumber('true')` is `NaN`, so the comparison is always false regardless of what you pick in the checkbox — the step just silently shows as skipped.

Fixed by using the boolean directly: `if: ${{ inputs.submit }}`.