### PR TITLE
Reconcile main → qa: TestFlight-submit fix + Sonar security fixes

### DIFF
--- a/.github/workflows/mobile-eas-build.yml
+++ b/.github/workflows/mobile-eas-build.yml
@@ -65,7 +65,7 @@ jobs:
             --non-interactive
 
       - name: Submit to TestFlight
-        if: ${{ inputs.submit == 'true' }}
+        if: ${{ inputs.submit }}
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/version-1.2.0-blue" alt="Version 1.2.0"/>
-  <img src="https://img.shields.io/badge/tests-1434%20passing-brightgreen" alt="1434 tests passing"/>
+  <img src="https://img.shields.io/badge/tests-1437%20passing-brightgreen" alt="1437 tests passing"/>
   <a href="https://sonarcloud.io/component_measures?id=JustLikeFrank3_jobContextMCP&metric=coverage"><img src="https://sonarcloud.io/api/project_badges/measure?project=JustLikeFrank3_jobContextMCP&metric=coverage" alt="Coverage"/></a>
   <img src="https://img.shields.io/badge/tools-11%20domains%20%C2%B7%2085%20actions-informational" alt="11 domain tools, 85 actions"/>
   <img src="https://img.shields.io/badge/license-MIT-lightgrey" alt="MIT License"/>
@@ -35,7 +35,7 @@ Available as a **double-clickable desktop app** (macOS · Windows · Linux), a l
 | | |
 |---|---|
 | 11 domain tools (85 actions) | Resume + cover letter generation |
-| 1434 passing tests | Job fitment analysis with persona lenses |
+| 1437 passing tests | Job fitment analysis with persona lenses |
 | SQLite persistence + JSON fallback | Interview prep + debrief logging |
 | Local RAG semantic search | Outreach + relationship tracking |
 | Azure AKS deployment | Microsoft Entra ID authentication |

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,6 +11,32 @@ sonar.python.coverage.reportPaths=coverage.xml
 # wide, flat parameter list IS the machine-facing API the model reads. These
 # functions are dispatch-only (no human call sites) and each parameter is
 # documented per-action in the docstring.
-sonar.issue.ignore.multicriteria=e1
+#
+# The remaining ignores below are all reviewed false positives from static
+# analysis not tracing taint through a cross-module call — see the PR that
+# added each one for the human review. Genuinely fixable findings (e.g. the
+# command-argument-injection hotspot in transport/http/desktop.py) get fixed
+# in code instead of ignored here.
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4
+
 sonar.issue.ignore.multicriteria.e1.ruleKey=python:S107
 sonar.issue.ignore.multicriteria.e1.resourceKey=tools/consolidated.py
+
+# "Change this code to not construct the path from user-controlled data."
+# transport/http/routes/sync.py's _resolve_rel() always routes through
+# transport/http/desktop.py's _validated_member_path(), which whitelists
+# every path segment (rejects .., absolute paths, and Windows-reserved
+# chars) before any read/write. Sonar can't trace taint through that
+# cross-module call.
+sonar.issue.ignore.multicriteria.e2.ruleKey=pythonsecurity:S2083
+sonar.issue.ignore.multicriteria.e2.resourceKey=transport/http/routes/sync.py
+
+# "Using HTTP protocol is insecure." Both flagged lines are string-prefix
+# checks used to validate/normalize a URL, not an outgoing insecure
+# connection. lib/sync_client.py's _normalize_url() explicitly upgrades
+# http:// to https:// except for loopback (dev/self-sync).
+sonar.issue.ignore.multicriteria.e3.ruleKey=python:S5332
+sonar.issue.ignore.multicriteria.e3.resourceKey=transport/http/routes/mobile.py
+sonar.issue.ignore.multicriteria.e4.ruleKey=python:S5332
+sonar.issue.ignore.multicriteria.e4.resourceKey=lib/sync_client.py
+

--- a/templates/latex_assets/sections/experience.tex
+++ b/templates/latex_assets/sections/experience.tex
@@ -5,7 +5,7 @@
 \subsection{{\textbf{Senior Software Engineer} \textit{\ \ Contoso Cloud, Remote} \hfill 20XX --- Present}}
 \begin{zitemize}
 \item Led design and delivery of a customer-facing service from architecture through production and on-call; quantify the impact here (latency, scale, revenue, or adoption).
-\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1434 passing tests at 80\%+ line coverage through disciplined TDD.
+\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1437 passing tests at 80\%+ line coverage through disciplined TDD.
 \item Drove a cross-team win — a migration, a shared API pattern others adopted, or an SLA target consistently met.
 \end{zitemize}
 %====================

--- a/tests/test_desktop_mode.py
+++ b/tests/test_desktop_mode.py
@@ -700,6 +700,57 @@ def test_open_url_http_only(desktop_client, monkeypatch):
         assert resp.status_code == 422, bad
 
 
+class TestOpenWithOsArgumentInjection:
+    """A target string starting with '-' could be misread as a CLI flag by
+    the OS opener rather than a file/URL (argument injection) — regression
+    for the Sonar S6350 hotspot on the subprocess.Popen(["open"/"xdg-open",
+    target]) calls."""
+
+    def test_dash_prefixed_target_gets_relative_prefix(self, monkeypatch):
+        import subprocess
+
+        import transport.http.desktop as desktop_mod
+
+        monkeypatch.setattr(desktop_mod.sys, "platform", "linux")
+        monkeypatch.setattr(desktop_mod.os, "name", "posix")
+        calls = []
+        monkeypatch.setattr(subprocess, "Popen", lambda args: calls.append(args))
+
+        desktop_mod._open_with_os("--dangerous-flag")
+
+        assert calls == [["xdg-open", "./--dangerous-flag"]]
+
+    def test_normal_target_is_untouched(self, monkeypatch):
+        import subprocess
+
+        import transport.http.desktop as desktop_mod
+
+        monkeypatch.setattr(desktop_mod.sys, "platform", "linux")
+        monkeypatch.setattr(desktop_mod.os, "name", "posix")
+        calls = []
+        monkeypatch.setattr(subprocess, "Popen", lambda args: calls.append(args))
+
+        desktop_mod._open_with_os("/workspace/resumes/resume.pdf")
+
+        assert calls == [["xdg-open", "/workspace/resumes/resume.pdf"]]
+
+    def test_url_target_is_never_dash_prefixed(self, monkeypatch):
+        """A validated http(s) URL can never start with '-', so the guard
+        must be a no-op for the open-url call site."""
+        import subprocess
+
+        import transport.http.desktop as desktop_mod
+
+        monkeypatch.setattr(desktop_mod.sys, "platform", "linux")
+        monkeypatch.setattr(desktop_mod.os, "name", "posix")
+        calls = []
+        monkeypatch.setattr(subprocess, "Popen", lambda args: calls.append(args))
+
+        desktop_mod._open_with_os("https://example.com/job/123")
+
+        assert calls == [["xdg-open", "https://example.com/job/123"]]
+
+
 def test_open_file_renders_markdown_to_pdf(desktop_client, desktop_data_dir_env, monkeypatch, tmp_path):
     import transport.http.desktop as desktop_mod
     from transport.http.routes.dashboard import materials

--- a/transport/http/desktop.py
+++ b/transport/http/desktop.py
@@ -345,6 +345,13 @@ async def sync_run() -> dict:
 def _open_with_os(target: str) -> None:
     import subprocess
 
+    # A target starting with '-' could be misread as a CLI flag by the OS
+    # opener (argument injection) rather than a file/URL — a real path is
+    # never affected by this (absolute paths start with '/', URLs must have
+    # a valid scheme), so the prefix is a no-op except for that edge case.
+    if target.startswith("-"):
+        target = f"./{target}"
+
     if sys.platform == "darwin":
         subprocess.Popen(["open", target])
     elif os.name == "nt":


### PR DESCRIPTION
Reconciles the divergence created when PR #123 (Sonar security gate fixes) and PR #125 (TestFlight submit-step boolean bug) landed directly on `main` while `qa` moved ahead independently via PR #124 (desktop.py → desktop/ package split).

One real conflict: `transport/http/desktop.py` was deleted on `qa` (split into `transport/http/desktop/{os_open,import_workspace,...}.py`) and modified on `main` (the `_open_with_os()` argument-injection guard from #123). Ported the fix into its new home, `transport/http/desktop/os_open.py`, and updated the three new regression tests' imports to match (`transport.http.desktop` → `transport.http.desktop.os_open`). Everything else merged cleanly (mostly README/LaTeX test-count badges and the two independent, non-overlapping feature sets).

Full suite: 1437 passed, 17 skipped. Frontend build verified clean.