### PR TITLE
feat: design handoff — animated splash, desktop SPA redesign, LinkedIn CSV import, mobile 6-tab app

### DIFF
--- a/desktop/splash/index.html
+++ b/desktop/splash/index.html
@@ -3,53 +3,130 @@
 <head>
   <meta charset="UTF-8" />
   <title>jobContext</title>
+  <!-- Fonts are best-effort: the desktop app may boot offline, so every
+       font-family below carries a system fallback and nothing waits on the
+       network. -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
   <style>
-    :root { color-scheme: light dark; }
+    * { box-sizing: border-box; }
     html, body {
       height: 100%;
       margin: 0;
-      font-family: -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-      background: #0b1220;
-      color: #e6edf5;
+      font-family: 'Space Grotesk', -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background: linear-gradient(165deg, #0A0F1C 0%, #0B1220 100%);
+      color: #F0F5FF;
+      overflow: hidden;
     }
-    .wrap {
-      height: 100%;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      gap: 18px;
+    @keyframes jc-discIn { 0% { opacity: 0; transform: scale(.5); } 100% { opacity: 1; transform: scale(1); } }
+    @keyframes jc-ringDraw { 0% { stroke-dashoffset: 1; } 100% { stroke-dashoffset: 0; } }
+    @keyframes jc-popIn { 0% { opacity: 0; transform: scale(.5); } 70% { opacity: 1; transform: scale(1.12); } 100% { transform: scale(1); } }
+    @keyframes jc-riseIn { 0% { opacity: 0; transform: translateY(18px); filter: blur(8px); } 100% { opacity: 1; transform: translateY(0); filter: blur(0); } }
+    @keyframes jc-fadeIn { 0% { opacity: 0; } 100% { opacity: 1; } }
+    @keyframes jc-glowIn { 0% { opacity: 0; transform: scale(.7); } 100% { opacity: .6; transform: scale(1); } }
+    @keyframes jc-glowPulse { 0%, 100% { opacity: .3; transform: scale(1); } 50% { opacity: .65; transform: scale(1.14); } }
+    @keyframes jc-sheen { 0% { background-position: 130% 0; } 100% { background-position: -30% 0; } }
+    @keyframes jc-barFill { 0% { transform: scaleX(0); } 100% { transform: scaleX(1); } }
+    @keyframes jc-blink { 0%, 100% { opacity: .35; } 50% { opacity: 1; } }
+
+    .stage {
+      position: relative; height: 100%; width: 100%;
+      display: flex; flex-direction: column; align-items: center; justify-content: center;
     }
-    .mark {
-      width: 72px;
-      height: 72px;
-      border-radius: 18px;
-      background: #00B5C8; /* Miami Blue */
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 34px;
-      font-weight: 700;
-      color: #06222a;
-      letter-spacing: -1px;
+    .badge-wrap {
+      position: relative; width: 128px; height: 128px;
+      display: flex; align-items: center; justify-content: center; margin-bottom: 40px;
     }
-    .spinner {
-      width: 26px;
-      height: 26px;
-      border: 3px solid rgba(0, 181, 200, 0.25);
-      border-top-color: #00B5C8;
-      border-radius: 50%;
-      animation: spin 0.9s linear infinite;
+    .badge-glow {
+      position: absolute; width: 200px; height: 200px; border-radius: 50%;
+      background: radial-gradient(circle, rgba(0,181,200,.45) 0%, rgba(0,181,200,0) 68%);
+      filter: blur(6px);
+      animation: jc-glowIn .9s ease .1s both;
     }
-    @keyframes spin { to { transform: rotate(360deg); } }
-    #status { font-size: 14px; opacity: 0.75; max-width: 520px; text-align: center; padding: 0 24px; }
+    .badge-glow-pulse {
+      position: absolute; width: 210px; height: 210px; border-radius: 50%;
+      background: radial-gradient(circle, rgba(0,181,200,.4) 0%, rgba(0,181,200,0) 66%);
+      animation: jc-glowPulse 3.6s ease-in-out 2.6s infinite;
+    }
+    .badge-svg { position: relative; filter: drop-shadow(0 0 22px rgba(0,181,200,.5)); }
+    .disc { transform-box: fill-box; transform-origin: center; animation: jc-discIn .6s cubic-bezier(.34,1.56,.64,1) .15s both; }
+    .ring { stroke-dasharray: 1; animation: jc-ringDraw 1s ease .45s both; }
+    .ring-inner { animation: jc-fadeIn .6s ease 1.15s both; }
+    .glyph-c { stroke-dasharray: 1; animation: jc-ringDraw .8s ease .95s both; }
+    .glyph-j-dot { transform-box: fill-box; transform-origin: center; animation: jc-popIn .5s cubic-bezier(.34,1.56,.64,1) 1.25s both; }
+    .glyph-j-stem { transform-box: fill-box; transform-origin: center; animation: jc-popIn .5s cubic-bezier(.34,1.56,.64,1) 1.35s both; }
+
+    .wordmark { display: flex; align-items: baseline; gap: 1px; animation: jc-riseIn .7s cubic-bezier(.2,.7,.2,1) 1.5s both; }
+    .wordmark span {
+      font-size: 44px; font-weight: 700; letter-spacing: -1.6px;
+      background-size: 260% 100%;
+      -webkit-background-clip: text; background-clip: text;
+      -webkit-text-fill-color: transparent; color: transparent;
+    }
+    .word-job {
+      background-image: linear-gradient(100deg, #FFFFFF 30%, #DFF4FF 50%, #FFFFFF 70%);
+      animation: jc-sheen 1.2s ease 1.75s both;
+    }
+    .word-context {
+      background-image: linear-gradient(100deg, #00B5C8 30%, #8FF0FB 50%, #00B5C8 70%);
+      animation: jc-sheen 1.2s ease 1.9s both;
+    }
+    .tagline {
+      margin-top: 14px; font-size: 15px; font-weight: 500;
+      color: #D7E3F8; opacity: .82; letter-spacing: .1px;
+      animation: jc-riseIn .7s cubic-bezier(.2,.7,.2,1) 1.95s both;
+    }
+    .progress {
+      position: absolute; bottom: 84px; left: 0; right: 0;
+      display: flex; flex-direction: column; align-items: center; gap: 16px;
+      animation: jc-fadeIn .6s ease 1.5s both;
+    }
+    #status {
+      font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 11px; font-weight: 500; letter-spacing: 3px; text-transform: uppercase;
+      color: #6FE0EE; animation: jc-blink 1.8s ease-in-out 1.7s infinite;
+      max-width: 520px; text-align: center; padding: 0 24px;
+    }
+    .bar-track {
+      width: 196px; height: 4px; border-radius: 999px;
+      background: rgba(215,227,248,.12); overflow: hidden;
+    }
+    .bar-fill {
+      height: 100%; width: 100%; border-radius: 999px; transform-origin: left;
+      background: linear-gradient(90deg, #00B5C8, #6FE0EE);
+      box-shadow: 0 0 12px rgba(0,181,200,.75);
+      animation: jc-barFill 2.1s cubic-bezier(.45,.05,.2,1) 1.55s both;
+    }
   </style>
 </head>
 <body>
-  <div class="wrap">
-    <div class="mark">jC</div>
-    <div class="spinner"></div>
-    <div id="status">Starting jobContext…</div>
+  <div class="stage">
+    <div class="badge-wrap">
+      <div class="badge-glow"></div>
+      <div class="badge-glow-pulse"></div>
+      <svg class="badge-svg" width="128" height="128" viewBox="0 0 320 320" aria-hidden="true">
+        <circle class="disc" cx="160" cy="160" r="153" fill="#0A0F1C"></circle>
+        <circle class="ring" cx="160" cy="160" r="153" fill="none" stroke="#00B5C8" stroke-width="10" pathLength="1"></circle>
+        <circle class="ring-inner" cx="160" cy="160" r="139" fill="none" stroke="#00B5C8" stroke-width="2" stroke-opacity=".35"></circle>
+        <g transform="translate(-12 0)">
+          <path class="glyph-c" d="M234 118 A 56 56 0 1 0 234 202" fill="none" stroke="#00B5C8" stroke-width="32" stroke-linecap="round" pathLength="1"></path>
+          <circle class="glyph-j-dot" cx="100" cy="112" r="19" fill="#FFFFFF"></circle>
+          <path class="glyph-j-stem" d="M100 142 L100 205 Q100 230 74 230" fill="none" stroke="#FFFFFF" stroke-width="30" stroke-linecap="round"></path>
+        </g>
+      </svg>
+    </div>
+
+    <div class="wordmark">
+      <span class="word-job">job</span><span class="word-context">Context</span>
+    </div>
+    <div class="tagline">The memory layer for your career.</div>
+
+    <div class="progress">
+      <!-- The shell writes startup failures into #status (main.rs) — keep the id. -->
+      <div id="status">restoring your context</div>
+      <div class="bar-track"><div class="bar-fill"></div></div>
+    </div>
   </div>
 </body>
 </html>

--- a/frontend/src/screens/Health.jsx
+++ b/frontend/src/screens/Health.jsx
@@ -1,129 +1,189 @@
 import { Panel } from '../design-system'
-import {
-  useApi, Screen, SectionHead, StatGrid, Stat,
-  EYEBROW, fmtDate,
-} from './_shared.jsx'
+import { useApi, Screen, fmtDate } from './_shared.jsx'
 
-/* Wellbeing — mood and energy check-ins over time.
-   Data: GET /dashboard/health/data (_health_payload).
+/* Wellbeing — mood and energy check-ins, per the desktop design handoff.
+   Data: GET /dashboard/health/data (_health_payload), plus the existing
+   GET /api/dashboard/home payload for the Oura readiness card (same source
+   Home.jsx already uses — no new endpoints).
 
-   Ports the legacy /dashboard/health graphs: a paired mood (blue) + energy
-   (teal) trend over the last 30 check-ins, plus per-entry meters. */
+   Layout follows the handoff's WELLBEING page: a two-column grid with an
+   energy check-in card (5 emoji tiles) and a 7-DAY MOOD bar chart on the
+   left; the Oura readiness card and RECENT CHECK-INS rows on the right.
 
-const MOOD_COLOR = '#3b82f6'
-const ENERGY_COLOR = 'var(--cyan-400)'
+   There is no check-in write path in the web UI (check-ins arrive via the
+   MCP tools / mobile), so the energy card is read-only and reflects the
+   latest logged check-in instead of inventing an endpoint. */
+
 const SCALE = 10 // mood/energy are logged 1–10
+const CYAN_DIM = 'color-mix(in srgb, var(--cyan-500) 35%, transparent)'
+
+const MOODS = [
+  { emoji: '\u{1F614}', word: 'Low' },
+  { emoji: '\u{1F615}', word: 'Drained' },
+  { emoji: '\u{1F642}', word: 'Steady' },
+  { emoji: '\u{1F600}', word: 'Good' },
+  { emoji: '\u{1F929}', word: 'Great' },
+]
+
+const MONO_LABEL = {
+  fontSize: 11,
+  fontWeight: 'var(--fw-semibold)',
+  letterSpacing: '1.2px',
+  color: 'var(--faint)',
+  fontFamily: 'var(--font-mono)',
+  textTransform: 'uppercase',
+}
 
 function toNum(v) {
   const n = Number.parseFloat(v)
   return Number.isFinite(n) ? n : null
 }
 
-function energyTone(n) {
-  const v = Number(n)
-  if (Number.isNaN(v)) return 'muted'
-  if (v >= 7) return 'green'
-  if (v >= 4) return 'accent'
-  return 'warn'
+/* 1–10 score -> one of the five emoji tiles (1-2, 3-4, 5-6, 7-8, 9-10). */
+function bucket(v) {
+  const n = toNum(v)
+  if (n == null) return null
+  return Math.max(0, Math.min(4, Math.ceil(n / 2) - 1))
 }
 
-/* Twin-bar trend: one slot per check-in, oldest -> newest, mood + energy. */
-function TrendChart({ entries }) {
-  // entries arrive newest-first; reverse so the chart reads left (old) to right (new).
-  const points = [...entries].reverse()
-  if (points.length === 0) return null
+function monoDate(iso) {
+  if (!iso) return '—'
+  const d = new Date(String(iso).slice(0, 10) + 'T00:00:00')
+  if (Number.isNaN(d.getTime())) return String(iso).slice(0, 10).toUpperCase()
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }).toUpperCase()
+}
 
+function dayLetter(iso) {
+  const d = new Date(String(iso).slice(0, 10) + 'T00:00:00')
+  return Number.isNaN(d.getTime()) ? '·' : 'SMTWTFS'[d.getDay()]
+}
+
+/* Energy check-in card — 5 emoji tiles; the tile matching the latest logged
+   energy is highlighted. Read-only: the web UI has no check-in write path. */
+function EnergyCheckin({ latest }) {
+  const sel = bucket(latest?.energy)
   return (
-    <Panel pad="16px 18px" style={{ marginBottom: 20 }}>
-      <div style={{ ...EYEBROW, marginBottom: 12 }}>
-        Mood &amp; energy {'\u2014'} last {points.length} check-ins
+    <Panel pad="20px" radius="18px">
+      <div style={{ fontSize: 14, fontWeight: 'var(--fw-semibold)', color: 'var(--text-soft)' }}>
+        {'How’s your energy today?'}
       </div>
-      <div style={{ display: 'flex', alignItems: 'flex-end', gap: 3, height: 88 }}>
+      <div style={{ marginTop: 14, display: 'flex', gap: 10 }}>
+        {MOODS.map((m, i) => (
+          <div
+            key={m.word}
+            title={`${m.word}${i === sel ? ' · latest check-in' : ''}`}
+            style={{
+              flex: 1, height: 58, borderRadius: 13, fontSize: 22,
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              background: i === sel ? 'color-mix(in srgb, var(--cyan-500) 18%, transparent)' : 'rgba(255,255,255,.05)',
+              border: i === sel ? '1.5px solid var(--cyan-500)' : '1.5px solid transparent',
+            }}
+          >
+            {m.emoji}
+          </div>
+        ))}
+      </div>
+      <div style={{ ...MONO_LABEL, letterSpacing: '0.8px', marginTop: 12 }}>
+        {latest
+          ? `Latest check-in · ${monoDate(latest.date)} · energy ${latest.energy ?? '—'}/${SCALE}`
+          : 'No check-ins yet · log one from chat or mobile'}
+      </div>
+    </Panel>
+  )
+}
+
+/* 7-DAY MOOD — last 7 check-ins, oldest -> newest; the newest bar is solid
+   cyan, earlier bars are dimmed, mono day letters underneath. */
+function MoodChart({ entries }) {
+  const points = entries.slice(0, 7).reverse()
+  if (points.length === 0) return null
+  return (
+    <div>
+      <div style={MONO_LABEL}>7-day mood</div>
+      <div style={{ marginTop: 14, display: 'flex', alignItems: 'flex-end', gap: 12, height: 110 }}>
         {points.map((e, i) => {
           const mood = toNum(e.mood)
-          const energy = toNum(e.energy)
-          const moodH = mood == null ? 0 : (mood / SCALE) * 100
-          const energyH = energy == null ? 0 : (energy / SCALE) * 100
-          const title = `${fmtDate(e.date) || 'Undated'}\nMood: ${e.mood ?? '\u2014'}  Energy: ${e.energy ?? '\u2014'}`
+          const pct = mood == null ? 0 : Math.max(6, (mood / SCALE) * 100)
           return (
             <div
               key={`${e.date}-${i}`}
-              title={title}
-              style={{ flex: 1, display: 'flex', alignItems: 'flex-end', gap: 2, height: '100%', minWidth: 4 }}
+              title={`${fmtDate(e.date) || 'Undated'} · mood ${e.mood ?? '—'}/${SCALE}`}
+              style={{ flex: 1, height: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8, justifyContent: 'flex-end' }}
             >
-              <div style={{ flex: 1, height: `${moodH}%`, background: MOOD_COLOR, borderRadius: '3px 3px 0 0', minHeight: moodH ? 2 : 0 }} />
-              <div style={{ flex: 1, height: `${energyH}%`, background: ENERGY_COLOR, borderRadius: '3px 3px 0 0', minHeight: energyH ? 2 : 0 }} />
+              <div
+                style={{
+                  width: '100%', height: `${pct}%`, minHeight: mood == null ? 2 : 0, borderRadius: 7,
+                  background: i === points.length - 1 ? 'var(--cyan-500)' : CYAN_DIM,
+                }}
+              />
+              <div style={{ fontSize: 10, color: 'var(--faint)', fontFamily: 'var(--font-mono)' }}>{dayLetter(e.date)}</div>
             </div>
           )
         })}
       </div>
-      <div style={{ display: 'flex', gap: 18, marginTop: 12 }}>
-        <Legend color={MOOD_COLOR} label="Mood" />
-        <Legend color={ENERGY_COLOR} label="Energy" />
-      </div>
-    </Panel>
-  )
-}
-
-function Legend({ color, label }) {
-  return (
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, color: 'var(--muted)', fontSize: 'var(--fs-xs)' }}>
-      <span style={{ width: 10, height: 10, borderRadius: 3, background: color }} />
-      {label}
-    </span>
-  )
-}
-
-function Meter({ label, value, color }) {
-  const n = toNum(value)
-  const pct = n == null ? 0 : Math.max(0, Math.min(100, (n / SCALE) * 100))
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-      <span style={{ width: 50, fontSize: 'var(--fs-xs)', color: 'var(--muted)' }}>{label}</span>
-      <div style={{ width: 104, height: 8, background: 'var(--ink-600)', borderRadius: 'var(--radius-pill)', overflow: 'hidden' }}>
-        <div style={{ width: `${pct}%`, height: '100%', background: color, borderRadius: 'var(--radius-pill)' }} />
-      </div>
-      <span style={{ fontFamily: 'var(--font-mono)', fontWeight: 'var(--fw-bold)', fontSize: 'var(--fs-sm)', color: 'var(--text-strong)' }}>
-        {value ?? '\u2014'}
-      </span>
     </div>
   )
 }
 
-function CheckinCard({ entry }) {
+/* Big-number gradient card. Shows Oura readiness when a ring is connected;
+   otherwise falls back to the 30-check-in average energy so the slot never
+   fabricates data. */
+function ReadinessCard({ oura, move, avgEnergy }) {
+  const big = oura ? oura.score : (avgEnergy ?? '—')
+  const title = oura ? 'Oura readiness' : 'Avg energy'
+  const sub = oura
+    ? (move || oura.label || '')
+    : `${SCALE}-point scale, last 30 check-ins · connect an Oura ring in Settings for readiness`
   return (
-    <Panel pad="14px 16px">
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: 10, flexWrap: 'wrap' }}>
-        <div style={{ color: 'var(--text-strong)', fontWeight: 'var(--fw-semibold)', fontSize: 'var(--fs-base)' }}>
-          {entry.date ? fmtDate(entry.date) : 'Undated'}
+    <div
+      style={{
+        borderRadius: 18, padding: 20, display: 'flex', alignItems: 'center', gap: 18,
+        background: 'linear-gradient(150deg, color-mix(in srgb, var(--cyan-500) 14%, transparent), color-mix(in srgb, var(--cyan-500) 3%, transparent))',
+        border: '1px solid color-mix(in srgb, var(--cyan-500) 26%, transparent)',
+      }}
+    >
+      <div style={{ fontSize: 46, fontWeight: 'var(--fw-bold)', color: 'var(--cyan-300)', letterSpacing: '-1px', lineHeight: 1 }}>
+        {big}
+      </div>
+      <div>
+        <div style={{ fontSize: 14, fontWeight: 'var(--fw-semibold)', color: 'var(--text)' }}>{title}</div>
+        {sub && <div style={{ fontSize: 12.5, color: '#8AB6C4', marginTop: 3, lineHeight: 1.4 }}>{sub}</div>}
+      </div>
+    </div>
+  )
+}
+
+function CheckinRow({ entry }) {
+  const b = bucket(entry.mood)
+  const face = b == null ? '·' : MOODS[b].emoji
+  const word = entry.label || (b == null ? 'Check-in' : MOODS[b].word)
+  return (
+    <div style={{ borderRadius: 12, padding: '12px 14px', background: 'rgba(255,255,255,.035)', border: '1px solid rgba(255,255,255,.06)' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 10 }}>
+        <div style={{ fontSize: 13.5, color: 'var(--text-soft)', minWidth: 0 }}>
+          {face} {word} {'·'} mood {entry.mood ?? '—'}/{SCALE} {'·'} energy {entry.energy ?? '—'}/{SCALE}
         </div>
-        <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
-          {entry.mood != null && entry.mood !== '' && (
-            <span style={{ fontSize: 'var(--fs-xs)', color: 'var(--muted)' }}>Mood: {entry.mood}</span>
-          )}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexShrink: 0 }}>
           {entry.productive != null && (
-            <span style={{ fontSize: 'var(--fs-xs)', color: entry.productive ? 'var(--green-300)' : 'var(--muted)' }}>
-              {entry.productive ? 'Productive' : 'Rest'}
+            <span style={{ fontSize: 10, fontFamily: 'var(--font-mono)', fontWeight: 'var(--fw-semibold)', letterSpacing: '0.5px', color: entry.productive ? 'var(--green-300)' : 'var(--muted)' }}>
+              {entry.productive ? 'PRODUCTIVE' : 'REST'}
             </span>
           )}
+          <span style={{ fontSize: 11, color: 'var(--faint)', fontFamily: 'var(--font-mono)' }}>{monoDate(entry.date)}</span>
         </div>
-      </div>
-      <div style={{ display: 'flex', gap: 18, marginTop: 10, flexWrap: 'wrap' }}>
-        <Meter label="Mood" value={entry.mood} color={MOOD_COLOR} />
-        <Meter label="Energy" value={entry.energy} color={ENERGY_COLOR} />
       </div>
       {entry.notes && (
-        <div style={{ color: 'var(--text-soft)', fontSize: 'var(--fs-sm)', marginTop: 10, lineHeight: 1.5 }}>
-          {entry.notes}
-        </div>
+        <div style={{ fontSize: 12.5, color: 'var(--muted)', marginTop: 8, lineHeight: 1.5 }}>{entry.notes}</div>
       )}
-    </Panel>
+    </div>
   )
 }
 
 export default function Health() {
   const { data, loading, error } = useApi('/dashboard/health/data')
+  const home = useApi('/api/dashboard/home') // readiness only; failures just hide the card
   const recent = data?.recent || []
+  const oura = home.data?.oura || null
 
   return (
     <Screen
@@ -132,20 +192,25 @@ export default function Health() {
       empty={!loading && !error && (data?.total_entries ?? 0) === 0}
       emptyLabel="No check-ins logged yet."
     >
-      <StatGrid>
-        <Stat label="Check-ins" value={data?.total_entries ?? 0} tone="accent" />
-        <Stat label="Avg mood" value={data?.avg_mood != null ? `${data.avg_mood} / 10` : '\u2014'} tone="green" />
-        <Stat label="Avg energy" value={data?.avg_energy != null ? `${data.avg_energy} / 10` : '\u2014'} tone={energyTone(data?.avg_energy)} />
-        <Stat label="Recent window" value={recent.length} sub="entries shown" tone="muted" />
-      </StatGrid>
-
-      <TrendChart entries={recent} />
-
-      <SectionHead title="Recent check-ins" right={`${recent.length}`} />
-      <div style={{ display: 'grid', gap: 10 }}>
-        {recent.map((e, i) => (
-          <CheckinCard key={`${e.date}-${i}`} entry={e} />
-        ))}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: 18, alignItems: 'start' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+          <EnergyCheckin latest={recent[0]} />
+          <MoodChart entries={recent} />
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+          <ReadinessCard oura={oura} move={home.data?.today?.move} avgEnergy={data?.avg_energy} />
+          <div style={{ ...MONO_LABEL, letterSpacing: '0.8px' }}>
+            {`${data?.total_entries ?? 0} check-ins · avg mood ${data?.avg_mood ?? '—'}/${SCALE} · avg energy ${data?.avg_energy ?? '—'}/${SCALE}`}
+          </div>
+          <div>
+            <div style={MONO_LABEL}>Recent check-ins</div>
+            <div style={{ marginTop: 12, display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {recent.map((e, i) => (
+                <CheckinRow key={`${e.date}-${i}`} entry={e} />
+              ))}
+            </div>
+          </div>
+        </div>
       </div>
     </Screen>
   )

--- a/frontend/src/screens/Home.jsx
+++ b/frontend/src/screens/Home.jsx
@@ -4,28 +4,52 @@ import { Icon } from '../design-system'
 import { apiFetch } from '../auth/api.js'
 import useDesktopMode from '../shell/useDesktopMode.js'
 
-/* HomeScreen — the Oura-readiness redesign. Converted from the design
-   handoff's home.jsx IIFE to ESM.
+/* HomeScreen — re-skinned to the desktop design handoff's HOME page:
+   mono date eyebrow + greeting, a 4-tile stat row, then a 1.35fr/1fr grid
+   (cyan-tinted priorities card + daily-digest list on the left, readiness
+   card + "today's move" nudge on the right), then the workspace nav cards.
 
    Data: fetched from GET /api/dashboard/home (see transport/http/routes/
    dashboard/api.py). Until that responds it renders MOCK so the screen is
    never blank. The API shape mirrors MOCK exactly.
 
    Behavior:
-   - Oura toggle: when off (or no ring connected), the readiness panel becomes
-     a Daily Digest in the same slot. hasOura is seeded from whether the API
-     returned an oura payload — a null payload shows the digest, never a
-     zeroed-out ring.
-   - Animated gauge + bars on mount (skipped under prefers-reduced-motion). */
+   - Oura toggle: when off (or no ring connected), the readiness card shows
+     a note instead of the gauge. hasOura is seeded from whether the API
+     returned an oura payload — a null payload never shows a zeroed ring.
+   - The daily digest is always visible (left column) so enabling Oura
+     augments the page rather than replacing the digest.
+   - Animated gauge + bars on mount (skipped under prefers-reduced-motion).
+   - The page title/subtitle come from DashboardShell — this screen renders
+     content only. */
 
 const ACCENT = 'var(--cyan-500)'
+
+/* Handoff card recipe: rgba(255,255,255,.04) fill, .07 border, 14-18 radius */
+const CARD_BG = 'rgba(255,255,255,.04)'
+const CARD_BORDER = '1px solid rgba(255,255,255,.07)'
+
+/* Mono uppercase section eyebrow (JetBrains Mono per the handoff) */
+const MONO_EYEBROW = {
+  fontFamily: 'var(--font-mono)',
+  fontSize: 11,
+  fontWeight: 600,
+  letterSpacing: '1.2px',
+  textTransform: 'uppercase',
+  color: '#7C8AA6',
+}
+const MONO_EYEBROW_CYAN = {
+  ...MONO_EYEBROW,
+  letterSpacing: '1.5px',
+  color: 'var(--cyan-300)',
+}
 
 const DEFAULT_CARDS = [
   { key: 'pipeline', title: 'Pipeline', desc: 'Share-sheet intake, assessment, resume selection, cover letter, and apply queue' },
   { key: 'job-hunt', title: 'Job Hunt', desc: 'Applications, Kanban board, status breakdown' },
   { key: 'materials', title: 'Materials', desc: 'Resumes, cover letters, PDFs, and untracked files' },
   { key: 'rejections', title: 'Rejections', desc: 'Funnel analysis, patterns, company breakdown' },
-  { key: 'posts', title: 'Posts', desc: 'LinkedIn pipeline: draft \u2192 written \u2192 approved \u2192 posted' },
+  { key: 'posts', title: 'Posts', desc: 'LinkedIn pipeline: draft → written → approved → posted' },
   { key: 'people', title: 'Outreach', desc: 'Contacts, follow-up queue, warm vs cold' },
   { key: 'health', title: 'Wellbeing', desc: 'Mood & energy log, trend sparklines' },
   { key: 'interviews', title: 'Interviews', desc: 'Upcoming schedule, debrief log, verbatim quotes' },
@@ -50,13 +74,6 @@ const MOCK = {
   cards: DEFAULT_CARDS,
 }
 
-const EYEBROW = {
-  font: 'var(--fw-semibold) var(--fs-2xs)/1.2 var(--font-sans)',
-  textTransform: 'uppercase',
-  letterSpacing: 'var(--ls-eyebrow)',
-  color: 'var(--muted)',
-}
-
 function prefersReducedMotion() {
   return (
     typeof window !== 'undefined' &&
@@ -65,8 +82,22 @@ function prefersReducedMotion() {
   )
 }
 
+function dateEyebrow() {
+  const d = new Date()
+  const wd = d.toLocaleDateString('en-US', { weekday: 'short' }).toUpperCase()
+  const mo = d.toLocaleDateString('en-US', { month: 'short' }).toUpperCase()
+  return `${wd} · ${mo} ${d.getDate()}`
+}
+
+function timeGreeting() {
+  const h = new Date().getHours()
+  if (h < 12) return 'Good morning'
+  if (h < 18) return 'Good afternoon'
+  return 'Good evening'
+}
+
 /* ---------- pieces ---------- */
-function Gauge({ score, accent, size = 184, animate = true }) {
+function Gauge({ score, accent, size = 168, animate = true }) {
   const R = 78
   const C = 2 * Math.PI * R
   const [off, setOff] = useState(animate ? C : C * (1 - score / 100))
@@ -116,26 +147,26 @@ function Gauge({ score, accent, size = 184, animate = true }) {
           style={{
             fontFamily: 'var(--font-display)',
             fontWeight: 700,
-            fontSize: size > 170 ? '2.7rem' : '2.3rem',
+            fontSize: size > 160 ? '2.5rem' : '2.2rem',
             lineHeight: 1,
-            color: 'var(--text-strong)',
+            color: 'var(--text)',
           }}
         >
           {score}
         </div>
-        <div style={{ ...EYEBROW, marginTop: 5 }}>Score</div>
+        <div style={{ ...MONO_EYEBROW, fontSize: 9.5, marginTop: 5 }}>Score</div>
       </div>
     </div>
   )
 }
 
-function Bars({ bars, accent, animate, smallLabel }) {
+function Bars({ bars, accent, animate }) {
   const [on, setOn] = useState(!animate)
   useEffect(() => {
     if (animate) requestAnimationFrame(() => requestAnimationFrame(() => setOn(true)))
   }, [animate])
   return (
-    <div style={{ marginTop: 12 }}>
+    <div style={{ marginTop: 10 }}>
       {bars.map((b, i) => {
         const green = b.tone === 'green'
         const col = green ? 'var(--green-500)' : accent
@@ -149,10 +180,8 @@ function Bars({ bars, accent, animate, smallLabel }) {
                 marginBottom: 6,
               }}
             >
-              <span style={{ fontSize: smallLabel ? '0.82rem' : '0.85rem', color: 'var(--muted)' }}>
-                {b.label}
-              </span>
-              <span style={{ fontWeight: 700, fontSize: '0.95rem', color: col }}>
+              <span style={{ fontSize: 12.5, color: 'var(--muted)' }}>{b.label}</span>
+              <span style={{ fontFamily: 'var(--font-mono)', fontWeight: 600, fontSize: 12.5, color: col }}>
                 {b.val}
                 {b.unit}
               </span>
@@ -219,126 +248,116 @@ function Toggle({ on, onClick, accent, disabled = false }) {
   )
 }
 
-function Digest({ digest, compact, withNote }) {
-  const items = digest?.items || []
-  return (
-    <div>
-      {digest?.date && (
-        <div style={{ marginTop: 8, color: 'var(--muted)', fontSize: compact ? '0.82rem' : '0.85rem' }}>
-          {digest.date}
-        </div>
-      )}
-      <div style={{ marginTop: compact ? 10 : 12 }}>
-        {items.length === 0 && (
-          <div style={{ color: 'var(--faint)', fontSize: '0.85rem', padding: '8px 0' }}>
-            Nothing pressing right now. Apply to 2 or 3 new roles today.
-          </div>
-        )}
-        {items.map((d, i) => (
-          <div
-            key={i}
-            style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              gap: 12,
-              padding: (compact ? 11 : 13) + 'px 0',
-              borderTop: '1px solid var(--border-soft)',
-            }}
-          >
-            <span
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 10,
-                fontSize: compact ? '0.88rem' : '0.9rem',
-                color: 'var(--text)',
-              }}
-            >
-              <span style={{ width: 7, height: 7, borderRadius: 999, background: d.color, flexShrink: 0 }} />
-              {d.label}
-            </span>
-            <span style={{ fontWeight: 700, fontSize: compact ? '0.9rem' : '0.92rem', color: d.color, whiteSpace: 'nowrap' }}>
-              {d.value}
-            </span>
-          </div>
-        ))}
-      </div>
-      {withNote && (
-        <div style={{ marginTop: 16, fontSize: '0.8rem', color: 'var(--faint)', lineHeight: 1.5 }}>
-          No Oura ring connected. Showing your daily digest. Connect a ring in Settings to see readiness.
-        </div>
-      )}
-    </div>
-  )
-}
-
-function PanelHead({ hasOura, setHasOura, ouraConnected, accent }) {
-  return (
-    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12 }}>
-      <div style={{ ...EYEBROW, color: 'var(--cyan-300)' }}>{hasOura ? 'Oura \u00b7 Readiness' : 'Daily Digest'}</div>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-        <span style={{ fontSize: '0.66rem', color: 'var(--faint)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
-          {ouraConnected ? 'Oura ring' : 'Not connected'}
-        </span>
-        <Toggle on={hasOura} onClick={() => setHasOura((v) => !v)} accent={accent} disabled={!ouraConnected} />
-      </div>
-    </div>
-  )
-}
-
-function Overdue({ n }) {
+function StatTile({ value, label, tint = false, valueColor }) {
   return (
     <div
       style={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        gap: 7,
-        background: 'var(--tint-danger)',
-        color: 'var(--danger-soft)',
-        border: '1px solid color-mix(in srgb,var(--danger) 35%,transparent)',
-        borderRadius: 999,
-        padding: '6px 13px',
-        fontSize: '0.8rem',
-        fontWeight: 600,
+        flex: '1 1 150px',
+        padding: 18,
+        borderRadius: 16,
+        background: tint ? 'rgba(0,181,200,.1)' : CARD_BG,
+        border: tint ? '1px solid rgba(0,181,200,.24)' : CARD_BORDER,
       }}
     >
-      <span style={{ width: 7, height: 7, borderRadius: 999, background: 'var(--danger)' }} />
-      {n} overdue
-    </div>
-  )
-}
-
-function BigNum({ value, label }) {
-  return (
-    <div>
-      <div style={{ fontFamily: 'var(--font-display)', fontWeight: 700, fontSize: '2.4rem', lineHeight: 1, color: 'var(--text-strong)' }}>
+      <div
+        style={{
+          fontFamily: 'var(--font-display)',
+          fontSize: 30,
+          fontWeight: 700,
+          lineHeight: 1.1,
+          color: valueColor || (tint ? 'var(--cyan-300)' : 'var(--text)'),
+        }}
+      >
         {value}
       </div>
-      <div style={{ ...EYEBROW, marginTop: 6 }}>{label}</div>
+      <div style={{ fontSize: 12, color: tint ? '#8AB6C4' : 'var(--muted)', marginTop: 3 }}>{label}</div>
     </div>
   )
 }
 
-function Priorities({ priorities }) {
-  if (!priorities || priorities.length === 0) {
+/* Digest rows styled like the handoff's FOLLOW-UPS DUE list — one card per
+   item with a colored dot + label and a mono status chip on the right. */
+function Digest({ digest }) {
+  const items = digest?.items || []
+  if (items.length === 0) {
     return (
-      <div style={{ marginTop: 12, color: 'var(--faint)', fontSize: '0.9rem' }}>
-        No priority actions queued.
+      <div
+        style={{
+          borderRadius: 14,
+          padding: '14px 16px',
+          background: CARD_BG,
+          border: CARD_BORDER,
+          color: 'var(--faint)',
+          fontSize: 13,
+        }}
+      >
+        Nothing pressing right now. Apply to 2 or 3 new roles today.
       </div>
     )
   }
-  return priorities.map((p) => (
-    <div key={p.n} style={{ display: 'flex', gap: 12, alignItems: 'flex-start', marginTop: 12 }}>
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {items.map((d, i) => {
+        const col = d.color || 'var(--cyan-300)'
+        return (
+          <div
+            key={i}
+            style={{
+              borderRadius: 14,
+              padding: '14px 16px',
+              background: CARD_BG,
+              border: CARD_BORDER,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 12,
+            }}
+          >
+            <span style={{ display: 'flex', alignItems: 'center', gap: 10, fontSize: 14, color: 'var(--text)' }}>
+              <span style={{ width: 7, height: 7, borderRadius: 999, background: col, flexShrink: 0 }} />
+              {d.label}
+            </span>
+            <span
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: 10.5,
+                fontWeight: 600,
+                textTransform: 'uppercase',
+                letterSpacing: '.5px',
+                color: col,
+                background: `color-mix(in srgb, ${col} 14%, transparent)`,
+                padding: '4px 9px',
+                borderRadius: 8,
+                whiteSpace: 'nowrap',
+                flexShrink: 0,
+              }}
+            >
+              {d.value}
+            </span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+/* Numbered checkbox rows per the handoff's priorities card — the first
+   (current) item gets the cyan box. */
+function Priorities({ priorities }) {
+  if (!priorities || priorities.length === 0) {
+    return <div style={{ color: 'var(--faint)', fontSize: 13.5 }}>No priority actions queued.</div>
+  }
+  return priorities.map((p, i) => (
+    <div key={p.n} style={{ display: 'flex', alignItems: 'flex-start', gap: 12 }}>
       <span
         style={{
-          width: 21,
-          height: 21,
-          borderRadius: 999,
-          background: 'var(--tint-primary)',
-          color: 'var(--cyan-300)',
+          width: 18,
+          height: 18,
+          borderRadius: 6,
+          border: `2px solid ${i === 0 ? 'var(--cyan-500)' : 'rgba(215,227,248,.35)'}`,
+          color: i === 0 ? 'var(--cyan-300)' : 'var(--faint)',
           fontFamily: 'var(--font-mono)',
-          fontSize: '0.7rem',
+          fontSize: 9,
           fontWeight: 700,
           display: 'flex',
           alignItems: 'center',
@@ -349,82 +368,59 @@ function Priorities({ priorities }) {
       >
         {p.n}
       </span>
-      <span style={{ fontSize: '0.92rem', color: 'var(--text)', lineHeight: 1.4 }}>{p.text}</span>
+      <span style={{ fontSize: 14.5, color: '#E8EFFB', lineHeight: 1.4 }}>{p.text}</span>
     </div>
   ))
 }
 
-/* ---------- hero ---------- */
-function ReadinessOrDigest({ data, hasOura, setHasOura, ouraConnected, accent, animate, size, compact }) {
+function ReadinessCard({ data, hasOura, setHasOura, ouraConnected, accent, animate }) {
   const showReadiness = hasOura && data.oura
   return (
-    <>
-      <PanelHead hasOura={hasOura} setHasOura={setHasOura} ouraConnected={ouraConnected} accent={accent} />
-      {showReadiness ? (
-        <>
-          <div style={{ display: 'flex', justifyContent: 'center', marginTop: compact ? 14 : 16 }}>
-            <Gauge score={data.oura.score} accent={accent} size={size} animate={animate} />
-          </div>
-          <div style={{ textAlign: 'center', marginTop: compact ? 8 : 10, fontWeight: 600, fontSize: compact ? '0.95rem' : '0.98rem', color: accent }}>
-            {data.oura.label}
-          </div>
-          <Bars bars={data.oura.bars} accent={accent} animate={animate} smallLabel={compact} />
-          {/* Readiness never hides the digest — both are useful at once. Stack the
-             digest below the ring so enabling Oura augments the panel, not replaces it. */}
-          <div style={{ marginTop: compact ? 18 : 22, paddingTop: compact ? 16 : 18, borderTop: '1px solid var(--border-soft)' }}>
-            <div style={{ ...EYEBROW, color: 'var(--cyan-300)' }}>Daily Digest</div>
-            <Digest digest={data.digest} compact />
-          </div>
-        </>
-      ) : (
-        <Digest digest={data.digest} compact={compact} withNote={!compact} />
-      )}
-    </>
-  )
-}
-
-function SplitHero({ data, hasOura, setHasOura, ouraConnected, accent, animate }) {
-  return (
-    <div
-      style={{
-        background: 'var(--surface)',
-        border: '1px solid var(--border)',
-        borderRadius: 'var(--radius-xl)',
-        overflow: 'hidden',
-        boxShadow: 'var(--shadow-md)',
-        marginBottom: 34,
-      }}
-    >
-      <div style={{ height: 3, background: 'linear-gradient(90deg,var(--cyan-500) 0%,color-mix(in srgb,var(--cyan-500) 30%,transparent) 55%,transparent 100%)' }} />
-      <div className="hero-split-grid" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr' }}>
-        <div style={{ padding: '26px 30px' }}>
-          <ReadinessOrDigest data={data} hasOura={hasOura} setHasOura={setHasOura} ouraConnected={ouraConnected} accent={accent} animate={animate} size={184} />
-        </div>
-        <div className="hero-split-right" style={{ padding: '26px 30px', borderLeft: '1px solid var(--border-soft)' }}>
-          <div style={{ ...EYEBROW, color: 'var(--cyan-300)' }}>Pipeline {'\u00b7'} Today</div>
-          <div style={{ display: 'flex', alignItems: 'flex-start', gap: 30, marginTop: 14 }}>
-            <BigNum value={data.today.active} label="Active" />
-            <BigNum value={data.today.inflight} label="In-flight" />
-            {data.today.overdue > 0 && <div style={{ marginLeft: 'auto' }}><Overdue n={data.today.overdue} /></div>}
-          </div>
-          <div style={{ ...EYEBROW, marginTop: 24 }}>Priority actions</div>
-          <div style={{ marginTop: 10 }}><Priorities priorities={data.today.priorities} /></div>
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12 }}>
+        <div style={MONO_EYEBROW_CYAN}>{showReadiness ? 'Oura · Readiness' : 'Readiness'}</div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 9.5,
+              fontWeight: 600,
+              color: 'var(--faint)',
+              textTransform: 'uppercase',
+              letterSpacing: '.8px',
+            }}
+          >
+            {ouraConnected ? 'Oura ring' : 'Not connected'}
+          </span>
+          <Toggle on={hasOura} onClick={() => setHasOura((v) => !v)} accent={accent} disabled={!ouraConnected} />
         </div>
       </div>
       <div
         style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 12,
-          padding: '15px 30px',
-          borderTop: '1px solid var(--border-soft)',
-          background: 'color-mix(in srgb,var(--cyan-500) 5%,var(--surface))',
+          marginTop: 10,
+          borderRadius: 16,
+          padding: 18,
+          background: 'rgba(255,255,255,.045)',
+          border: '1px solid rgba(255,255,255,.08)',
         }}
       >
-        <span style={{ width: 8, height: 8, borderRadius: 999, background: 'var(--green-500)', flexShrink: 0 }} />
-        <span style={{ ...EYEBROW, color: 'var(--green-300)', flexShrink: 0 }}>Today&rsquo;s move</span>
-        <span style={{ color: 'var(--text-soft)', fontSize: '0.9rem', lineHeight: 1.4 }}>{data.today.move}</span>
-        <span style={{ marginLeft: 'auto', color: 'var(--cyan-400)', fontSize: '1.1rem', flexShrink: 0 }}>{'\u2192'}</span>
+        {showReadiness ? (
+          <>
+            <div style={{ display: 'flex', justifyContent: 'center', marginTop: 4 }}>
+              <Gauge score={data.oura.score} accent={accent} animate={animate} />
+            </div>
+            <div style={{ textAlign: 'center', marginTop: 10, fontWeight: 600, fontSize: 14.5, color: accent }}>
+              {data.oura.label}
+            </div>
+            <Bars bars={data.oura.bars} accent={accent} animate={animate} />
+          </>
+        ) : (
+          <div style={{ fontSize: 13, color: 'var(--faint)', lineHeight: 1.5 }}>
+            {ouraConnected
+              ? 'Readiness hidden — flip the toggle to bring it back.'
+              : 'No Oura ring connected. Connect a ring in Settings to see readiness.'}
+          </div>
+        )}
       </div>
     </div>
   )
@@ -458,87 +454,174 @@ export default function Home() {
   }, [])
 
   const cards = (data.cards || DEFAULT_CARDS).filter((c) => c.key !== 'digest')
+  const readinessOn = hasOura && data.oura
 
   return (
     <div>
+      {/* greeting — the 28px page title lives in DashboardShell; this is the
+          handoff's mono date eyebrow + a smaller greeting line */}
+      <div style={{ ...MONO_EYEBROW_CYAN, letterSpacing: '1px', fontSize: 13, fontWeight: 500 }}>
+        {dateEyebrow()}
+      </div>
       <div
         style={{
-          textAlign: 'center',
           fontFamily: 'var(--font-display)',
-          fontSize: '1.55rem',
-          fontWeight: 600,
-          color: 'var(--text-strong)',
-          margin: '2px 0 18px',
+          fontSize: 20,
+          fontWeight: 700,
+          letterSpacing: '-0.4px',
+          color: 'var(--text)',
+          marginTop: 4,
         }}
       >
-        {data.welcomeIsDefault ? 'Welcome.' : `Welcome back, ${data.welcomeName}.`}
+        {data.welcomeIsDefault ? timeGreeting() : `${timeGreeting()}, ${data.welcomeName}`}
       </div>
 
       {data.welcomeIsDefault && isDesktop && (
-        <div style={{ textAlign: 'center', margin: '-8px 0 18px' }}>
-          <button
-            onClick={() =>
-              navigate('/chat', {
-                state: {
-                  seed:
-                    "I'm new here — check my workspace and walk me through setting it up.",
-                },
-              })
-            }
-            style={{
-              background: 'var(--surface-raised)',
-              border: '1px solid color-mix(in srgb, var(--cyan-500) 50%, transparent)',
-              borderRadius: 'var(--radius-md)',
-              color: 'var(--cyan-300)',
-              padding: '8px 16px',
-              fontSize: 'var(--fs-sm)',
-              fontFamily: 'inherit',
-              cursor: 'pointer',
-            }}
-          >
-            Set up your workspace with the assistant {'→'}
-          </button>
-        </div>
+        <button
+          onClick={() =>
+            navigate('/chat', {
+              state: {
+                seed:
+                  "I'm new here — check my workspace and walk me through setting it up.",
+              },
+            })
+          }
+          style={{
+            marginTop: 14,
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 7,
+            fontSize: 13,
+            fontWeight: 700,
+            fontFamily: 'inherit',
+            color: '#04222A',
+            background: 'var(--cyan-500)',
+            border: 'none',
+            padding: '9px 16px',
+            borderRadius: 10,
+            boxShadow: '0 4px 14px rgba(0,181,200,.25)',
+            cursor: 'pointer',
+          }}
+        >
+          Set up your workspace with the assistant {'→'}
+        </button>
       )}
 
-      <SplitHero data={data} hasOura={hasOura} setHasOura={setHasOura} ouraConnected={ouraConnected} accent={ACCENT} animate={animate} />
+      {/* stat tile row */}
+      <div style={{ marginTop: 22, display: 'flex', gap: 14, flexWrap: 'wrap' }}>
+        <StatTile value={data.today.active} label="Active apps" />
+        <StatTile value={data.today.inflight} label="In-flight" />
+        <StatTile value={readinessOn ? data.oura.score : '—'} label="Readiness" tint={Boolean(readinessOn)} valueColor={readinessOn ? undefined : 'var(--faint)'} />
+        <StatTile value={data.today.overdue} label="Overdue follow-ups" valueColor={data.today.overdue > 0 ? '#E0B77A' : 'var(--text)'} />
+      </div>
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(248px, 1fr))', gap: 14 }}>
-        {cards.map((c) => {
-          const on = hover === c.key
-          return (
-            <a
-              key={c.key}
-              href={`/app/${c.key === 'home' ? '' : c.key}`}
-              onClick={(e) => {
-                e.preventDefault()
-                navigate(c.key === 'home' ? '/' : `/${c.key}`)
-              }}
-              onMouseEnter={() => setHover(c.key)}
-              onMouseLeave={() => setHover(null)}
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                gap: 7,
-                textDecoration: 'none',
-                background: on ? 'var(--surface-raised)' : 'var(--surface)',
-                border: `1px solid ${on ? 'color-mix(in srgb, var(--cyan-500) 50%, transparent)' : 'var(--border)'}`,
-                borderRadius: 'var(--radius-xl)',
-                padding: '20px 22px',
-                boxShadow: on ? 'var(--glow-primary)' : 'none',
-                transition: 'border-color var(--dur-base), background var(--dur-base), box-shadow var(--dur-base), transform var(--dur-base)',
-                transform: on ? 'translateY(-2px)' : 'none',
-              }}
-            >
-              <div style={{ color: 'var(--cyan-400)', height: 24 }}>
-                <Icon name={c.key} size={24} />
-              </div>
-              <div style={{ fontWeight: 700, fontSize: 'var(--fs-h3)', color: 'var(--text-strong)' }}>{c.title}</div>
-              <div style={{ color: 'var(--muted)', fontSize: 'var(--fs-sm)', lineHeight: 1.45 }}>{c.desc}</div>
-              <div style={{ color: 'var(--cyan-400)', fontSize: 'var(--fs-sm)', fontWeight: 600, marginTop: 4 }}>Open {'\u2192'}</div>
-            </a>
-          )
-        })}
+      {/* two-column grid (collapses via .hero-split-grid at <=720px) */}
+      <div
+        className="hero-split-grid"
+        style={{ marginTop: 22, display: 'grid', gridTemplateColumns: '1.35fr 1fr', gap: 18, alignItems: 'start' }}
+      >
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+          {/* cyan-tinted priorities card */}
+          <div
+            style={{
+              borderRadius: 18,
+              padding: 20,
+              background: 'linear-gradient(150deg, rgba(0,181,200,.15), rgba(0,181,200,.04))',
+              border: '1px solid rgba(0,181,200,.26)',
+            }}
+          >
+            <div style={MONO_EYEBROW_CYAN}>Today&rsquo;s priorities</div>
+            <div style={{ marginTop: 14, display: 'flex', flexDirection: 'column', gap: 12 }}>
+              <Priorities priorities={data.today.priorities} />
+            </div>
+          </div>
+
+          {/* daily digest list */}
+          <div>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: 12 }}>
+              <div style={MONO_EYEBROW}>Daily digest</div>
+              {data.digest.date && (
+                <div style={{ ...MONO_EYEBROW, textTransform: 'none', letterSpacing: '.5px', fontWeight: 500, color: 'var(--faint)' }}>
+                  {data.digest.date}
+                </div>
+              )}
+            </div>
+            <div style={{ marginTop: 10 }}>
+              <Digest digest={data.digest} />
+            </div>
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+          <ReadinessCard
+            data={data}
+            hasOura={hasOura}
+            setHasOura={setHasOura}
+            ouraConnected={ouraConnected}
+            accent={ACCENT}
+            animate={animate}
+          />
+
+          {/* today's move — the handoff's nudge card */}
+          <div
+            style={{
+              borderRadius: 16,
+              padding: 18,
+              background: 'rgba(0,181,200,.06)',
+              border: '1px solid rgba(0,181,200,.16)',
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
+              <span style={{ width: 6, height: 6, borderRadius: 999, background: '#6FD3A0', flexShrink: 0 }} />
+              <span style={{ ...MONO_EYEBROW, color: '#6FD3A0' }}>Today&rsquo;s move</span>
+            </div>
+            <div style={{ marginTop: 8, fontSize: 13.5, color: 'var(--text-soft)', lineHeight: 1.4 }}>
+              {data.today.move}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* workspace nav cards */}
+      <div style={{ marginTop: 26 }}>
+        <div style={MONO_EYEBROW}>Workspace</div>
+        <div style={{ marginTop: 10, display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(248px, 1fr))', gap: 14 }}>
+          {cards.map((c) => {
+            const on = hover === c.key
+            return (
+              <a
+                key={c.key}
+                href={`/app/${c.key === 'home' ? '' : c.key}`}
+                onClick={(e) => {
+                  e.preventDefault()
+                  navigate(c.key === 'home' ? '/' : `/${c.key}`)
+                }}
+                onMouseEnter={() => setHover(c.key)}
+                onMouseLeave={() => setHover(null)}
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 7,
+                  textDecoration: 'none',
+                  background: on ? 'rgba(255,255,255,.07)' : CARD_BG,
+                  border: `1px solid ${on ? 'color-mix(in srgb, var(--cyan-500) 50%, transparent)' : 'rgba(255,255,255,.07)'}`,
+                  borderRadius: 16,
+                  padding: '18px 20px',
+                  boxShadow: on ? 'var(--glow-primary)' : 'none',
+                  transition: 'border-color var(--dur-base), background var(--dur-base), box-shadow var(--dur-base), transform var(--dur-base)',
+                  transform: on ? 'translateY(-2px)' : 'none',
+                }}
+              >
+                <div style={{ color: 'var(--cyan-400)', height: 24 }}>
+                  <Icon name={c.key} size={24} />
+                </div>
+                <div style={{ fontWeight: 700, fontSize: 15.5, color: 'var(--text)' }}>{c.title}</div>
+                <div style={{ color: 'var(--muted)', fontSize: 12.5, lineHeight: 1.45 }}>{c.desc}</div>
+                <div style={{ color: 'var(--cyan-400)', fontSize: 12.5, fontWeight: 600, marginTop: 4 }}>Open {'→'}</div>
+              </a>
+            )
+          })}
+        </div>
       </div>
     </div>
   )

--- a/frontend/src/screens/Interviews.jsx
+++ b/frontend/src/screens/Interviews.jsx
@@ -1,15 +1,17 @@
-import { Panel } from '../design-system'
+import { useState } from 'react'
 import {
-  useApi, Screen, SectionHead, StatGrid, Stat, Badge, EmptyState, EYEBROW,
+  useApi, Screen, StatGrid, Stat, EmptyState,
 } from './_shared.jsx'
-import { dayLabel } from './interviewUtils.js'
+import { dayLabel, startOfDayLocal } from './interviewUtils.js'
 
 /* Interviews — upcoming schedule and debrief log.
    Data: GET /dashboard/interviews/data (_interviews_payload).
 
-   Ports the legacy /dashboard/interviews two-column board: upcoming on the
-   left, recent debriefs on the right, with day labels, type labels, what
-   landed, verbatim quotes, and surfaced priorities. */
+   Design-handoff layout: mono UPCOMING eyebrow over a 2-col card grid — the
+   next interview gets a cyan-tinted gradient card with a mono countdown chip,
+   later ones get neutral cards — then RECENT DEBRIEFS as compact rows with
+   mono dates. Debrief rows expand to reveal what landed, verbatim quotes, and
+   surfaced priorities (payload detail the handoff rows don't show). */
 
 const TYPE_LABELS = {
   recruiter_screen: 'Recruiter Screen',
@@ -30,24 +32,60 @@ function typeLabel(t) {
   return TYPE_LABELS[t] || String(t).replaceAll('_', ' ')
 }
 
-function ratingTone(n) {
+/* Handoff palette (jobContext Desktop Import.dc.html, Interviews page). */
+const MONO_EYEBROW = {
+  fontFamily: 'var(--font-mono)',
+  fontSize: 11,
+  fontWeight: 'var(--fw-semibold)',
+  letterSpacing: '1.2px',
+  textTransform: 'uppercase',
+  color: '#7C8AA6',
+}
+
+const CHIP_MONO = {
+  fontFamily: 'var(--font-mono)',
+  fontSize: 11,
+  fontWeight: 'var(--fw-semibold)',
+  whiteSpace: 'nowrap',
+}
+
+/* Self-rating chip colors, mapped onto the handoff status palette. */
+function ratingColors(n) {
   const v = Number(n)
-  if (Number.isNaN(v)) return 'muted'
-  if (v >= 8) return 'green'
-  if (v >= 5) return 'accent'
-  return 'warn'
+  if (Number.isNaN(v)) return ['#9BB0D0', 'rgba(255,255,255,.06)']
+  if (v >= 8) return ['#6FD3A0', 'rgba(111,211,160,.15)']
+  if (v >= 5) return ['#6FE0EE', 'rgba(0,181,200,.15)']
+  return ['#E0B77A', 'rgba(224,183,122,.15)']
 }
 
 function quoteText(q) {
   return typeof q === 'string' ? q : q?.quote || ''
 }
 
+/* "JUL 9"-style mono date for debrief rows. */
+function monoDate(iso) {
+  const d = startOfDayLocal(iso)
+  if (!d) return '—'
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }).toUpperCase()
+}
+
+function metaLine(iv) {
+  return [
+    typeLabel(iv.interview_type),
+    iv.interview_format,
+    iv.interviewer
+      ? `with ${iv.interviewer}${iv.interviewer_role ? ` (${iv.interviewer_role})` : ''}`
+      : '',
+    iv.duration_minutes ? `${iv.duration_minutes} min` : '',
+  ].filter(Boolean).join(' · ')
+}
+
 function BulletSection({ label, items }) {
   if (!Array.isArray(items) || items.length === 0) return null
   return (
     <>
-      <div style={{ ...EYEBROW, marginTop: 10, marginBottom: 4 }}>{label}</div>
-      <ul style={{ margin: 0, paddingLeft: 16, color: 'var(--text-soft)', fontSize: 'var(--fs-sm)', lineHeight: 1.5 }}>
+      <div style={{ ...MONO_EYEBROW, fontSize: 10, marginTop: 12, marginBottom: 4 }}>{label}</div>
+      <ul style={{ margin: 0, paddingLeft: 16, color: '#B7C6E0', fontSize: 12.5, lineHeight: 1.5 }}>
         {items.map((x, i) => (
           <li key={i} style={{ marginBottom: 2 }}>{x}</li>
         ))}
@@ -56,87 +94,186 @@ function BulletSection({ label, items }) {
   )
 }
 
-function InterviewCard({ iv, upcoming }) {
+function SectionLabel({ label, count, first }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'baseline',
+        marginTop: first ? 4 : 26,
+        marginBottom: 12,
+      }}
+    >
+      <div style={MONO_EYEBROW}>{label}</div>
+      <div style={{ ...MONO_EYEBROW, letterSpacing: 0 }}>{count}</div>
+    </div>
+  )
+}
+
+/* Upcoming interview card. The next one (featured) gets the cyan-tinted
+   gradient treatment; later ones are neutral. */
+function UpcomingCard({ iv, featured }) {
   const date = (iv.interview_date || '').slice(0, 10)
   const rel = dayLabel(iv.interview_date)
   const isToday = rel === 'Today'
-  const badgeTone = upcoming ? (isToday ? 'warn' : 'accent') : 'muted'
-  const badgeText = upcoming ? rel || date : date || '\u2014'
-
-  const meta = [
-    typeLabel(iv.interview_type),
-    iv.interview_format,
-    iv.interviewer
-      ? `with ${iv.interviewer}${iv.interviewer_role ? ` (${iv.interviewer_role})` : ''}`
-      : '',
-    iv.duration_minutes ? `${iv.duration_minutes} min` : '',
-  ].filter(Boolean).join(' \u00b7 ')
-
-  const quotes = Array.isArray(iv.verbatim_quotes) ? iv.verbatim_quotes.slice(0, 3) : []
+  const chipText = (rel || date || '—').toUpperCase()
+  const chipColor = featured ? '#6FE0EE' : isToday ? '#E0B77A' : '#A9B6CE'
+  const meta = metaLine(iv)
 
   return (
-    <Panel
-      pad="14px 16px"
-      style={upcoming ? { borderColor: 'color-mix(in srgb, var(--cyan-500) 45%, var(--border))' } : undefined}
+    <div
+      style={{
+        borderRadius: 16,
+        padding: 18,
+        background: featured
+          ? 'linear-gradient(150deg, rgba(0,181,200,.13), rgba(0,181,200,.03))'
+          : 'rgba(255,255,255,.045)',
+        border: featured ? '1px solid rgba(0,181,200,.26)' : '1px solid rgba(255,255,255,.08)',
+      }}
     >
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: 12, flexWrap: 'wrap' }}>
-        <div style={{ minWidth: 0 }}>
-          <div style={{ color: 'var(--text-strong)', fontWeight: 'var(--fw-semibold)', fontSize: 'var(--fs-base)' }}>
-            {iv.company || 'Unknown'}
-          </div>
-          {iv.role && (
-            <div style={{ color: 'var(--muted)', fontSize: 'var(--fs-sm)', marginTop: 2 }}>{iv.role}</div>
-          )}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+        <div style={{ fontSize: 16, fontWeight: 'var(--fw-bold)', color: '#F0F5FF', minWidth: 0 }}>
+          {[iv.company || 'Unknown', iv.role].filter(Boolean).join(' · ')}
         </div>
-        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', justifyContent: 'flex-end' }}>
-          <Badge tone={badgeTone}>{badgeText}</Badge>
-          {!upcoming && iv.self_rating != null && (
-            <Badge tone={ratingTone(iv.self_rating)}>{`\u2605 ${iv.self_rating}/10`}</Badge>
-          )}
-        </div>
+        <div style={{ ...CHIP_MONO, color: chipColor }}>{chipText}</div>
       </div>
-
       {meta && (
-        <div style={{ color: 'var(--muted)', fontSize: 'var(--fs-xs)', marginTop: 6 }}>{meta}</div>
+        <div style={{ fontSize: 13, color: '#8A99B5', marginTop: 5 }}>{meta}</div>
       )}
+      {iv.notes && (
+        <div style={{ fontSize: 12.5, color: '#B7C6E0', marginTop: 12, lineHeight: 1.45 }}>
+          {iv.notes}
+        </div>
+      )}
+    </div>
+  )
+}
 
-      {upcoming ? (
-        iv.notes && (
-          <div style={{ color: 'var(--text-soft)', fontSize: 'var(--fs-sm)', marginTop: 8, lineHeight: 1.45 }}>
-            {iv.notes}
+/* Recent debrief row: handoff-style compact row (title, synopsis, mono date)
+   that expands to the full debrief detail. */
+function DebriefRow({ iv }) {
+  const [open, setOpen] = useState(false)
+
+  const quotes = Array.isArray(iv.verbatim_quotes) ? iv.verbatim_quotes.slice(0, 3) : []
+  const landed = Array.isArray(iv.what_landed) ? iv.what_landed : []
+  const synopsis =
+    landed[0] || (quotes[0] ? `“${quoteText(quotes[0])}”` : '') || iv.notes || metaLine(iv)
+  const hasBody =
+    landed.length > 0 || quotes.length > 0 ||
+    (Array.isArray(iv.surfaced_priorities) && iv.surfaced_priorities.length > 0) || iv.notes
+  const [ratingFg, ratingBg] = ratingColors(iv.self_rating)
+  const meta = metaLine(iv)
+
+  return (
+    <div
+      style={{
+        borderRadius: 14,
+        background: 'rgba(255,255,255,.035)',
+        border: '1px solid rgba(255,255,255,.06)',
+      }}
+    >
+      <button
+        type="button"
+        onClick={() => hasBody && setOpen((o) => !o)}
+        aria-expanded={open}
+        style={{
+          appearance: 'none',
+          width: '100%',
+          textAlign: 'left',
+          background: 'transparent',
+          border: 'none',
+          cursor: hasBody ? 'pointer' : 'default',
+          padding: '14px 16px',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          gap: 12,
+          font: 'inherit',
+          color: 'inherit',
+        }}
+      >
+        <div style={{ minWidth: 0 }}>
+          <div style={{ fontSize: 14.5, fontWeight: 'var(--fw-semibold)', color: '#E8EFFB' }}>
+            {[iv.company || 'Unknown', typeLabel(iv.interview_type)].filter(Boolean).join(' · ')}
           </div>
-        )
-      ) : (
-        <>
-          <BulletSection label="What landed" items={iv.what_landed} />
+          {synopsis && (
+            <div
+              style={{
+                fontSize: 12.5,
+                color: '#8A99B5',
+                marginTop: 1,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: open ? 'normal' : 'nowrap',
+              }}
+            >
+              {synopsis}
+            </div>
+          )}
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
+          {iv.self_rating != null && (
+            <span
+              style={{
+                ...CHIP_MONO,
+                fontSize: 10,
+                color: ratingFg,
+                background: ratingBg,
+                padding: '4px 8px',
+                borderRadius: 8,
+              }}
+            >
+              {`★ ${iv.self_rating}/10`}
+            </span>
+          )}
+          <span style={{ ...CHIP_MONO, color: '#6B7A96' }}>{monoDate(iv.interview_date)}</span>
+          {hasBody && (
+            <span
+              aria-hidden
+              style={{
+                color: '#6B7A96',
+                fontSize: 'var(--fs-xs)',
+                transition: 'transform var(--dur-base)',
+                transform: open ? 'rotate(90deg)' : 'rotate(0deg)',
+              }}
+            >
+              {'▶'}
+            </span>
+          )}
+        </div>
+      </button>
+
+      {open && hasBody && (
+        <div style={{ padding: '0 16px 14px', borderTop: '1px solid rgba(255,255,255,.06)' }}>
+          {meta && (
+            <div style={{ fontSize: 12.5, color: '#8A99B5', marginTop: 12 }}>{meta}</div>
+          )}
+          <BulletSection label="What landed" items={landed} />
           {quotes.map((q, i) => (
             <div
               key={i}
               style={{
                 borderLeft: '3px solid var(--cyan-500)',
                 paddingLeft: 10,
-                margin: '8px 0 0',
-                color: 'var(--text-soft)',
-                fontSize: 'var(--fs-sm)',
+                margin: '10px 0 0',
+                color: '#B7C6E0',
+                fontSize: 12.5,
                 fontStyle: 'italic',
                 lineHeight: 1.45,
               }}
             >
-              {`\u201c${quoteText(q)}\u201d`}
+              {`“${quoteText(q)}”`}
             </div>
           ))}
           <BulletSection label="Surfaced priorities" items={iv.surfaced_priorities} />
-        </>
+          {iv.notes && (
+            <div style={{ fontSize: 12.5, color: '#B7C6E0', marginTop: 12, lineHeight: 1.45 }}>
+              {iv.notes}
+            </div>
+          )}
+        </div>
       )}
-    </Panel>
-  )
-}
-
-function Column({ title, count, children }) {
-  return (
-    <div>
-      <SectionHead title={title} right={`${count}`} />
-      <div style={{ display: 'grid', gap: 10 }}>{children}</div>
     </div>
   )
 }
@@ -159,19 +296,25 @@ export default function Interviews() {
         <Stat label="Debriefs" value={recent.length} />
       </StatGrid>
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))', gap: 20 }}>
-        <Column title="Upcoming interviews" count={upcoming.length}>
-          {upcoming.length > 0
-            ? upcoming.map((iv, i) => <InterviewCard key={`up-${i}`} iv={iv} upcoming />)
-            : <EmptyState label="No upcoming interviews scheduled." />}
-        </Column>
+      <SectionLabel label="Upcoming" count={upcoming.length} first />
+      {upcoming.length > 0 ? (
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))', gap: 14 }}>
+          {upcoming.map((iv, i) => (
+            <UpcomingCard key={`up-${i}`} iv={iv} featured={i === 0} />
+          ))}
+        </div>
+      ) : (
+        <EmptyState label="No upcoming interviews scheduled." />
+      )}
 
-        <Column title="Recent debriefs" count={recent.length}>
-          {recent.length > 0
-            ? recent.map((iv, i) => <InterviewCard key={`re-${i}`} iv={iv} upcoming={false} />)
-            : <EmptyState label="No debriefs logged yet." hint="Use log_interview() from your assistant." />}
-        </Column>
-      </div>
+      <SectionLabel label="Recent debriefs" count={recent.length} />
+      {recent.length > 0 ? (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {recent.map((iv, i) => <DebriefRow key={`re-${i}`} iv={iv} />)}
+        </div>
+      ) : (
+        <EmptyState label="No debriefs logged yet." hint="Use log_interview() from your assistant." />
+      )}
     </Screen>
   )
 }

--- a/frontend/src/screens/People.jsx
+++ b/frontend/src/screens/People.jsx
@@ -1,64 +1,231 @@
 import { useState } from 'react'
 import {
-  useApi, Screen, SectionHead, StatGrid, Stat, Badge, statusTone,
-  Bars, ExpandableCard, Chips, DetailLine, fmtDate,
+  useApi, Screen, StatGrid, Stat, Chips, EmptyState, fmtDate,
 } from './_shared.jsx'
-import { Panel } from '../design-system'
 
 /* Outreach — contacts, warm vs cold, and the follow-up queue.
    Data: GET /dashboard/people/data (_people_payload).
 
-   Each contact is an expandable card matching the Posts pattern: collapsed
-   shows name + relationship/company + outreach status; expanded reveals the
-   context blurb, tags, contact info, notes, and last-touched date. */
+   Design-handoff layout: pill filter chips (derived from the real outreach
+   statuses in the payload) that filter live, a cyan hint bar (carries the
+   follow-up queue summary), and a 2-col contact card grid — colored-initials
+   avatar, name/title, mono status chip, then a divider with the contact
+   synopsis and a mono last-touch line. */
+
+/* Handoff palette (jobContext Desktop Import.dc.html lines 482-492). */
+const AVATAR_BG = ['#6FE0EE', '#9BE0C0', '#E0C98A', '#C7A9E8', '#E8A9B4']
+
+const STATUS_STYLES = [
+  [/replied|responded|connected|referred|met|accepted|intro/, ['#6FD3A0', 'rgba(111,211,160,.15)']],
+  [/warm|follow|active|scheduled/, ['#6FE0EE', 'rgba(0,181,200,.15)']],
+  [/sent|await|pending|reached|outreach|waiting/, ['#E0B77A', 'rgba(224,183,122,.15)']],
+]
+
+function statusColors(status) {
+  const s = (status || '').toLowerCase()
+  for (const [re, colors] of STATUS_STYLES) {
+    if (re.test(s)) return colors
+  }
+  return ['#9BB0D0', 'rgba(255,255,255,.06)']
+}
+
+const MONO_EYEBROW = {
+  fontFamily: 'var(--font-mono)',
+  fontSize: 11,
+  fontWeight: 'var(--fw-semibold)',
+  letterSpacing: '1.2px',
+  textTransform: 'uppercase',
+  color: '#7C8AA6',
+}
+
+function initials(name) {
+  const parts = String(name || '').trim().split(/\s+/).filter(Boolean)
+  if (parts.length === 0) return '?'
+  return parts.slice(0, 2).map((p) => p[0].toUpperCase()).join('')
+}
+
+/* Stable avatar color per contact so it survives filtering/reordering. */
+function avatarBg(name) {
+  let h = 0
+  for (const c of String(name || '')) h = (h * 31 + c.codePointAt(0)) % 997
+  return AVATAR_BG[h % AVATAR_BG.length]
+}
+
+/* "JUL 12"-style mono date for last-touch lines. */
+function monoDate(iso) {
+  if (!iso) return ''
+  const d = new Date(String(iso).slice(0, 10) + 'T00:00:00')
+  if (Number.isNaN(d.getTime())) return String(iso).slice(0, 10).toUpperCase()
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }).toUpperCase()
+}
+
+function SectionLabel({ label, count, first }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'baseline',
+        marginTop: first ? 0 : 22,
+        marginBottom: 12,
+      }}
+    >
+      <div style={MONO_EYEBROW}>{label}</div>
+      <div style={{ ...MONO_EYEBROW, letterSpacing: 0 }}>{count}</div>
+    </div>
+  )
+}
 
 function PersonCard({ person }) {
+  const [fg, bg] = statusColors(person.outreach_status)
+  const status = person.outreach_status || 'none'
   const hasBody =
     person.context || person.notes || person.contact_info ||
     (Array.isArray(person.tags) && person.tags.length > 0) || person.last_updated
 
   return (
-    <ExpandableCard
-      title={person.name || 'Unknown'}
-      subtitle={[person.relationship, person.company].filter(Boolean).join(' \u00b7 ')}
-      right={<Badge tone={statusTone(person.outreach_status)}>{person.outreach_status || 'none'}</Badge>}
+    <div
+      style={{
+        borderRadius: 14,
+        padding: '15px 16px',
+        background: 'rgba(255,255,255,.04)',
+        border: '1px solid rgba(255,255,255,.07)',
+      }}
     >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+        <div
+          style={{
+            width: 40,
+            height: 40,
+            borderRadius: '50%',
+            background: avatarBg(person.name),
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontWeight: 'var(--fw-bold)',
+            fontSize: 15,
+            color: '#04222A',
+            flexShrink: 0,
+          }}
+        >
+          {initials(person.name)}
+        </div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 15, fontWeight: 'var(--fw-semibold)', color: '#F0F5FF' }}>
+            {person.name || 'Unknown'}
+          </div>
+          <div style={{ fontSize: 12.5, color: '#8A99B5' }}>
+            {[person.relationship, person.company].filter(Boolean).join(' · ')}
+          </div>
+        </div>
+        <div
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 10,
+            fontWeight: 'var(--fw-semibold)',
+            textTransform: 'uppercase',
+            color: fg,
+            background: bg,
+            padding: '4px 8px',
+            borderRadius: 8,
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {status}
+        </div>
+      </div>
+
       {hasBody && (
-        <>
-          {person.context && <DetailLine label="Context">{person.context}</DetailLine>}
-          {person.contact_info && <DetailLine label="Contact">{person.contact_info}</DetailLine>}
-          {person.notes && <DetailLine label="Notes">{person.notes}</DetailLine>}
+        <div style={{ marginTop: 12, paddingTop: 12, borderTop: '1px solid rgba(255,255,255,.06)' }}>
+          {person.context && (
+            <div style={{ fontSize: 12.5, color: '#B7C6E0', lineHeight: 1.45 }}>{person.context}</div>
+          )}
+          {person.contact_info && (
+            <div style={{ fontSize: 12, color: '#8A99B5', lineHeight: 1.45, marginTop: person.context ? 6 : 0 }}>
+              <span style={{ color: '#7C8AA6', fontWeight: 'var(--fw-semibold)' }}>Contact: </span>
+              {person.contact_info}
+            </div>
+          )}
+          {person.notes && (
+            <div style={{ fontSize: 12, color: '#8A99B5', lineHeight: 1.45, marginTop: 6 }}>
+              <span style={{ color: '#7C8AA6', fontWeight: 'var(--fw-semibold)' }}>Notes: </span>
+              {person.notes}
+            </div>
+          )}
           {Array.isArray(person.tags) && person.tags.length > 0 && (
-            <div style={{ marginTop: 10 }}>
+            <div style={{ marginTop: 8 }}>
               <Chips items={person.tags} />
             </div>
           )}
           {person.last_updated && (
-            <div style={{ color: 'var(--faint)', fontSize: 'var(--fs-xs)', marginTop: 10 }}>
-              Last touched {fmtDate(person.last_updated)}
+            <div
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: 10.5,
+                color: '#6B7A96',
+                textTransform: 'uppercase',
+                marginTop: 8,
+              }}
+              title={`Last touched ${fmtDate(person.last_updated)}`}
+            >
+              {`${status} · ${monoDate(person.last_updated)}`}
             </div>
           )}
-        </>
+        </div>
       )}
-    </ExpandableCard>
+    </div>
+  )
+}
+
+function CardGrid({ people, keyPrefix }) {
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: 10 }}>
+      {people.map((p, i) => <PersonCard key={`${keyPrefix}-${p.name}-${i}`} person={p} />)}
+    </div>
   )
 }
 
 export default function People() {
   const { data, loading, error } = useApi('/dashboard/people/data')
   const [q, setQ] = useState('')
+  const [filter, setFilter] = useState('all')
   const recent = data?.recent || []
   const followUp = data?.follow_up_queue || []
   const byStatus = data?.by_status || []
 
+  /* Filter chips from the real status values present in the payload. */
+  const statuses = byStatus.length > 0
+    ? byStatus.map((s) => ({ status: s.status, count: s.count }))
+    : [...new Set([...recent, ...followUp].map((p) => p.outreach_status).filter(Boolean))]
+      .map((status) => ({ status, count: null }))
+
   const query = q.trim().toLowerCase()
   const match = (p) =>
-    !query ||
-    [p.name, p.company, p.relationship, p.outreach_status, p.context, ...(p.tags || [])]
-      .join(' ').toLowerCase().includes(query)
+    (filter === 'all' || (p.outreach_status || 'none') === filter) &&
+    (!query ||
+      [p.name, p.company, p.relationship, p.outreach_status, p.context, ...(p.tags || [])]
+        .join(' ').toLowerCase().includes(query))
 
   const shownRecent = recent.filter(match)
   const shownFollowUp = followUp.filter(match)
+  const filtering = query || filter !== 'all'
+
+  const fuNames = followUp.map((p) => p.name).filter(Boolean)
+  const fuHint = fuNames.slice(0, 3).join(', ') + (fuNames.length > 3 ? ` +${fuNames.length - 3} more` : '')
+
+  const chip = (active) => ({
+    cursor: 'pointer',
+    fontSize: 12.5,
+    fontWeight: 'var(--fw-semibold)',
+    color: active ? '#04222A' : '#A9B6CE',
+    background: active ? '#00B5C8' : 'rgba(255,255,255,.05)',
+    padding: '7px 15px',
+    borderRadius: 'var(--radius-pill)',
+    border: 'none',
+    font: 'inherit',
+    textTransform: 'capitalize',
+    whiteSpace: 'nowrap',
+  })
 
   return (
     <Screen
@@ -74,38 +241,75 @@ export default function People() {
         <Stat label="Statuses" value={byStatus.length} tone="muted" />
       </StatGrid>
 
-      {byStatus.length > 0 && (
-        <Panel style={{ marginBottom: 20 }}>
-          <SectionHead title="By outreach status" />
-          <Bars items={byStatus} labelKey="status" tone="accent" />
-        </Panel>
+      {statuses.length > 0 && (
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 14 }}>
+          <button type="button" style={chip(filter === 'all')} onClick={() => setFilter('all')}>
+            All
+          </button>
+          {statuses.map(({ status, count }) => (
+            <button
+              key={status}
+              type="button"
+              style={chip(filter === status)}
+              onClick={() => setFilter(filter === status ? 'all' : status)}
+            >
+              {String(status).replace(/_/g, ' ')}
+              {count != null && (
+                <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10.5, marginLeft: 6, opacity: 0.75 }}>
+                  {count}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {followUp.length > 0 && (
+        <div
+          style={{
+            borderRadius: 14,
+            padding: '13px 16px',
+            background: 'rgba(0,181,200,.07)',
+            border: '1px solid rgba(0,181,200,.18)',
+            fontSize: 13,
+            color: '#C9D6EC',
+            marginBottom: 14,
+          }}
+        >
+          <span style={{ color: '#6FE0EE', fontWeight: 'var(--fw-semibold)' }}>Follow-up queue: </span>
+          {`${fuHint} ${fuNames.length === 1 ? 'needs' : 'need'} a follow-up`}
+        </div>
       )}
 
       <input
         value={q}
         onChange={(e) => setQ(e.target.value)}
-        placeholder={'Filter by name, company, relationship, tag\u2026'}
+        placeholder={'Filter by name, company, relationship, tag…'}
         style={{
           width: '100%', maxWidth: 440, marginBottom: 16, boxSizing: 'border-box',
-          background: 'var(--surface-sunken)', border: '1px solid var(--border)',
-          borderRadius: 'var(--radius-sm)', padding: '9px 11px',
-          color: 'var(--text)', fontSize: 'var(--fs-sm)',
+          background: 'rgba(255,255,255,.04)', border: '1px solid rgba(255,255,255,.08)',
+          borderRadius: 12, padding: '9px 12px',
+          color: '#E8EFFB', fontSize: 13,
         }}
       />
 
       {shownFollowUp.length > 0 && (
         <>
-          <SectionHead title="Follow-up queue" right={`${shownFollowUp.length}`} />
-          <div style={{ display: 'grid', gap: 8, marginBottom: 20 }}>
-            {shownFollowUp.map((p, i) => <PersonCard key={`fu-${p.name}-${i}`} person={p} />)}
-          </div>
+          <SectionLabel label="Follow-up queue" count={shownFollowUp.length} first />
+          <CardGrid people={shownFollowUp} keyPrefix="fu" />
         </>
       )}
 
-      <SectionHead title="Recent contacts" right={`${shownRecent.length}${query ? ` of ${recent.length}` : ''}`} />
-      <div style={{ display: 'grid', gap: 8 }}>
-        {shownRecent.map((p, i) => <PersonCard key={`re-${p.name}-${i}`} person={p} />)}
-      </div>
+      <SectionLabel
+        label="Recent contacts"
+        count={`${shownRecent.length}${filtering ? ` of ${recent.length}` : ''}`}
+        first={shownFollowUp.length === 0}
+      />
+      {shownRecent.length > 0 ? (
+        <CardGrid people={shownRecent} keyPrefix="re" />
+      ) : (
+        <EmptyState label="No contacts match this filter." />
+      )}
     </Screen>
   )
 }

--- a/frontend/src/screens/Pipeline.jsx
+++ b/frontend/src/screens/Pipeline.jsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, useCallback } from 'react'
 import { Panel, Button } from '../design-system'
 import { apiFetch, apiPost } from '../auth/api.js'
-import { Screen, StatGrid, Stat, EmptyState, EYEBROW } from './_shared.jsx'
+import { Screen, EmptyState, EYEBROW } from './_shared.jsx'
+import { useToolbarSlot } from '../shell/toolbarSlot.jsx'
 import { actionError } from './pipeline/shared.jsx'
-import JobCard from './pipeline/JobCard.jsx'
+import JobCard, { ROW_GRID } from './pipeline/JobCard.jsx'
 import AddJobModal from './pipeline/AddJobModal.jsx'
 import EditResumeModal from './pipeline/EditResumeModal.jsx'
 import EditCoverLetterModal from './pipeline/EditCoverLetterModal.jsx'
@@ -18,17 +19,46 @@ import TemplateModal from './pipeline/TemplateModal.jsx'
    plus a search filter and the Add Job intake modal. The AI editor flows now
    live here too, in React: Edit Resume, Edit Cover Letter (draft → review →
    accept/discard), and the visual Template chooser with a live preview.
-   The card and modals live in ./pipeline/. */
+   The card and modals live in ./pipeline/.
+
+   Skin follows the desktop design handoff's PIPELINE page: "N active ·
+   M applied" count line, segmented All/Active/Applied chips, and a
+   5-column table (COMPANY / ROLE / STAGE / FIT / NEXT STEP) with mono
+   headers — each row expands below its table line into the full detail +
+   action area, so no functionality from the card era is lost. */
 
 function personaOption(o) {
   if (typeof o === 'string') return { value: o, label: o }
   return { value: o.id || o.name || '', label: o.label || o.name || o.id || '' }
 }
 
+/* Statuses still moving through the funnel (design chips: All / Active / Applied). */
+const ACTIVE_STATUSES = new Set(['pending', 'evaluated', 'added'])
+
+/* Segmented chip per the handoff: cyan fill + deep-cyan ink when active. */
+function Chip({ active, onClick, children }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        appearance: 'none', cursor: 'pointer', border: 'none',
+        fontSize: 12.5, fontWeight: 'var(--fw-semibold)', fontFamily: 'var(--font-sans)',
+        color: active ? '#04222A' : 'var(--muted)',
+        background: active ? 'var(--cyan-500)' : 'rgba(255,255,255,.05)',
+        padding: '7px 15px', borderRadius: 'var(--radius-pill)', whiteSpace: 'nowrap',
+      }}
+    >
+      {children}
+    </button>
+  )
+}
+
 export default function Pipeline() {
   const [state, setState] = useState({ data: null, loading: true, error: null })
   const [busy, setBusy] = useState(null)
   const [filter, setFilter] = useState('')
+  const [stageFilter, setStageFilter] = useState('all')
   const [persona, setPersona] = useState('')
   const [addOpen, setAddOpen] = useState(false)
   const [editor, setEditor] = useState(null) // { type: 'edit-resume'|'edit-cl'|'templates', job }
@@ -44,6 +74,13 @@ export default function Pipeline() {
   }, [])
 
   useEffect(() => { load() }, [load])
+
+  // "+ Add Job" is the page's primary action — projected into the shell's
+  // sticky toolbar per the desktop design's content-toolbar spec.
+  useToolbarSlot(
+    <Button size="sm" onClick={() => setAddOpen(true)}>{'＋'} Add Job</Button>,
+    [],
+  )
 
   const data = state.data
   const jobs = data?.jobs || []
@@ -89,11 +126,15 @@ export default function Pipeline() {
   }
 
   const q = filter.trim().toLowerCase()
-  const shown = q
-    ? jobs.filter((j) => [j.company, j.role, j.status, j.source, j.decision_notes].join(' ').toLowerCase().includes(q))
-    : jobs
+  const stageMatch = (j) =>
+    stageFilter === 'all' ||
+    (stageFilter === 'active' ? ACTIVE_STATUSES.has(j.status) : j.status === 'applied')
+  const shown = jobs.filter((j) =>
+    stageMatch(j) &&
+    (!q || [j.company, j.role, j.status, j.source, j.decision_notes].join(' ').toLowerCase().includes(q)))
 
   const countBy = (s) => jobs.filter((j) => j.status === s).length
+  const activeCount = jobs.filter((j) => ACTIVE_STATUSES.has(j.status)).length
 
   const fieldStyle = {
     flex: 1, minWidth: 220, maxWidth: 420, boxSizing: 'border-box',
@@ -104,13 +145,18 @@ export default function Pipeline() {
 
   return (
     <Screen loading={state.loading} error={state.error} empty={false}>
-      <StatGrid>
-        <Stat label="Queue total" value={data?.total ?? 0} tone="accent" />
-        <Stat label="Pending" value={countBy('pending')} tone="warn" />
-        <Stat label="Evaluated" value={countBy('evaluated')} />
-        <Stat label="Added" value={countBy('added')} tone="green" />
-        <Stat label="Applied" value={countBy('applied')} tone="green" />
-      </StatGrid>
+      <div style={{ fontSize: 13.5, color: 'var(--muted)', marginBottom: 14 }}>
+        {activeCount} active {'·'} {countBy('applied')} applied
+      </div>
+
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap', marginBottom: 12 }}>
+        <Chip active={stageFilter === 'all'} onClick={() => setStageFilter('all')}>All</Chip>
+        <Chip active={stageFilter === 'active'} onClick={() => setStageFilter('active')}>Active</Chip>
+        <Chip active={stageFilter === 'applied'} onClick={() => setStageFilter('applied')}>Applied</Chip>
+        <span style={{ marginLeft: 'auto', fontSize: 10.5, fontFamily: 'var(--font-mono)', fontWeight: 'var(--fw-semibold)', letterSpacing: '0.5px', color: 'var(--faint)', textTransform: 'uppercase' }}>
+          {`${data?.total ?? 0} total · ${countBy('pending')} pending · ${countBy('evaluated')} evaluated · ${countBy('added')} added · ${countBy('applied')} applied`}
+        </span>
+      </div>
 
       <div style={{ display: 'flex', gap: 10, alignItems: 'center', flexWrap: 'wrap', marginBottom: 16 }}>
         <input
@@ -133,7 +179,6 @@ export default function Pipeline() {
             </select>
           </label>
         )}
-        <Button size="sm" onClick={() => setAddOpen(true)}>{'＋'} Add Job</Button>
       </div>
 
       {busy && (
@@ -152,7 +197,20 @@ export default function Pipeline() {
           hint={jobs.length === 0 ? 'Use Add Job, or share a posting from your phone.' : undefined}
         />
       ) : (
-        <div style={{ display: 'grid', gap: 10 }}>
+        <div style={{ borderRadius: 16, border: '1px solid var(--border)', overflow: 'hidden', background: 'var(--surface)' }}>
+          <div
+            style={{
+              display: 'grid', gridTemplateColumns: ROW_GRID, gap: 10, padding: '12px 20px',
+              background: 'rgba(255,255,255,.04)', fontSize: 10.5, fontWeight: 'var(--fw-semibold)',
+              letterSpacing: '0.5px', color: 'var(--faint)', fontFamily: 'var(--font-mono)',
+            }}
+          >
+            <div>COMPANY</div>
+            <div>ROLE</div>
+            <div>STAGE</div>
+            <div style={{ textAlign: 'center' }}>FIT</div>
+            <div>NEXT STEP</div>
+          </div>
           {shown.map((job) => (
             <JobCard
               key={job.id}

--- a/frontend/src/screens/Posts.jsx
+++ b/frontend/src/screens/Posts.jsx
@@ -1,120 +1,208 @@
 import { useState } from 'react'
 import useDesktopMode from '../shell/useDesktopMode.js'
 import { nativeAnchorHandler } from '../shell/nativeOpen.js'
-import {
-  useApi, Screen, SectionHead, StatGrid, Stat,
-  ExpandableCard, Chips, DetailLine, EYEBROW, fmtDate, fmtNum,
-} from './_shared.jsx'
+import { useToolbarSlot } from '../shell/toolbarSlot.jsx'
+import { apiPost } from '../auth/api.js'
+import { useApi, Screen, fmtDate } from './_shared.jsx'
+import ImportFlow, { StepIndicator } from './posts/ImportFlow.jsx'
+import { fmtK } from './posts/csv.js'
 
-/* Posts — LinkedIn content pipeline and engagement.
+/* Posts — LinkedIn content + engagement, per the desktop design handoff.
    Data: GET /dashboard/posts/data (_posts_payload).
 
-   Each post is an expandable card: collapsed shows title + date + a compact
-   metric line; expanded reveals the full metric grid, every hashtag, the
-   source slug, and the LinkedIn link. A search filter narrows by title /
-   source / hashtag. */
+   List mode: aggregate metric strip, post cards (text, cyan hashtag line,
+   ◎/♥/💬 mono metrics, Update button → metrics sheet), search filter.
+   Import mode: the 3-step LinkedIn CSV flow (ImportFlow); the toolbar slot
+   carries the "Import from LinkedIn" action or the 1·2·3 step indicator. */
 
-function MetricCell({ label, value, tone }) {
+const MONO = { fontFamily: 'var(--font-mono)' }
+
+function MetricSheet({ post, onClose, onSaved }) {
+  const digits = (v) => v.replace(/[^0-9]/g, '')
+  const [imp, setImp] = useState(String(post.impressions || ''))
+  const [rx, setRx] = useState(String(post.reactions || ''))
+  const [cm, setCm] = useState(String(post.comments || ''))
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState('')
+
+  async function save() {
+    setBusy(true)
+    setErr('')
+    try {
+      await apiPost('/dashboard/posts/metrics', {
+        post_id: post.id,
+        impressions: +imp || 0,
+        reactions: +rx || 0,
+        comments: +cm || 0,
+      })
+      onSaved()
+    } catch (e) {
+      setErr(e?.body?.detail || e.message || 'Could not save.')
+      setBusy(false)
+    }
+  }
+
+  const label = { fontSize: 11, fontWeight: 'var(--fw-semibold)', letterSpacing: 1, color: '#7C8AA6', ...MONO }
+  const input = {
+    marginTop: 6, width: '100%', boxSizing: 'border-box', background: 'rgba(255,255,255,.05)',
+    border: '1px solid rgba(255,255,255,.12)', borderRadius: 12, padding: '11px 13px',
+    color: 'var(--text)', fontSize: 15, fontFamily: 'var(--font-sans)', outline: 'none',
+  }
+
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-      <span style={{ fontFamily: 'var(--font-mono)', fontWeight: 'var(--fw-bold)', fontSize: 'var(--fs-lg)', color: tone }}>
-        {fmtNum(value)}
-      </span>
-      <span style={EYEBROW}>{label}</span>
+    <div
+      onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+      style={{ position: 'fixed', inset: 0, zIndex: 90, background: 'rgba(4,7,14,.66)', backdropFilter: 'blur(3px)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 20 }}
+    >
+      <div style={{ width: 440, maxWidth: '100%', background: '#0E1524', borderRadius: 20, border: '1px solid rgba(255,255,255,.1)', padding: 24, boxShadow: '0 30px 80px rgba(0,0,0,.6)' }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <div style={{ fontSize: 18, fontWeight: 'var(--fw-bold)', color: 'var(--text)' }}>Update metrics</div>
+          <div onClick={onClose} style={{ cursor: 'pointer', color: '#8A99B5', fontSize: 24, lineHeight: 1 }}>×</div>
+        </div>
+        <div style={{ marginTop: 6, fontSize: '12.5px', color: '#8A99B5', lineHeight: 1.4, display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
+          {post.text || post.title}
+        </div>
+        <div style={{ marginTop: 18 }}>
+          <div style={label}>IMPRESSIONS</div>
+          <input type="text" inputMode="numeric" value={imp} onChange={(e) => setImp(digits(e.target.value))} style={input} />
+        </div>
+        <div style={{ marginTop: 12, display: 'flex', gap: 12 }}>
+          <div style={{ flex: 1 }}>
+            <div style={label}>REACTIONS</div>
+            <input type="text" inputMode="numeric" value={rx} onChange={(e) => setRx(digits(e.target.value))} style={input} />
+          </div>
+          <div style={{ flex: 1 }}>
+            <div style={label}>COMMENTS</div>
+            <input type="text" inputMode="numeric" value={cm} onChange={(e) => setCm(digits(e.target.value))} style={input} />
+          </div>
+        </div>
+        {err && <div style={{ marginTop: 12, color: 'var(--danger-soft)', fontSize: 'var(--fs-sm)' }}>{err}</div>}
+        <div onClick={busy ? undefined : save} style={{ marginTop: 22, textAlign: 'center', background: 'var(--cyan-500)', color: '#04222A', fontWeight: 'var(--fw-bold)', fontSize: 15, padding: 13, borderRadius: 14, cursor: busy ? 'wait' : 'pointer' }}>
+          {busy ? 'Saving…' : 'Save metrics'}
+        </div>
+      </div>
     </div>
   )
 }
 
-function PostCard({ post }) {
-  const useDesktopModeValue = useDesktopMode()
-  const hasMetrics = (post.impressions || 0) + (post.reactions || 0) + (post.comments || 0) > 0
-  const compact = hasMetrics
-    ? `${fmtNum(post.impressions)} views \u00b7 ${fmtNum(post.reactions)} reactions`
-    : 'No metrics logged'
-
+function PostCard({ post, isDesktop, onEdit }) {
+  const tags = (post.hashtags || []).map((t) => `#${t}`).join(' ')
   return (
-    <ExpandableCard
-      title={post.title || post.source || 'Untitled post'}
-      subtitle={post.posted_date ? fmtDate(post.posted_date) : ''}
-      right={
-        <span style={{ color: hasMetrics ? 'var(--green-300)' : 'var(--muted)', fontFamily: 'var(--font-mono)', fontSize: 'var(--fs-xs)', whiteSpace: 'nowrap' }}>
-          {compact}
-        </span>
-      }
-    >
-      {hasMetrics && (
-        <div style={{ display: 'flex', gap: 22, flexWrap: 'wrap', marginBottom: 4 }}>
-          <MetricCell label="Impressions" value={post.impressions} tone="var(--green-300)" />
-          <MetricCell label="Reactions" value={post.reactions} tone="var(--cyan-300)" />
-          <MetricCell label="Comments" value={post.comments} tone="var(--text-strong)" />
+    <div style={{ borderRadius: 16, padding: '16px 18px', background: 'rgba(255,255,255,.045)', border: '1px solid rgba(255,255,255,.08)', display: 'flex', alignItems: 'center', gap: 18, flexWrap: 'wrap' }}>
+      <div style={{ flex: 1, minWidth: 220 }}>
+        <div style={{ fontSize: 14, color: '#E8EFFB', lineHeight: 1.4 }}>
+          {post.text || post.title || post.source || 'Untitled post'}
         </div>
-      )}
-
-      {Array.isArray(post.hashtags) && post.hashtags.length > 0 && (
-        <DetailLine label="Hashtags">
-          <div style={{ marginTop: 6 }}>
-            <Chips items={post.hashtags} prefix="#" />
-          </div>
-        </DetailLine>
-      )}
-
-      {post.source && <DetailLine label="Source">{post.source}</DetailLine>}
-
-      {post.url ? (
-        <div style={{ marginTop: 12 }}>
-          <a href={post.url} target="_blank" rel="noreferrer" onClick={nativeAnchorHandler(useDesktopModeValue, post.url)} style={{ color: 'var(--cyan-300)', fontSize: 'var(--fs-sm)', textDecoration: 'none' }}>
-            View on LinkedIn {'\u2197'}
-          </a>
+        <div style={{ marginTop: 8, display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+          {tags && <span style={{ fontSize: 12, color: 'var(--cyan-300)', ...MONO }}>{tags}</span>}
+          {post.posted_date && <span style={{ fontSize: 11, color: '#6B7A96', ...MONO }}>{fmtDate(post.posted_date) || post.posted_date}</span>}
+          {post.url && (
+            <a href={post.url} target="_blank" rel="noreferrer" onClick={nativeAnchorHandler(isDesktop, post.url)} style={{ fontSize: 12, color: 'var(--cyan-300)', textDecoration: 'none' }}>
+              View on LinkedIn ↗
+            </a>
+          )}
         </div>
-      ) : (
-        <div style={{ marginTop: 12, color: 'var(--faint)', fontSize: 'var(--fs-xs)' }}>No public URL logged.</div>
-      )}
-    </ExpandableCard>
+      </div>
+      <div style={{ display: 'flex', gap: 20, fontSize: '12.5px', color: '#8A99B5', ...MONO, flexShrink: 0 }}>
+        <span>◎ {fmtK(post.impressions)}</span>
+        <span>♥ {fmtK(post.reactions)}</span>
+        <span>💬 {fmtK(post.comments)}</span>
+      </div>
+      <div onClick={onEdit} style={{ cursor: 'pointer', fontSize: 12, fontWeight: 'var(--fw-semibold)', color: 'var(--cyan-300)', background: 'rgba(0,181,200,.12)', border: '1px solid rgba(0,181,200,.24)', padding: '7px 14px', borderRadius: 9, flexShrink: 0 }}>
+        Update
+      </div>
+    </div>
   )
 }
 
 export default function Posts() {
-  const { data, loading, error } = useApi('/dashboard/posts/data')
+  const { data, loading, error, reload } = useApi('/dashboard/posts/data')
+  const isDesktop = useDesktopMode()
   const [q, setQ] = useState('')
-  const posts = data?.posts || []
+  const [mode, setMode] = useState('list') // list | import
+  const [step, setStep] = useState(1)
+  const [sheetPost, setSheetPost] = useState(null)
 
+  const importing = mode === 'import'
+
+  useToolbarSlot(
+    importing ? (
+      <StepIndicator step={step} />
+    ) : (
+      <div
+        onClick={() => { setMode('import'); setStep(1) }}
+        style={{ cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 7, fontSize: 13, fontWeight: 'var(--fw-bold)', color: '#04222A', background: 'var(--cyan-500)', padding: '9px 16px', borderRadius: 10, boxShadow: '0 4px 14px rgba(0,181,200,.25)' }}
+      >
+        ↧ Import from LinkedIn
+      </div>
+    ),
+    [importing, step],
+  )
+
+  if (importing) {
+    return (
+      <ImportFlow
+        step={step}
+        setStep={setStep}
+        onDone={() => { setMode('list'); reload() }}
+        onCancel={() => setMode('list')}
+      />
+    )
+  }
+
+  const posts = data?.posts || []
   const query = q.trim().toLowerCase()
   const shown = query
-    ? posts.filter((p) => [p.title, p.source, ...(p.hashtags || [])].join(' ').toLowerCase().includes(query))
+    ? posts.filter((p) => [p.text, p.title, p.source, ...(p.hashtags || [])].join(' ').toLowerCase().includes(query))
     : posts
 
   return (
-    <Screen
-      loading={loading}
-      error={error}
-      empty={!loading && !error && posts.length === 0}
-      emptyLabel="No LinkedIn posts logged yet."
-    >
-      <StatGrid>
-        <Stat label="Posts" value={data?.total ?? 0} tone="accent" />
-        <Stat label="Impressions" value={fmtNum(data?.total_impressions)} tone="green" />
-        <Stat label="Reactions" value={fmtNum(data?.total_reactions)} />
-        <Stat label="Comments" value={fmtNum(data?.total_comments)} tone="muted" />
-      </StatGrid>
+    <Screen loading={loading} error={error} empty={false}>
+      <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+        <div style={{ flex: 1, minWidth: 150, padding: '16px 18px', borderRadius: 16, background: 'rgba(255,255,255,.04)', border: '1px solid rgba(255,255,255,.07)' }}>
+          <div style={{ fontSize: 24, fontWeight: 'var(--fw-bold)', color: 'var(--text)' }}>{fmtK(data?.total_impressions)}</div>
+          <div style={{ fontSize: '11.5px', color: '#8A99B5', marginTop: 2 }}>Impressions</div>
+        </div>
+        <div style={{ flex: 1, minWidth: 150, padding: '16px 18px', borderRadius: 16, background: 'rgba(255,255,255,.04)', border: '1px solid rgba(255,255,255,.07)' }}>
+          <div style={{ fontSize: 24, fontWeight: 'var(--fw-bold)', color: 'var(--text)' }}>{fmtK(data?.total_reactions)}</div>
+          <div style={{ fontSize: '11.5px', color: '#8A99B5', marginTop: 2 }}>Reactions</div>
+        </div>
+        <div style={{ flex: 1, minWidth: 150, padding: '16px 18px', borderRadius: 16, background: 'rgba(0,181,200,.1)', border: '1px solid rgba(0,181,200,.22)' }}>
+          <div style={{ fontSize: 24, fontWeight: 'var(--fw-bold)', color: 'var(--cyan-300)' }}>{data?.total ?? 0}</div>
+          <div style={{ fontSize: '11.5px', color: '#8AB6C4', marginTop: 2 }}>Posts logged</div>
+        </div>
+      </div>
 
       <input
         value={q}
         onChange={(e) => setQ(e.target.value)}
-        placeholder={'Filter by title, source, hashtag\u2026'}
+        placeholder={'Filter by text, source, hashtag…'}
         style={{
-          width: '100%', maxWidth: 440, marginBottom: 14, boxSizing: 'border-box',
+          width: '100%', maxWidth: 440, margin: '20px 0 0', boxSizing: 'border-box',
           background: 'var(--surface-sunken)', border: '1px solid var(--border)',
           borderRadius: 'var(--radius-sm)', padding: '9px 11px',
           color: 'var(--text)', fontSize: 'var(--fs-sm)',
         }}
       />
 
-      <SectionHead title="Posts" right={`${shown.length}${query ? ` of ${posts.length}` : ''}`} />
-      <div style={{ display: 'grid', gap: 8 }}>
+      <div style={{ marginTop: 20, display: 'flex', flexDirection: 'column', gap: 10 }}>
+        {shown.length === 0 && (
+          <div style={{ color: 'var(--muted)', fontSize: 'var(--fs-sm)', padding: '30px 0', textAlign: 'center' }}>
+            {posts.length === 0 ? 'No LinkedIn posts logged yet — import your Shares.csv to get started.' : 'No posts match your filter.'}
+          </div>
+        )}
         {shown.map((p, i) => (
-          <PostCard key={`${p.source || p.title}-${i}`} post={p} />
+          <PostCard key={p.id ?? `${p.source}-${i}`} post={p} isDesktop={isDesktop} onEdit={() => setSheetPost(p)} />
         ))}
       </div>
+
+      {sheetPost && (
+        <MetricSheet
+          post={sheetPost}
+          onClose={() => setSheetPost(null)}
+          onSaved={() => { setSheetPost(null); reload() }}
+        />
+      )}
     </Screen>
   )
 }

--- a/frontend/src/screens/pipeline/JobCard.jsx
+++ b/frontend/src/screens/pipeline/JobCard.jsx
@@ -1,7 +1,50 @@
-import { Panel } from '../../design-system'
-import { Badge, statusTone, EYEBROW, fmtDate } from '../_shared.jsx'
+import { EYEBROW, fmtDate } from '../_shared.jsx'
+
+/* Pipeline row — one job, styled per the desktop design handoff's 5-column
+   table (COMPANY with 34px initial tile / ROLE / STAGE chip / FIT / NEXT
+   STEP), followed by the full detail + action area the design omits: every
+   assessment detail, action button, and AI-editor entry point is preserved. */
 
 const CLOSED = new Set(['added', 'applied', 'dismissed'])
+
+/* Shared column template so the header row in Pipeline.jsx lines up. */
+export const ROW_GRID = 'minmax(0, 2fr) minmax(0, 2fr) minmax(0, 1.1fr) minmax(0, .7fr) minmax(0, 1.4fr)'
+
+/* Real queue statuses mapped onto the handoff's stage palette by progress:
+   applied = furthest along (OFFER green), added = ready to go out (ONSITE
+   cyan), evaluated = mid-funnel (SCREEN amber), pending = neutral
+   (APPLIED/INTERESTED grey), dismissed = closed (danger red). */
+const STAGE = {
+  applied: { c: '#6FD3A0', bg: 'rgba(111,211,160,.14)' },
+  added: { c: '#6FE0EE', bg: 'rgba(0,181,200,.14)' },
+  evaluated: { c: '#E0B77A', bg: 'rgba(224,183,122,.14)' },
+  pending: { c: '#9BB0D0', bg: 'rgba(255,255,255,.06)' },
+  dismissed: { c: '#E39393', bg: 'rgba(227,147,147,.12)' },
+}
+
+/* fitment_score is a free string ("7/10", "85"). Normalize to a 0–100 pct
+   for the handoff's score coloring; display the raw value untouched. */
+function scoreInfo(raw) {
+  const text = String(raw || '').trim()
+  if (!text) return null
+  const m = text.match(/(\d+(?:\.\d+)?)\s*(?:\/\s*(\d+(?:\.\d+)?))?/)
+  if (!m) return { text, color: '#9BB0D0' }
+  const num = Number.parseFloat(m[1])
+  const den = m[2] ? Number.parseFloat(m[2]) : (num <= 10 ? 10 : 100)
+  const pct = den > 0 ? (num / den) * 100 : num
+  const color = pct >= 85 ? '#6FE0EE' : pct >= 78 ? '#E0EAF7' : '#9BB0D0'
+  return { text, color }
+}
+
+function nextStep(job) {
+  switch (job.status) {
+    case 'evaluated': return 'Queue apply or generate materials'
+    case 'added': return 'Generate materials & apply'
+    case 'applied': return 'Awaiting reply'
+    case 'dismissed': return 'Closed'
+    default: return 'Run assessment'
+  }
+}
 
 /* compact action button with default / primary / danger tones */
 function ActionBtn({ onClick, disabled, tone = 'default', title, children }) {
@@ -50,27 +93,51 @@ export default function JobCard({ job, busy, isOwner, onAction, onOpenEditor }) 
   const canApply = job.status === 'evaluated'
   const appliedDone = job.status === 'applied' || job.status === 'dismissed'
   const evalLabel = job.assessed ? 'Re-run Assessment' : 'Run Assessment'
+  const stage = STAGE[job.status] || STAGE.pending
+  const score = scoreInfo(job.fitment_score)
+  const initial = (job.company || '').trim().charAt(0).toUpperCase() || '?'
 
   return (
-    <Panel pad="14px 16px">
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: 12, flexWrap: 'wrap' }}>
-        <div style={{ minWidth: 0 }}>
-          <div style={{ color: 'var(--text-strong)', fontWeight: 'var(--fw-semibold)', fontSize: 'var(--fs-base)' }}>
-            {job.company || 'Unknown company'} {job.role ? `— ${job.role}` : ''}
+    <div style={{ borderTop: '1px solid rgba(255,255,255,.05)', padding: '14px 20px' }}>
+      <div style={{ display: 'grid', gridTemplateColumns: ROW_GRID, gap: 10, alignItems: 'center' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 11, minWidth: 0 }}>
+          <div
+            style={{
+              width: 34, height: 34, borderRadius: 10, background: 'rgba(255,255,255,.06)',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              fontWeight: 'var(--fw-bold)', color: '#C9D6EC', flexShrink: 0,
+            }}
+          >
+            {initial}
           </div>
-          <div style={{ color: 'var(--faint)', fontSize: 'var(--fs-xs)', marginTop: 3 }}>
-            #{job.id} {'·'} {job.source || 'n/a'}{job.added_date ? ` · ${fmtDate(job.added_date)}` : ''}
+          <div style={{ minWidth: 0 }}>
+            <div style={{ fontSize: 14.5, fontWeight: 'var(--fw-semibold)', color: 'var(--text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {job.company || 'Unknown company'}
+            </div>
+            <div style={{ fontSize: 10.5, color: 'var(--faint)', fontFamily: 'var(--font-mono)', textTransform: 'uppercase', marginTop: 3, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              #{job.id} {'·'} {job.source || 'n/a'}{job.added_date ? ` · ${fmtDate(job.added_date)}` : ''}
+            </div>
           </div>
         </div>
-        <Badge tone={statusTone(job.status)}>{job.status || 'pending'}</Badge>
+        <div style={{ fontSize: 13.5, color: 'var(--muted)', minWidth: 0 }}>{job.role || '—'}</div>
+        <div>
+          <span
+            style={{
+              fontSize: 10, fontWeight: 'var(--fw-semibold)', color: stage.c, background: stage.bg,
+              padding: '4px 9px', borderRadius: 8, fontFamily: 'var(--font-mono)',
+              textTransform: 'uppercase', whiteSpace: 'nowrap',
+            }}
+          >
+            {job.status || 'pending'}
+          </span>
+        </div>
+        <div style={{ textAlign: 'center', fontSize: 16, fontWeight: 'var(--fw-bold)', fontFamily: 'var(--font-mono)', color: score ? score.color : 'var(--faint)' }}>
+          {score ? score.text : '—'}
+        </div>
+        <div style={{ fontSize: 13, color: 'var(--muted)' }}>{nextStep(job)}</div>
       </div>
 
       {job.assessment_summary && <Detail label="Assessment">{job.assessment_summary}</Detail>}
-      {job.fitment_score && (
-        <Detail label="Fitment">
-          <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--cyan-300)' }}>{job.fitment_score}</span>
-        </Detail>
-      )}
       {job.decision_notes && <Detail label="Notes">{job.decision_notes}</Detail>}
       {job.resume_template && (
         <Detail label="Resume template">{job.resume_template} / {job.resume_style || 'navy'}</Detail>
@@ -116,6 +183,6 @@ export default function JobCard({ job, busy, isOwner, onAction, onOpenEditor }) 
         <ActionBtn disabled={busy} onClick={() => onOpenEditor(job, 'edit-cl')}>Edit Cover Letter</ActionBtn>
         <ActionBtn disabled={busy} onClick={() => onOpenEditor(job, 'templates')}>Templates</ActionBtn>
       </div>
-    </Panel>
+    </div>
   )
 }

--- a/frontend/src/screens/posts/ImportFlow.jsx
+++ b/frontend/src/screens/posts/ImportFlow.jsx
@@ -1,0 +1,314 @@
+import { useRef, useState } from 'react'
+import { apiPost } from '../../auth/api.js'
+import { parseCSV, autoDetectMap, extractHashtags, numCell, fmtK } from './csv.js'
+
+/* LinkedIn CSV import — the desktop design's 3-step flow.
+   1 Upload: dashed drop zone (real drag-and-drop + file input).
+   2 Map & preview: per-field column selects with MAPPED/REQUIRED/OPTIONAL
+     tags, live 5-row preview, metrics note, footer bar with the count.
+   3 Done: glow-check, stat tiles, and the summary of what was persisted.
+   Confirm POSTs to /dashboard/posts/import (log_linkedin_post +
+   update_post_metrics server-side) — unlike the prototype, it's real. */
+
+const MONO = { fontFamily: 'var(--font-mono)' }
+const EYEBROW = {
+  fontSize: 11, fontWeight: 'var(--fw-semibold)', letterSpacing: 1.5,
+  color: '#56637E', ...MONO,
+}
+
+export function StepIndicator({ step }) {
+  const dot = (n) => ({
+    width: 20, height: 20, borderRadius: '50%',
+    background: step >= n ? 'var(--cyan-500)' : 'rgba(255,255,255,.14)',
+    color: '#04222A', fontSize: 11, fontWeight: 'var(--fw-bold)',
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+  })
+  const lbl = (n) => ({ fontSize: 12, fontWeight: 'var(--fw-semibold)', color: step >= n ? 'var(--cyan-300)' : '#54627C' })
+  const line = (n) => ({ width: 26, height: 2, borderRadius: 2, background: step >= n ? 'var(--cyan-500)' : 'rgba(255,255,255,.12)' })
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}><div style={dot(1)}>1</div><span style={lbl(1)}>Upload</span></div>
+      <div style={line(2)} />
+      <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}><div style={dot(2)}>2</div><span style={lbl(2)}>Map</span></div>
+      <div style={line(3)} />
+      <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}><div style={dot(3)}>3</div><span style={lbl(3)}>Done</span></div>
+    </div>
+  )
+}
+
+const SAMPLE_CSV = [
+  'Date,ShareLink,ShareCommentary,SharedUrl,MediaUrl,Visibility',
+  '2026-06-14,https://lnkd.in/a1,"Got laid off, so I built the tool I wished I had — persistent memory for my job search. #jobsearch #buildinpublic",,,MEMBER_NETWORK',
+  '2026-06-22,https://lnkd.in/b2,"Your career has context. Your AI should too. Here is how I wired mine up with MCP. #AI #MCP #careers",,,PUBLIC',
+  '2026-07-01,https://lnkd.in/c3,"Shipped v1.2: an offline desktop app that remembers your whole job hunt. #buildinpublic",,,PUBLIC',
+  '2026-07-09,https://lnkd.in/d4,"Interview prep is just context assembly. A thread on how I automated mine. #interviews #jobsearch",,,PUBLIC',
+].join('\n')
+
+const FIELD_DEFS = [
+  { key: 'text', title: 'Post text', req: true },
+  { key: 'date', title: 'Date', req: false },
+  { key: 'imp', title: 'Impressions', req: false },
+  { key: 'rx', title: 'Reactions', req: false },
+  { key: 'cm', title: 'Comments', req: false },
+]
+
+export default function ImportFlow({ step, setStep, onDone, onCancel }) {
+  const [dragOver, setDragOver] = useState(false)
+  const [fileName, setFileName] = useState('')
+  const [headers, setHeaders] = useState([])
+  const [rows, setRows] = useState([])
+  const [map, setMap] = useState({ text: -1, date: -1, imp: -1, rx: -1, cm: -1 })
+  const [result, setResult] = useState(null)
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState('')
+  const fileRef = useRef(null)
+
+  function ingest(text, name) {
+    const parsed = parseCSV(text)
+    if (parsed.length < 2) { setErr('That CSV has no data rows.'); return }
+    setErr('')
+    setFileName(name)
+    setHeaders(parsed[0].map((h) => h.trim()))
+    setRows(parsed)
+    setMap(autoDetectMap(parsed[0]))
+    setStep(2)
+  }
+
+  function readFile(file) {
+    const reader = new FileReader()
+    reader.onload = () => ingest(String(reader.result), file.name)
+    reader.readAsText(file)
+  }
+
+  const dataRows = rows.slice(1)
+  const validRows = dataRows.filter((r) => map.text >= 0 && (r[map.text] || '').trim())
+  const hasMetrics = map.imp >= 0 || map.rx >= 0 || map.cm >= 0
+  const canImport = map.text >= 0 && validRows.length > 0 && !busy
+  const metricRowCount = validRows.filter((r) =>
+    [map.imp, map.rx, map.cm].some((idx) => idx >= 0 && numCell(r[idx]) != null)).length
+
+  async function confirm() {
+    if (!canImport) return
+    setBusy(true)
+    setErr('')
+    try {
+      const posts = validRows.map((r) => {
+        const text = r[map.text].trim()
+        const metric = (idx) => (idx >= 0 ? numCell(r[idx]) : null)
+        return {
+          text,
+          posted_date: map.date >= 0 ? (r[map.date] || '').trim() : '',
+          hashtags: extractHashtags(text),
+          impressions: metric(map.imp),
+          reactions: metric(map.rx),
+          comments: metric(map.cm),
+        }
+      })
+      const res = await apiPost('/dashboard/posts/import', { posts })
+      setResult(res)
+      setStep(3)
+    } catch (e) {
+      setErr(e?.body?.detail || e.message || 'Import failed.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (step === 1) {
+    return (
+      <div>
+        <div style={{ fontSize: 27, fontWeight: 'var(--fw-bold)', color: 'var(--text)', letterSpacing: '-0.6px' }}>Import posts from LinkedIn</div>
+        <div style={{ fontSize: '14.5px', color: '#A9B6CE', marginTop: 8, maxWidth: 600, lineHeight: 1.55 }}>
+          Export your data from LinkedIn (Settings → Data Privacy → Get a copy of your data),
+          then drop the CSV here. Everything is parsed locally and written to your workspace.
+        </div>
+
+        <label
+          onDrop={(e) => { e.preventDefault(); setDragOver(false); const f = e.dataTransfer.files?.[0]; if (f) readFile(f) }}
+          onDragOver={(e) => { e.preventDefault(); if (!dragOver) setDragOver(true) }}
+          onDragLeave={(e) => { e.preventDefault(); setDragOver(false) }}
+          style={{
+            marginTop: 24, position: 'relative', display: 'flex', flexDirection: 'column',
+            alignItems: 'center', justifyContent: 'center', gap: 15, padding: 54,
+            borderRadius: 24, border: `2px dashed ${dragOver ? 'var(--cyan-500)' : 'rgba(0,181,200,.4)'}`,
+            background: dragOver ? 'rgba(0,181,200,.1)' : 'rgba(0,181,200,.03)',
+            cursor: 'pointer', transition: 'all .18s', overflow: 'hidden',
+          }}
+        >
+          <div style={{ position: 'absolute', width: 260, height: 260, borderRadius: '50%', background: 'radial-gradient(circle, rgba(0,181,200,.16), rgba(0,181,200,0) 68%)', animation: 'jc-glowRing 3.5s ease-in-out infinite', pointerEvents: 'none' }} />
+          <div style={{ position: 'relative', width: 72, height: 72, borderRadius: 20, background: 'linear-gradient(150deg, rgba(0,181,200,.25), rgba(0,181,200,.06))', border: '1px solid rgba(0,181,200,.3)', display: 'flex', alignItems: 'center', justifyContent: 'center', animation: 'jc-float 3.5s ease-in-out infinite', boxShadow: '0 8px 30px rgba(0,181,200,.15)' }}>
+            <svg width={32} height={32} viewBox="0 0 24 24" fill="none" stroke="var(--cyan-300)" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round"><path d="M12 3v13M7 8l5-5 5 5" /><path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2" /></svg>
+          </div>
+          <div style={{ position: 'relative', fontSize: 18, fontWeight: 'var(--fw-semibold)', color: 'var(--text)' }}>Drag your CSV here</div>
+          <div style={{ position: 'relative', fontSize: 13, color: '#8A99B5', ...MONO }}>Shares.csv · Engagement.csv · analytics export</div>
+          <div style={{ position: 'relative', marginTop: 6, fontSize: '13.5px', fontWeight: 'var(--fw-bold)', color: '#04222A', background: 'var(--cyan-500)', padding: '10px 22px', borderRadius: 12, boxShadow: '0 6px 20px rgba(0,181,200,.3)' }}>Choose file…</div>
+          <input ref={fileRef} type="file" accept=".csv,text/csv" style={{ display: 'none' }} onChange={(e) => { const f = e.target.files?.[0]; if (f) readFile(f); e.target.value = '' }} />
+        </label>
+
+        {err && <div style={{ marginTop: 14, color: 'var(--danger-soft)', fontSize: 'var(--fs-sm)' }}>{err}</div>}
+        <div style={{ marginTop: 18, display: 'flex', alignItems: 'center', gap: 10, fontSize: 13, color: '#8A99B5' }}>
+          <span onClick={() => ingest(SAMPLE_CSV, 'Shares.csv (sample)')} style={{ cursor: 'pointer', color: 'var(--cyan-300)', fontWeight: 'var(--fw-semibold)', display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+            <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M5 12h14M13 6l6 6-6 6" /></svg>
+            Use sample Shares.csv
+          </span>
+          <span>to preview the flow</span>
+        </div>
+      </div>
+    )
+  }
+
+  if (step === 2) {
+    const preview = validRows.slice(0, 5).map((r, i) => {
+      const cell = (idx) => {
+        if (idx < 0) return { v: '—', muted: true }
+        const n = numCell(r[idx])
+        return n == null ? { v: '—', muted: true } : { v: fmtK(n), muted: false }
+      }
+      return {
+        text: (r[map.text] || '').replace(/\s+/g, ' ').trim() || '(empty)',
+        imp: cell(map.imp), rx: cell(map.rx), cm: cell(map.cm),
+        zebra: i % 2 ? 'rgba(255,255,255,.015)' : 'transparent',
+      }
+    })
+    const cellColor = (c) => (c.muted ? '#54627C' : '#E8EFFB')
+
+    return (
+      <div style={{ paddingBottom: 90 }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 12, flexWrap: 'wrap' }}>
+          <div style={{ fontSize: 24, fontWeight: 'var(--fw-bold)', color: 'var(--text)', letterSpacing: '-0.5px' }}>Map & preview</div>
+          <div style={{ display: 'inline-flex', alignItems: 'center', gap: 7, fontSize: 12, color: '#8A99B5', ...MONO, background: 'rgba(255,255,255,.04)', padding: '4px 10px', borderRadius: 8 }}>
+            {fileName} · {Math.max(0, rows.length - 1)} rows
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: 30, marginTop: 22, flexWrap: 'wrap' }}>
+          <div style={{ width: 322, flexShrink: 0 }}>
+            <div style={{ ...EYEBROW, marginBottom: 12 }}>COLUMN MAPPING</div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 13 }}>
+              {FIELD_DEFS.map((f) => {
+                const mapped = map[f.key] >= 0
+                const tag = mapped ? 'MAPPED' : f.req ? 'REQUIRED' : 'OPTIONAL'
+                const tagColor = mapped ? '#6FD3A0' : f.req ? '#E39393' : '#56637E'
+                const border = mapped ? 'rgba(0,181,200,.25)' : f.req ? 'rgba(227,147,147,.3)' : 'rgba(255,255,255,.07)'
+                return (
+                  <div key={f.key} style={{ padding: '13px 14px', borderRadius: 13, background: 'rgba(255,255,255,.035)', border: `1px solid ${border}` }}>
+                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                      <div style={{ fontSize: 12, fontWeight: 'var(--fw-semibold)', color: '#C9D6EC' }}>{f.title}</div>
+                      <div style={{ fontSize: '9.5px', fontWeight: 'var(--fw-semibold)', letterSpacing: 0.5, color: tagColor, ...MONO }}>{tag}</div>
+                    </div>
+                    <select
+                      value={String(map[f.key])}
+                      onChange={(e) => setMap((m) => ({ ...m, [f.key]: parseInt(e.target.value, 10) }))}
+                      style={{
+                        marginTop: 9, width: '100%', background: 'rgba(255,255,255,.05)',
+                        border: '1px solid rgba(255,255,255,.12)', borderRadius: 10,
+                        padding: '9px 12px', color: 'var(--text)', fontSize: '13.5px',
+                        fontFamily: 'var(--font-sans)', outline: 'none', cursor: 'pointer',
+                      }}
+                    >
+                      <option value="-1" style={{ background: '#0E1524' }}>— none —</option>
+                      {headers.map((h, i) => (
+                        <option key={i} value={String(i)} style={{ background: '#0E1524' }}>{h || `Column ${i + 1}`}</option>
+                      ))}
+                    </select>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+          <div style={{ flex: 1, minWidth: 320 }}>
+            <div style={{ ...EYEBROW, marginBottom: 12 }}>PREVIEW · FIRST {preview.length} ROWS</div>
+            <div style={{ borderRadius: 16, border: '1px solid rgba(255,255,255,.08)', overflow: 'hidden', background: 'rgba(255,255,255,.02)' }}>
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 82px 68px 78px', background: 'rgba(0,181,200,.06)', padding: '11px 16px', fontSize: '10.5px', fontWeight: 'var(--fw-semibold)', letterSpacing: 0.5, color: 'var(--cyan-300)', ...MONO }}>
+                <div>POST TEXT</div><div style={{ textAlign: 'right' }}>IMPR</div><div style={{ textAlign: 'right' }}>RX</div><div style={{ textAlign: 'right' }}>COMM</div>
+              </div>
+              {preview.map((row, i) => (
+                <div key={i} style={{ display: 'grid', gridTemplateColumns: '1fr 82px 68px 78px', padding: '13px 16px', borderTop: '1px solid rgba(255,255,255,.05)', alignItems: 'center', background: row.zebra }}>
+                  <div style={{ fontSize: 13, color: '#E8EFFB', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', paddingRight: 14 }}>{row.text}</div>
+                  <div style={{ textAlign: 'right', fontSize: 13, color: cellColor(row.imp), ...MONO }}>{row.imp.v}</div>
+                  <div style={{ textAlign: 'right', fontSize: 13, color: cellColor(row.rx), ...MONO }}>{row.rx.v}</div>
+                  <div style={{ textAlign: 'right', fontSize: 13, color: cellColor(row.cm), ...MONO }}>{row.cm.v}</div>
+                </div>
+              ))}
+            </div>
+            <div style={{ marginTop: 14, display: 'flex', alignItems: 'flex-start', gap: 9, padding: '12px 14px', borderRadius: 12, background: hasMetrics ? 'rgba(111,211,160,.07)' : 'rgba(224,183,122,.07)', border: `1px solid ${hasMetrics ? 'rgba(111,211,160,.2)' : 'rgba(224,183,122,.2)'}` }}>
+              <div style={{ color: hasMetrics ? '#6FD3A0' : '#E0B77A', flexShrink: 0, marginTop: 1 }}>{hasMetrics ? '✓' : '!'}</div>
+              <div style={{ fontSize: '12.5px', color: '#B7C6E0', lineHeight: 1.45 }}>
+                {hasMetrics
+                  ? 'Engagement columns detected — metrics will be saved with each post.'
+                  : 'No metric columns mapped — posts import with metrics at 0; fill them in later on the Posts screen.'}
+              </div>
+            </div>
+            {err && <div style={{ marginTop: 12, color: 'var(--danger-soft)', fontSize: 'var(--fs-sm)' }}>{err}</div>}
+          </div>
+        </div>
+
+        <div style={{ position: 'sticky', bottom: 0, marginTop: 26, marginLeft: -36, marginRight: -36, padding: '16px 36px', background: 'rgba(10,15,28,.85)', backdropFilter: 'blur(18px)', borderTop: '1px solid rgba(255,255,255,.07)', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+          <div style={{ fontSize: '13.5px', color: '#C9D6EC' }}>
+            <span style={{ color: 'var(--cyan-300)', fontWeight: 'var(--fw-bold)', fontSize: 16 }}>{validRows.length}</span> posts ready to import
+          </div>
+          <div style={{ display: 'flex', gap: 10 }}>
+            <div onClick={onCancel} style={{ cursor: 'pointer', fontSize: '13.5px', fontWeight: 'var(--fw-semibold)', color: '#C9D6EC', background: 'rgba(255,255,255,.06)', padding: '11px 18px', borderRadius: 11 }}>Cancel</div>
+            <div
+              onClick={confirm}
+              style={{
+                cursor: canImport ? 'pointer' : 'not-allowed',
+                fontSize: '13.5px', fontWeight: 'var(--fw-bold)', color: '#04222A',
+                background: canImport ? 'var(--cyan-500)' : '#455266',
+                opacity: canImport ? 1 : 0.5, padding: '11px 22px', borderRadius: 11,
+                boxShadow: canImport ? '0 6px 20px rgba(0,181,200,.3)' : 'none',
+              }}
+            >
+              {busy ? 'Importing…' : `Import ${validRows.length} posts →`}
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // Step 3 — done
+  const summary = [
+    `${result?.logged ?? 0} posts logged via log_linkedin_post`,
+    'Persisted to your workspace (SQLite + JSON fallback)',
+    result?.with_metrics ? 'Engagement metrics saved per post' : 'Metrics left at 0 — editable anytime',
+    'Reindexed as tone samples for cover-letter voice',
+  ]
+  return (
+    <div style={{ minHeight: 480, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center' }}>
+      <div style={{ position: 'relative', width: 84, height: 84, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <div style={{ position: 'absolute', inset: -14, borderRadius: '50%', background: 'radial-gradient(circle, rgba(111,211,160,.3), rgba(111,211,160,0) 70%)', animation: 'jc-glowRing 3s ease-in-out infinite' }} />
+        <div style={{ width: 84, height: 84, borderRadius: '50%', background: 'rgba(111,211,160,.14)', border: '1.5px solid rgba(111,211,160,.5)', display: 'flex', alignItems: 'center', justifyContent: 'center', animation: 'jc-checkPop .5s cubic-bezier(.34,1.56,.64,1) both' }}>
+          <svg width={40} height={40} viewBox="0 0 24 24" fill="none" stroke="#7BD88F" strokeWidth={2.4} strokeLinecap="round" strokeLinejoin="round"><path d="M4 12.5l5 5 11-11" /></svg>
+        </div>
+      </div>
+      <div style={{ fontSize: 27, fontWeight: 'var(--fw-bold)', color: 'var(--text)', letterSpacing: '-0.5px', marginTop: 24 }}>Imported {result?.logged ?? 0} posts</div>
+      <div style={{ fontSize: '14.5px', color: '#A9B6CE', marginTop: 8 }}>Written to your workspace and ready across every jobContext client.</div>
+      <div style={{ marginTop: 26, display: 'flex', gap: 12, flexWrap: 'wrap', justifyContent: 'center' }}>
+        <div style={{ width: 132, padding: 16, borderRadius: 16, background: 'rgba(0,181,200,.08)', border: '1px solid rgba(0,181,200,.2)' }}>
+          <div style={{ fontSize: 28, fontWeight: 'var(--fw-bold)', color: 'var(--cyan-300)' }}>{result?.logged ?? 0}</div>
+          <div style={{ fontSize: 11, color: '#8AB6C4', marginTop: 3 }}>posts logged</div>
+        </div>
+        <div style={{ width: 132, padding: 16, borderRadius: 16, background: 'rgba(255,255,255,.04)', border: '1px solid rgba(255,255,255,.08)' }}>
+          <div style={{ fontSize: 28, fontWeight: 'var(--fw-bold)', color: 'var(--text)' }}>{result?.with_metrics ?? metricRowCount}</div>
+          <div style={{ fontSize: 11, color: '#8A99B5', marginTop: 3 }}>with metrics</div>
+        </div>
+        <div style={{ width: 132, padding: 16, borderRadius: 16, background: 'rgba(255,255,255,.04)', border: '1px solid rgba(255,255,255,.08)' }}>
+          <div style={{ fontSize: 15, fontWeight: 'var(--fw-bold)', color: 'var(--text)', marginTop: 8 }}>CSV</div>
+          <div style={{ fontSize: 11, color: '#8A99B5', marginTop: 5 }}>source</div>
+        </div>
+      </div>
+      <div style={{ marginTop: 22, width: 480, maxWidth: '100%', borderRadius: 16, background: 'rgba(255,255,255,.035)', border: '1px solid rgba(255,255,255,.07)', overflow: 'hidden', textAlign: 'left' }}>
+        {summary.map((s) => (
+          <div key={s} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '13px 18px', borderBottom: '1px solid rgba(255,255,255,.05)' }}>
+            <svg width={15} height={15} viewBox="0 0 24 24" fill="none" stroke="#6FD3A0" strokeWidth={2.6} strokeLinecap="round" strokeLinejoin="round"><path d="M4 12.5l5 5 11-11" /></svg>
+            <div style={{ fontSize: '13.5px', color: 'var(--text-soft)' }}>{s}</div>
+          </div>
+        ))}
+      </div>
+      <div style={{ marginTop: 26, display: 'flex', gap: 10 }}>
+        <div onClick={onDone} style={{ cursor: 'pointer', fontSize: '13.5px', fontWeight: 'var(--fw-bold)', color: '#04222A', background: 'var(--cyan-500)', padding: '12px 24px', borderRadius: 12, boxShadow: '0 6px 20px rgba(0,181,200,.28)' }}>View in Posts</div>
+        <div onClick={() => { setResult(null); setFileName(''); setHeaders([]); setRows([]); setMap({ text: -1, date: -1, imp: -1, rx: -1, cm: -1 }); setStep(1) }} style={{ cursor: 'pointer', fontSize: '13.5px', fontWeight: 'var(--fw-semibold)', color: '#C9D6EC', background: 'rgba(255,255,255,.06)', padding: '12px 20px', borderRadius: 12 }}>Import another</div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/screens/posts/csv.js
+++ b/frontend/src/screens/posts/csv.js
@@ -1,0 +1,67 @@
+/* LinkedIn CSV parsing per the design handoff's parser spec.
+
+   parseCSV handles quoted fields, escaped quotes (""), embedded commas and
+   newlines, and \r\n / \r / \n line endings; fully-empty rows are dropped.
+   autoDetectMap matches lowercased headers (exact first, then substring),
+   first match wins. LinkedIn's basic Shares.csv has no metric columns —
+   those import as 0 and get filled in later via the Update sheet. */
+
+export function parseCSV(text) {
+  const rows = []
+  let row = []
+  let cur = ''
+  let q = false
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i]
+    if (q) {
+      if (c === '"') {
+        if (text[i + 1] === '"') { cur += '"'; i++ } else q = false
+      } else cur += c
+    } else if (c === '"') {
+      q = true
+    } else if (c === ',') {
+      row.push(cur); cur = ''
+    } else if (c === '\n' || c === '\r') {
+      if (c === '\r' && text[i + 1] === '\n') i++
+      row.push(cur); rows.push(row); row = []; cur = ''
+    } else {
+      cur += c
+    }
+  }
+  if (cur.length || row.length) { row.push(cur); rows.push(row) }
+  return rows.filter((r) => r.length > 1 || (r[0] && r[0].trim()))
+}
+
+const DETECT = {
+  text: ['sharecommentary', 'commentary', 'post text', 'text', 'content'],
+  date: ['date', 'created'],
+  imp: ['impressions', 'views'],
+  rx: ['reactions', 'likes'],
+  cm: ['comments'],
+}
+
+export function autoDetectMap(headerRow) {
+  const head = headerRow.map((h) => h.trim().toLowerCase())
+  const find = (names) => {
+    for (const n of names) {
+      const idx = head.findIndex((h) => h === n || h.includes(n))
+      if (idx >= 0) return idx
+    }
+    return -1
+  }
+  return Object.fromEntries(Object.entries(DETECT).map(([k, names]) => [k, find(names)]))
+}
+
+export function extractHashtags(text) {
+  return Array.from(String(text).matchAll(/#([\p{L}0-9_]+)/gu), (m) => m[1])
+}
+
+export function numCell(v) {
+  const n = parseInt(String(v || '').replace(/[^0-9]/g, ''), 10)
+  return Number.isNaN(n) ? null : n
+}
+
+export function fmtK(n) {
+  n = +n || 0
+  return n >= 1000 ? (n / 1000).toFixed(1).replace(/\.0$/, '') + 'k' : String(n)
+}

--- a/frontend/src/shell/DashboardShell.jsx
+++ b/frontend/src/shell/DashboardShell.jsx
@@ -1,48 +1,49 @@
+import { useEffect, useState } from 'react'
 import { useNavigate, useLocation, Outlet } from 'react-router-dom'
 import { Logo, NavTabs, Button, Icon } from '../design-system'
 import useDesktopMode from './useDesktopMode.js'
+import Sidebar from './Sidebar.jsx'
+import { ToolbarSlotContext } from './toolbarSlot.jsx'
 
-/* DashboardShell — app chrome: header (logo + title + settings gear + sign
-   out) and the tab bar. Converted from the design handoff's shell.jsx IIFE to
-   ESM and wired to react-router so each tab is a real URL.
+/* DashboardShell — app chrome per the desktop design handoff: a 236px
+   sidebar (WORKSPACE nav + TOOLS + pinned Settings + status card) beside a
+   scrollable main column with a sticky toolbar (breadcrumb left, per-screen
+   slot right — screens project actions/steps via useToolbarSlot). The page
+   title renders at the top of the content column, design-style.
 
-   Deltas from the original kit shell (per handoff):
-   - Digest tab removed (its content now lives on Home as the Oura fallback)
-   - Settings reached via the header button (no nav tab)
-   - API Keys kept as its own tab
-*/
+   Narrow viewports (<880px) fall back to the previous header + NavTabs
+   layout via the .jc-* classes in global.css — the sidebar design targets
+   desktop-width windows. */
 
-const TABS = [
+const PRIMARY_NAV = [
   { label: 'Home', key: 'home' },
   { label: 'Pipeline', key: 'pipeline' },
+  { label: 'Interviews', key: 'interviews' },
+  { label: 'People', key: 'people' },
+  { label: 'Posts', key: 'posts' },
+  { label: 'Wellbeing', key: 'health' },
+]
+
+const SECONDARY_NAV = [
   { label: 'Job Hunt', key: 'job-hunt' },
   { label: 'Materials', key: 'materials' },
   { label: 'Rejections', key: 'rejections' },
-  { label: 'Posts', key: 'posts' },
-  { label: 'Outreach', key: 'people' },
-  { label: 'Wellbeing', key: 'health' },
-  { label: 'Interviews', key: 'interviews' },
   { label: 'API Keys', key: 'api-keys' },
 ]
 
-// Desktop-only tabs (useDesktopMode probe) — hosted deployments never show
-// them. Chat is spliced in before API Keys; Settings becomes a nav tab
-// because the desktop header drops the top-right buttons (Sign out and
-// "Why use jobContext?" make no sense against a local single-user server).
-const CHAT_TAB = { label: 'Chat', key: 'chat' }
-const SETTINGS_TAB = { label: 'Settings', key: 'settings' }
+const CHAT_ITEM = { label: 'Chat', key: 'chat' }
 
 const PAGE_META = {
-  home: ['', 'Your career command center'],
+  home: ['Home', 'Your career command center'],
   pipeline: [
     'Pipeline',
-    'Share-sheet intake \u2192 assessment \u2192 resume \u2192 cover letter \u2192 queue apply',
+    'Share-sheet intake → assessment → resume → cover letter → queue apply',
   ],
   'job-hunt': ['Job Hunt Tracker', 'Applications & Kanban board'],
   materials: ['Materials', 'Resumes, cover letters, PDFs, and untracked files'],
   rejections: ['Rejections', 'Funnel analysis & patterns'],
-  posts: ['Posts', 'LinkedIn pipeline: draft \u2192 written \u2192 approved \u2192 posted'],
-  people: ['Outreach', 'Contacts, follow-up queue, warm vs cold'],
+  posts: ['Posts', 'LinkedIn pipeline: draft → written → approved → posted'],
+  people: ['People', 'Contacts, follow-up queue, warm vs cold'],
   health: ['Wellbeing', 'Mood & energy log, trend sparklines'],
   interviews: ['Interviews', 'Upcoming schedule, debrief log, verbatim quotes'],
   chat: ['Chat', 'Ask about your job search — answers come from your local data'],
@@ -50,11 +51,23 @@ const PAGE_META = {
   'api-keys': ['API Keys', 'Personal access tokens for MCP clients'],
 }
 
-// Map a tab key to its client route and back.
 const keyToPath = (key) => (key === 'home' ? '/' : `/${key}`)
 const pathToKey = (pathname) => {
   const seg = pathname.replace(/^\/+/, '').split('/')[0]
   return seg || 'home'
+}
+
+// Single source of truth for the narrow/wide split so only ONE layout (and
+// one <Outlet/>) mounts — rendering both would double-mount every screen.
+function useNarrowViewport() {
+  const [narrow, setNarrow] = useState(() => window.matchMedia('(max-width: 880px)').matches)
+  useEffect(() => {
+    const mq = window.matchMedia('(max-width: 880px)')
+    const onChange = (e) => setNarrow(e.matches)
+    mq.addEventListener('change', onChange)
+    return () => mq.removeEventListener('change', onChange)
+  }, [])
+  return narrow
 }
 
 // Sign out is a server-side POST /logout (clears the cookie + redirects).
@@ -70,86 +83,104 @@ export default function DashboardShell() {
   const navigate = useNavigate()
   const location = useLocation()
   const isDesktop = useDesktopMode()
-  const tabs = isDesktop
-    ? [...TABS.slice(0, -1), CHAT_TAB, TABS[TABS.length - 1], SETTINGS_TAB]
-    : TABS
+  const narrow = useNarrowViewport()
+  const [slotNode, setSlotNode] = useState(null)
+
+  const secondary = isDesktop ? [...SECONDARY_NAV.slice(0, 3), CHAT_ITEM, SECONDARY_NAV[3]] : SECONDARY_NAV
+  const allItems = [...PRIMARY_NAV, ...secondary, { label: 'Settings', key: 'settings' }]
   const tab = pathToKey(location.pathname)
-  const [title, subtitle] = PAGE_META[tab] || [
-    tabs.find((t) => t.key === tab)?.label || '',
-    '',
-  ]
+  const [title, subtitle] = PAGE_META[tab] || [allItems.find((t) => t.key === tab)?.label || '', '']
+  const go = (key) => navigate(keyToPath(key))
+
+  if (narrow) {
+    return (
+      <ToolbarSlotContext.Provider value={{ node: slotNode, setNode: setSlotNode }}>
+        <div className="jc-narrow">
+          <header
+            style={{
+              display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+              gap: 16, marginBottom: 18, flexWrap: 'wrap',
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 14, minWidth: 0 }}>
+              <Logo size={36} markOnly />
+              <div>
+                <h1 style={{ margin: 0, font: 'var(--text-page-title)', color: 'var(--text-strong)' }}>
+                  {title || <Logo size={26} wordmarkOnly />}
+                </h1>
+                {subtitle && (
+                  <div style={{ color: 'var(--muted)', fontSize: 'var(--fs-sm)', marginTop: 4 }}>{subtitle}</div>
+                )}
+              </div>
+            </div>
+            {!isDesktop && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                <Button variant="ghost" size="sm" onClick={() => navigate('/settings')}>
+                  <span style={{ display: 'inline-flex', color: 'var(--muted)' }}>
+                    <Icon name="settings" size={15} />
+                  </span>
+                  Settings
+                </Button>
+                <Button variant="ghost" size="sm" onClick={signOut}>Sign out</Button>
+              </div>
+            )}
+          </header>
+          <div style={{ marginBottom: 12 }}>
+            <NavTabs items={allItems} active={tab} onSelect={go} />
+          </div>
+          {slotNode && (
+            <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 12 }}>{slotNode}</div>
+          )}
+          <Outlet />
+        </div>
+      </ToolbarSlotContext.Provider>
+    )
+  }
 
   return (
-    <div
-      style={{
-        maxWidth: 'var(--wrap-max)',
-        margin: '0 auto',
-        padding: 'var(--page-pad)',
-      }}
-    >
-      <header
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          gap: 16,
-          marginBottom: 18,
-          flexWrap: 'wrap',
-        }}
-      >
-        <div style={{ display: 'flex', alignItems: 'center', gap: 14, minWidth: 0 }}>
-          <Logo size={36} markOnly />
-          <div>
-            <h1 style={{ margin: 0, font: 'var(--text-page-title)', color: 'var(--text-strong)' }}>
+    <ToolbarSlotContext.Provider value={{ node: slotNode, setNode: setSlotNode }}>
+      <div className="jc-shell">
+        <Sidebar
+          primary={PRIMARY_NAV}
+          secondary={secondary}
+          active={tab}
+          onSelect={go}
+          isDesktop={isDesktop}
+          onSignOut={signOut}
+        />
+
+        <div className="jc-main jc-scroll">
+          <div className="jc-toolbar">
+            <div style={{ fontSize: 13, color: '#7C8AA6', fontWeight: 'var(--fw-medium)' }}>{title}</div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              {slotNode}
+              {!isDesktop && !slotNode && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => window.open('/why', '_blank', 'noopener,noreferrer')}
+                >
+                  Why use jobContext?
+                </Button>
+              )}
+            </div>
+          </div>
+
+          <div className="jc-page">
+            <h1 style={{ margin: 0, fontFamily: 'var(--font-display)', fontSize: 28, fontWeight: 'var(--fw-bold)', letterSpacing: '-0.6px', color: 'var(--text)' }}>
               {title || <Logo size={26} wordmarkOnly />}
             </h1>
             {subtitle && (
-              <div style={{ color: 'var(--muted)', fontSize: 'var(--fs-sm)', marginTop: 4 }}>
-                {subtitle}
-              </div>
+              <div style={{ color: 'var(--muted)', fontSize: 'var(--fs-sm)', marginTop: 4, marginBottom: 4 }}>{subtitle}</div>
             )}
+            <div style={{ marginTop: 18 }}>
+              <Outlet />
+            </div>
           </div>
         </div>
-        {!isDesktop && (
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => window.open('/why', '_blank', 'noopener,noreferrer')}
-            >
-              <span style={{ display: 'inline-flex', color: 'var(--muted)' }}>
-                <svg viewBox="0 0 20 20" width={15} height={15} fill="none" stroke="currentColor" strokeWidth={1.5}>
-                  <circle cx="10" cy="10" r="7.5" />
-                  <path d="M10 9v4.5" strokeLinecap="round" />
-                  <circle cx="10" cy="6.5" r="0.8" fill="currentColor" stroke="none" />
-                </svg>
-              </span>
-              Why use jobContext?
-            </Button>
-            <Button variant="ghost" size="sm" onClick={() => navigate('/settings')}>
-              <span style={{ display: 'inline-flex', color: 'var(--muted)' }}>
-                <Icon name="settings" size={15} />
-              </span>
-              Settings
-            </Button>
-            <Button variant="ghost" size="sm" onClick={signOut}>
-              Sign out
-            </Button>
-          </div>
-        )}
-      </header>
-
-      <div style={{ marginBottom: 22 }}>
-        <NavTabs
-          items={tabs}
-          active={tab}
-          onSelect={(key) => navigate(keyToPath(key))}
-        />
       </div>
-
-      <Outlet />
-    </div>
+    </ToolbarSlotContext.Provider>
   )
 }
 
-export { TABS, PAGE_META }
+export { PRIMARY_NAV, SECONDARY_NAV, PAGE_META }

--- a/frontend/src/shell/Sidebar.jsx
+++ b/frontend/src/shell/Sidebar.jsx
@@ -1,0 +1,110 @@
+import Logo from '../design-system/Logo.jsx'
+
+/* Sidebar — the desktop design's left rail: badge + wordmark, WORKSPACE nav
+   with gradient-glass active pills and a cyan left accent bar, secondary
+   TOOLS section (routes the design bundle doesn't cover but the product
+   has), Settings pinned to the bottom, and the workspace status card
+   (LOCAL · SQLITE on desktop, CLOUD WORKSPACE hosted). */
+
+const STROKE = { fill: 'none', stroke: 'currentColor', strokeWidth: 1.7, strokeLinecap: 'round', strokeLinejoin: 'round' }
+
+const ICONS = {
+  home: <g><path d="M4 11 L12 4 L20 11" /><path d="M6 10 V19 H18 V10" /></g>,
+  pipeline: <g><circle cx="5" cy="6" r="1.4" /><path d="M9 6h11" /><circle cx="5" cy="12" r="1.4" /><path d="M9 12h11" /><circle cx="5" cy="18" r="1.4" /><path d="M9 18h11" /></g>,
+  interviews: <g><rect x="4" y="5" width="16" height="15" rx="2.5" /><path d="M4 9 H20 M9 3 V7 M15 3 V7" /></g>,
+  people: <g><circle cx="9" cy="8" r="3" /><path d="M4 19c0-3 2.3-5 5-5s5 2 5 5" /><circle cx="16.5" cy="9" r="2.2" /><path d="M15 14.2c2.2.2 4 2 4 4.8" /></g>,
+  posts: <g><circle cx="12" cy="12" r="2.2" /><path d="M8.5 8.5a5 5 0 0 0 0 7 M15.5 8.5a5 5 0 0 1 0 7 M6 6a9 9 0 0 0 0 12 M18 6a9 9 0 0 1 0 12" /></g>,
+  health: <path d="M12 20s-7-4.6-7-9.6A3.9 3.9 0 0 1 12 8 A3.9 3.9 0 0 1 19 10.4C19 15.4 12 20 12 20Z" />,
+  settings: <g><path d="M4 7h7 M17 7h3 M4 12h3 M11 12h9 M4 17h11 M19 17h1" /><circle cx="14" cy="7" r="2.2" /><circle cx="7" cy="12" r="2.2" /><circle cx="16" cy="17" r="2.2" /></g>,
+  'job-hunt': <g><rect x="4" y="5" width="4.5" height="14" rx="1.4" /><rect x="10" y="5" width="4.5" height="9" rx="1.4" /><rect x="16" y="5" width="4.5" height="12" rx="1.4" /></g>,
+  materials: <path d="M3.5 7.5a2 2 0 0 1 2-2h4l2 2.5h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-13a2 2 0 0 1-2-2Z" />,
+  rejections: <g><circle cx="12" cy="12" r="8" /><path d="M9.5 9.5l5 5 M14.5 9.5l-5 5" /></g>,
+  chat: <path d="M4 6.5A2.5 2.5 0 0 1 6.5 4h11A2.5 2.5 0 0 1 20 6.5v8a2.5 2.5 0 0 1-2.5 2.5H9l-5 4Z" />,
+  'api-keys': <g><circle cx="8" cy="14" r="4" /><path d="M11 11 L20 4 M16 7l2.5 2.5 M13 10l2 2" /></g>,
+}
+
+function NavIcon({ name }) {
+  return (
+    <svg width={19} height={19} viewBox="0 0 24 24" {...STROKE} style={{ flexShrink: 0 }}>
+      {ICONS[name] || ICONS.home}
+    </svg>
+  )
+}
+
+function NavItem({ item, active, onSelect }) {
+  return (
+    <div
+      onClick={() => onSelect(item.key)}
+      style={{
+        position: 'relative', display: 'flex', alignItems: 'center', gap: 11,
+        padding: '9px 12px', borderRadius: 10, cursor: 'pointer',
+        fontSize: '13.5px', fontWeight: 'var(--fw-medium)',
+        background: active ? 'linear-gradient(90deg, rgba(0,181,200,.2), rgba(0,181,200,.04))' : 'transparent',
+        color: active ? 'var(--cyan-300)' : '#93A2BE',
+        boxShadow: active ? 'inset 0 0 0 1px rgba(0,181,200,.22), 0 0 18px rgba(0,181,200,.1)' : 'none',
+      }}
+    >
+      <div style={{ position: 'absolute', left: 0, top: 8, bottom: 8, width: 3, borderRadius: 3, background: active ? 'var(--cyan-500)' : 'transparent' }} />
+      <NavIcon name={item.key} />
+      {item.label}
+    </div>
+  )
+}
+
+const MONO_HEAD = {
+  fontSize: 10, fontWeight: 'var(--fw-semibold)', letterSpacing: 1.5,
+  color: '#56637E', fontFamily: 'var(--font-mono)', padding: '4px 10px 8px',
+}
+
+export default function Sidebar({ primary, secondary, active, onSelect, isDesktop, onSignOut }) {
+  return (
+    <div className="jc-sidebar jc-scroll">
+      <div style={{ display: 'flex', alignItems: 'center', gap: 11, padding: '2px 8px 20px' }}>
+        <span style={{ filter: 'drop-shadow(0 0 12px rgba(0,181,200,.4))' }}><Logo size={34} markOnly /></span>
+        <div>
+          <div style={{ fontSize: 15, fontWeight: 'var(--fw-bold)', color: 'var(--text)', lineHeight: 1 }}>jobContext</div>
+          <div style={{ fontSize: 10, fontWeight: 'var(--fw-medium)', color: '#6B7A96', fontFamily: 'var(--font-mono)', letterSpacing: 1, marginTop: 3 }}>
+            {isDesktop ? 'DESKTOP' : 'CLOUD'}
+          </div>
+        </div>
+      </div>
+
+      <div style={MONO_HEAD}>WORKSPACE</div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        {primary.map((item) => (
+          <NavItem key={item.key} item={item} active={active === item.key} onSelect={onSelect} />
+        ))}
+      </div>
+
+      <div style={{ ...MONO_HEAD, paddingTop: 18 }}>TOOLS</div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        {secondary.map((item) => (
+          <NavItem key={item.key} item={item} active={active === item.key} onSelect={onSelect} />
+        ))}
+      </div>
+
+      <div style={{ flex: 1, minHeight: 18 }} />
+
+      <NavItem item={{ key: 'settings', label: 'Settings' }} active={active === 'settings'} onSelect={onSelect} />
+
+      <div style={{ marginTop: 10, padding: 12, borderRadius: 12, background: 'rgba(0,181,200,.06)', border: '1px solid rgba(0,181,200,.14)' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <div style={{ width: 7, height: 7, borderRadius: '50%', background: '#6FD3A0', animation: 'jc-pulse 2s ease-in-out infinite' }} />
+          <span style={{ fontSize: 11, fontWeight: 'var(--fw-semibold)', color: '#8FD3AE', fontFamily: 'var(--font-mono)' }}>
+            {isDesktop ? 'LOCAL · SQLITE' : 'CLOUD WORKSPACE'}
+          </span>
+        </div>
+        <div style={{ fontSize: 11, color: '#7C93A8', lineHeight: 1.45, marginTop: 6 }}>
+          {isDesktop
+            ? 'All data stays on this machine. Nothing leaves the device.'
+            : 'Synced workspace — desktop and mobile stay up to date.'}
+        </div>
+        {!isDesktop && (
+          <div onClick={onSignOut} style={{ marginTop: 8, fontSize: 11.5, fontWeight: 'var(--fw-semibold)', color: 'var(--cyan-300)', cursor: 'pointer' }}>
+            Sign out
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/shell/toolbarSlot.jsx
+++ b/frontend/src/shell/toolbarSlot.jsx
@@ -1,0 +1,17 @@
+import { createContext, useContext, useLayoutEffect } from 'react'
+
+/* Toolbar slot — lets a screen project content (primary action button, the
+   import step indicator) into the shell's sticky toolbar, per the desktop
+   design's content-toolbar spec. The shell provides setNode; screens use
+   useToolbarSlot(node, deps) and the slot clears itself on unmount. */
+
+export const ToolbarSlotContext = createContext({ node: null, setNode: () => {} })
+
+export function useToolbarSlot(node, deps = []) {
+  const { setNode } = useContext(ToolbarSlotContext)
+  useLayoutEffect(() => {
+    setNode(node)
+    return () => setNode(null)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps)
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -52,3 +52,90 @@ a {
     border-top: 1px solid var(--border-soft) !important;
   }
 }
+
+/* ── Desktop shell (design handoff): sidebar + scrolling main column ────── */
+
+.jc-shell {
+  display: flex;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.jc-sidebar {
+  width: 236px;
+  flex-shrink: 0;
+  background: linear-gradient(180deg, #0b1120, #080d18);
+  border-right: 1px solid rgba(255, 255, 255, 0.055);
+  padding: 20px 14px;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+.jc-main {
+  flex: 1;
+  overflow-y: auto;
+  min-width: 0;
+  position: relative;
+  background:
+    radial-gradient(70% 50% at 100% 0%, rgba(0, 181, 200, 0.07), rgba(0, 181, 200, 0) 60%),
+    linear-gradient(165deg, var(--ink-850), var(--ink-900));
+}
+
+.jc-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 36px;
+  background: rgba(10, 15, 28, 0.55);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  min-height: 60px;
+}
+
+.jc-page {
+  padding: 26px 36px 48px;
+  animation: jc-fadeUp 0.4s ease both;
+}
+
+/* Narrow fallback layout (the shell renders it via matchMedia, so no
+   display toggling here — just the container geometry). */
+.jc-narrow {
+  max-width: var(--wrap-max);
+  margin: 0 auto;
+  padding: var(--page-pad);
+}
+
+.jc-scroll::-webkit-scrollbar {
+  width: 9px;
+}
+.jc-scroll::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.09);
+  border-radius: 8px;
+}
+
+@keyframes jc-fadeUp {
+  0% { opacity: 0; transform: translateY(12px); }
+  100% { opacity: 1; transform: none; }
+}
+@keyframes jc-pulse {
+  0%, 100% { opacity: 0.35; }
+  50% { opacity: 1; }
+}
+@keyframes jc-glowRing {
+  0%, 100% { opacity: 0.45; transform: scale(1); }
+  50% { opacity: 0.85; transform: scale(1.06); }
+}
+@keyframes jc-float {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-5px); }
+}
+@keyframes jc-checkPop {
+  0% { opacity: 0; transform: scale(0.5); }
+  65% { opacity: 1; transform: scale(1.12); }
+  100% { transform: scale(1); }
+}

--- a/mobile/src/App.tsx
+++ b/mobile/src/App.tsx
@@ -1,23 +1,43 @@
 // jobContext mobile — capture reality, glance at state. Deep work lives on
 // the desktop; this app is the share sheet, the inbox, and the notification.
+//
+// UI per the design handoff: 6 tabs (Home, Pipeline, Interviews, People,
+// Posts, Wellbeing) on a navy-ink theme with cyan active states, plus an
+// animated splash while the app boots. The previous Inbox and Settings
+// screens stay mounted as chromeless routes (reached from Home) so the
+// activity feed and the sign-in flow keep working unchanged.
 import { NavigationContainer, DarkTheme } from '@react-navigation/native'
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs'
 import { StatusBar } from 'expo-status-bar'
 import * as SplashScreen from 'expo-splash-screen'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { ActivityIndicator, Pressable, Text } from 'react-native'
 import { SafeAreaProvider, useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useShareIntent } from 'expo-share-intent'
-import Inbox from './screens/Inbox'
-import Today from './screens/Today'
+import Home from './screens/Home'
 import Pipeline from './screens/Pipeline'
-import Networking from './screens/Networking'
+import Interviews from './screens/Interviews'
+import People from './screens/People'
+import Posts from './screens/Posts'
+import Wellbeing from './screens/Wellbeing'
+import Inbox from './screens/Inbox'
 import Settings from './screens/Settings'
 import { captureUrl } from './api'
+import { isSignedIn } from './auth'
 import { extractJobPage } from './pageExtract'
 import { ensurePushRegistration } from './push'
 import { colors } from './theme'
 import { setCaptureStatus, useCaptureStatus } from './captureStatus'
+import {
+  HomeIcon,
+  InterviewsIcon,
+  PeopleIcon,
+  PipelineIcon,
+  PostsIcon,
+  WellbeingIcon,
+} from './ui/icons'
+import Splash from './ui/Splash'
+import { t } from './ui/tokens'
 
 SplashScreen.preventAutoHideAsync().catch(() => {})
 
@@ -27,13 +47,17 @@ const theme = {
   ...DarkTheme,
   colors: {
     ...DarkTheme.colors,
-    background: colors.bg,
-    card: colors.surface,
-    border: colors.border,
-    text: colors.text,
-    primary: colors.cyan,
+    background: t.bg,
+    card: t.bg,
+    border: t.hairline,
+    text: t.text,
+    primary: t.cyan,
   },
 }
+
+// Keep the animated splash up until auth state has resolved AND the intro
+// timeline has had time to play (bar fill ends ~3.65s into the sequence).
+const SPLASH_MIN_MS = 3400
 
 function useIncomingShares() {
   const { hasShareIntent, shareIntent, resetShareIntent } = useShareIntent()
@@ -102,11 +126,18 @@ function CaptureBanner() {
 
 export default function App() {
   useIncomingShares()
+  const [booted, setBooted] = useState(false)
+
   useEffect(() => {
     ensurePushRegistration()
   }, [])
   useEffect(() => {
+    // Our animated splash takes over from the native launch screen.
     SplashScreen.hideAsync().catch(() => {})
+    Promise.all([
+      isSignedIn().catch(() => false),
+      new Promise((resolve) => setTimeout(resolve, SPLASH_MIN_MS)),
+    ]).then(() => setBooted(true))
   }, [])
 
   return (
@@ -114,42 +145,77 @@ export default function App() {
       <NavigationContainer theme={theme}>
         <StatusBar style="light" />
         <CaptureBanner />
-      <Tab.Navigator
-        screenOptions={{
-          headerStyle: { backgroundColor: colors.surface },
-          headerTitleStyle: { color: colors.text },
-          tabBarStyle: { backgroundColor: colors.surface, borderTopColor: colors.border },
-          tabBarActiveTintColor: colors.cyan,
-          tabBarInactiveTintColor: colors.faint,
-        }}
-      >
-        <Tab.Screen
-          name="Today"
-          component={Today}
-          options={{ tabBarIcon: ({ color }) => <Text style={{ color, fontSize: 18 }}>☀</Text> }}
-        />
-        <Tab.Screen
-          name="Inbox"
-          component={Inbox}
-          options={{ tabBarIcon: ({ color }) => <Text style={{ color, fontSize: 18 }}>▤</Text> }}
-        />
-        <Tab.Screen
-          name="Pipeline"
-          component={Pipeline}
-          options={{ tabBarIcon: ({ color }) => <Text style={{ color, fontSize: 18 }}>▥</Text> }}
-        />
-        <Tab.Screen
-          name="Networking"
-          component={Networking}
-          options={{ tabBarIcon: ({ color }) => <Text style={{ color, fontSize: 18 }}>☎</Text> }}
-        />
-        <Tab.Screen
-          name="Settings"
-          component={Settings}
-          options={{ tabBarIcon: ({ color }) => <Text style={{ color, fontSize: 18 }}>⚙</Text> }}
-        />
-      </Tab.Navigator>
+        <Tab.Navigator
+          screenOptions={{
+            headerShown: false,
+            tabBarStyle: {
+              backgroundColor: t.tabBg,
+              borderTopColor: t.hairline,
+              borderTopWidth: 1,
+            },
+            tabBarActiveTintColor: t.cyan,
+            tabBarInactiveTintColor: t.tabInactive,
+            tabBarLabelStyle: { fontSize: 9.5, fontWeight: '500' },
+          }}
+        >
+          <Tab.Screen
+            name="Home"
+            component={Home}
+            options={{ tabBarIcon: ({ color }) => <HomeIcon color={color} /> }}
+          />
+          <Tab.Screen
+            name="Pipeline"
+            component={Pipeline}
+            options={{ tabBarIcon: ({ color }) => <PipelineIcon color={color} /> }}
+          />
+          <Tab.Screen
+            name="Interviews"
+            component={Interviews}
+            options={{ tabBarIcon: ({ color }) => <InterviewsIcon color={color} /> }}
+          />
+          <Tab.Screen
+            name="People"
+            component={People}
+            options={{ tabBarIcon: ({ color }) => <PeopleIcon color={color} /> }}
+          />
+          <Tab.Screen
+            name="Posts"
+            component={Posts}
+            options={{ tabBarIcon: ({ color }) => <PostsIcon color={color} /> }}
+          />
+          <Tab.Screen
+            name="Wellbeing"
+            component={Wellbeing}
+            options={{ tabBarIcon: ({ color }) => <WellbeingIcon color={color} /> }}
+          />
+          {/* Chromeless routes — no tab-bar item; reached from Home. */}
+          <Tab.Screen
+            name="Activity"
+            component={Inbox}
+            options={{
+              tabBarItemStyle: { display: 'none' },
+              headerShown: true,
+              headerTitle: 'Activity',
+              headerStyle: { backgroundColor: t.bg },
+              headerTitleStyle: { color: t.text },
+              headerTintColor: t.cyan,
+            }}
+          />
+          <Tab.Screen
+            name="Settings"
+            component={Settings}
+            options={{
+              tabBarItemStyle: { display: 'none' },
+              headerShown: true,
+              headerTitle: 'Settings',
+              headerStyle: { backgroundColor: t.bg },
+              headerTitleStyle: { color: t.text },
+              headerTintColor: t.cyan,
+            }}
+          />
+        </Tab.Navigator>
       </NavigationContainer>
+      {!booted && <Splash />}
     </SafeAreaProvider>
   )
 }

--- a/mobile/src/screens/Home.tsx
+++ b/mobile/src/screens/Home.tsx
@@ -1,0 +1,253 @@
+// Home — the design's "Daily Digest" (variant 1a): greeting + date,
+// today's priorities (cyan-tinted card), follow-ups due with status chips,
+// next interview card, and a wellbeing nudge. All real data:
+//   GET /api/dashboard/home           greeting, priorities, move text, oura
+//   GET /dashboard/people/data        follow-up queue (optional — omitted on error)
+//   GET /dashboard/interviews/data    next interview (optional — omitted on error)
+// The avatar opens Settings; the activity row opens the Inbox feed —
+// both live as chromeless tab routes so no functionality is lost.
+import { useNavigation } from '@react-navigation/native'
+import { useCallback } from 'react'
+import { Pressable, StyleSheet, Text, View } from 'react-native'
+import { api } from '../api'
+import { countdownChip, interviewTimeLine } from '../ui/format'
+import {
+  Card,
+  ErrorState,
+  LoadingState,
+  Screen,
+  SectionLabel,
+  StatusChip,
+} from '../ui/primitives'
+import { fonts, t } from '../ui/tokens'
+import { useDashData } from '../ui/useDashData'
+
+type HomeData = {
+  welcomeName: string
+  hasOura: boolean
+  oura?: { score: number; label: string } | null
+  today: {
+    active: number
+    inflight: number
+    overdue: number
+    move: string
+    priorities: { n: string; text: string }[]
+  }
+}
+
+type Person = { id: number; name: string; company?: string; outreach_status?: string; last_updated?: string }
+type Interview = {
+  id?: number
+  company?: string
+  role?: string
+  interview_date?: string
+  interview_type?: string
+  interviewer?: string
+}
+
+type Bundle = {
+  home: HomeData
+  followups: Person[]
+  nextInterview: Interview | null
+}
+
+function dateLine(): string {
+  const d = new Date()
+  const days = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
+  const months = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC']
+  return `${days[d.getDay()]} · ${months[d.getMonth()]} ${d.getDate()}`
+}
+
+function greeting(): string {
+  const h = new Date().getHours()
+  if (h < 12) return 'Good morning'
+  if (h < 18) return 'Good afternoon'
+  return 'Good evening'
+}
+
+// outreach_status → follow-up chip. "responded" means they replied and the
+// ball is in our court (design's red/overdue slot); "sent" is waiting on them.
+function followupChip(status?: string): { label: string; color: string; bg: string } {
+  const s = (status || '').toLowerCase()
+  if (s === 'responded') return { label: 'NEEDS REPLY', color: t.red, bg: 'rgba(227,147,147,.14)' }
+  if (s === 'follow-up') return { label: 'DUE', color: t.amber, bg: 'rgba(224,183,122,.13)' }
+  if (s === 'sent') return { label: 'AWAITING', color: t.amber, bg: 'rgba(224,183,122,.13)' }
+  return { label: 'DRAFTED', color: t.textSecondary, bg: 'rgba(255,255,255,.06)' }
+}
+
+export default function Home() {
+  const nav = useNavigation<any>()
+  const load = useCallback(async (): Promise<Bundle> => {
+    const home = await api<HomeData>('/api/dashboard/home')
+    // Side sections are best-effort: a failure omits the section, not Home.
+    const [people, interviews] = await Promise.allSettled([
+      api<{ follow_up_queue: Person[] }>('/dashboard/people/data'),
+      api<{ upcoming: Interview[] }>('/dashboard/interviews/data'),
+    ])
+    return {
+      home,
+      followups:
+        people.status === 'fulfilled' ? (people.value.follow_up_queue || []).slice(0, 3) : [],
+      nextInterview:
+        interviews.status === 'fulfilled' ? interviews.value.upcoming?.[0] || null : null,
+    }
+  }, [])
+  const { data, loading, refreshing, error, refresh } = useDashData(load)
+
+  return (
+    <Screen refreshing={refreshing} onRefresh={refresh}>
+      {/* Greeting + avatar */}
+      <View style={styles.headerRow}>
+        <View>
+          <Text style={styles.date}>{dateLine()}</Text>
+          <Text style={styles.greeting}>
+            {greeting()}
+            {data?.home.welcomeName && data.home.welcomeName !== 'there'
+              ? `, ${data.home.welcomeName}`
+              : ''}
+          </Text>
+        </View>
+        <Pressable style={styles.avatar} onPress={() => nav.navigate('Settings')}>
+          <Text style={styles.avatarText}>{(data?.home.welcomeName || '·')[0].toUpperCase()}</Text>
+        </Pressable>
+      </View>
+
+      {loading && !data ? <LoadingState /> : null}
+      {error && !data ? <ErrorState message={error} onRetry={refresh} /> : null}
+
+      {data ? (
+        <>
+          {/* Today's priorities — cyan tint card */}
+          {data.home.today.priorities.length > 0 && (
+            <Card tint="high" style={{ borderRadius: 20, padding: 18, marginTop: 18 }}>
+              <Text style={styles.prioLabel}>
+                TODAY'S {data.home.today.priorities.length} PRIORIT
+                {data.home.today.priorities.length === 1 ? 'Y' : 'IES'}
+              </Text>
+              <View style={{ marginTop: 12, gap: 11 }}>
+                {data.home.today.priorities.map((p, i) => (
+                  <View key={p.n} style={styles.prioRow}>
+                    <View style={[styles.checkbox, i === 0 && { borderColor: t.cyan }]} />
+                    <Text style={styles.prioText}>{p.text}</Text>
+                  </View>
+                ))}
+              </View>
+            </Card>
+          )}
+
+          {/* Follow-ups due */}
+          {data.followups.length > 0 && (
+            <>
+              <SectionLabel>Follow-ups due</SectionLabel>
+              <View style={{ marginTop: 4 }}>
+                {data.followups.map((p) => {
+                  const chip = followupChip(p.outreach_status)
+                  return (
+                    <Card key={p.id} style={styles.followRow}>
+                      <View style={{ flex: 1, minWidth: 0 }}>
+                        <Text style={styles.followName}>{p.company || p.name}</Text>
+                        <Text style={styles.followSub} numberOfLines={1}>
+                          {p.company ? p.name : p.outreach_status || ''}
+                        </Text>
+                      </View>
+                      <StatusChip {...chip} />
+                    </Card>
+                  )
+                })}
+              </View>
+            </>
+          )}
+
+          {/* Next interview */}
+          {data.nextInterview && (
+            <>
+              <SectionLabel>Next interview</SectionLabel>
+              <Card raised style={{ marginTop: 4 }}>
+                <View style={styles.ivTop}>
+                  <Text style={styles.ivTitle} numberOfLines={1}>
+                    {[data.nextInterview.company, data.nextInterview.role]
+                      .filter(Boolean)
+                      .join(' · ')}
+                  </Text>
+                  <Text style={styles.ivCountdown}>{countdownChip(data.nextInterview.interview_date)}</Text>
+                </View>
+                <Text style={styles.ivMeta}>{interviewTimeLine(data.nextInterview)}</Text>
+                <Pressable onPress={() => nav.navigate('Interviews')}>
+                  <Text style={styles.ivLink}>View in Interviews →</Text>
+                </Pressable>
+              </Card>
+            </>
+          )}
+
+          {/* Wellbeing nudge — Today's Move text in the design's nudge card */}
+          {data.home.today.move ? (
+            <Card tint="low" style={styles.nudge}>
+              <Text style={styles.nudgeEmoji}>🌿</Text>
+              <Text style={styles.nudgeText}>{data.home.today.move}</Text>
+            </Card>
+          ) : null}
+
+          {/* Recent activity → Inbox feed (kept from the previous app) */}
+          <Pressable onPress={() => nav.navigate('Activity')}>
+            <Card style={styles.activityRow}>
+              <Text style={styles.activityText}>Recent activity</Text>
+              <Text style={styles.activityArrow}>→</Text>
+            </Card>
+          </Pressable>
+        </>
+      ) : null}
+    </Screen>
+  )
+}
+
+const styles = StyleSheet.create({
+  headerRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: 4 },
+  date: { fontSize: 13, fontWeight: '500', color: t.cyanBright, fontFamily: fonts.mono, letterSpacing: 1 },
+  greeting: { fontSize: 27, fontWeight: '700', color: t.text, letterSpacing: -0.6, marginTop: 3 },
+  avatar: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: t.tintFillHi,
+    borderWidth: 1,
+    borderColor: 'rgba(0,181,200,.4)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  avatarText: { fontWeight: '700', color: t.cyanBright },
+  prioLabel: { fontSize: 11, fontWeight: '600', letterSpacing: 1.5, color: t.cyanBright, fontFamily: fonts.mono },
+  prioRow: { flexDirection: 'row', alignItems: 'center', gap: 11 },
+  checkbox: { width: 18, height: 18, borderRadius: 6, borderWidth: 2, borderColor: 'rgba(215,227,248,.35)' },
+  prioText: { fontSize: 14.5, color: t.textBright, flex: 1 },
+  followRow: {
+    borderRadius: 14,
+    paddingVertical: 13,
+    paddingHorizontal: 14,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 10,
+    marginTop: 8,
+  },
+  followName: { fontSize: 15, fontWeight: '600', color: t.text },
+  followSub: { fontSize: 12.5, color: t.muted, marginTop: 1 },
+  ivTop: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: 10 },
+  ivTitle: { fontSize: 16, fontWeight: '700', color: t.text, flex: 1 },
+  ivCountdown: { fontSize: 11, fontWeight: '600', color: t.cyanBright, fontFamily: fonts.mono },
+  ivMeta: { fontSize: 13, color: t.muted, marginTop: 4, textTransform: 'capitalize' },
+  ivLink: { marginTop: 11, fontSize: 12, fontWeight: '600', color: t.cyanBright },
+  nudge: { flexDirection: 'row', alignItems: 'center', gap: 13, marginTop: 18 },
+  nudgeEmoji: { fontSize: 22 },
+  nudgeText: { fontSize: 13.5, color: t.textBody, lineHeight: 18, flex: 1 },
+  activityRow: {
+    borderRadius: 14,
+    paddingVertical: 13,
+    paddingHorizontal: 14,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginTop: 14,
+  },
+  activityText: { fontSize: 14, fontWeight: '600', color: t.textSecondary },
+  activityArrow: { fontSize: 14, color: t.cyanBright },
+})

--- a/mobile/src/screens/Interviews.tsx
+++ b/mobile/src/screens/Interviews.tsx
@@ -1,0 +1,149 @@
+// Interviews — design layout: "Upcoming" cards (company · role, countdown
+// chip, type/time line, debrief status) + "Recent debriefs" rows.
+// Data: GET /dashboard/interviews/data → { total, upcoming[], recent[] }.
+// The design's "Prep doc ready" slot has no per-interview field in the
+// payload, so upcoming cards show a debrief-pending dot instead; recent rows
+// surface the debrief signal that does exist (self_rating / what_landed /
+// verbatim_quotes).
+import { useCallback } from 'react'
+import { StyleSheet, Text, View } from 'react-native'
+import { api } from '../api'
+import {
+  Card,
+  EmptyState,
+  ErrorState,
+  LoadingState,
+  Screen,
+  ScreenTitle,
+  SectionLabel,
+} from '../ui/primitives'
+import { fonts, t } from '../ui/tokens'
+import { countdownChip, interviewTimeLine } from '../ui/format'
+import { useDashData } from '../ui/useDashData'
+
+type Quote = string | { speaker?: string; quote?: string }
+type Interview = {
+  id?: number
+  company?: string
+  role?: string
+  interview_date?: string
+  interview_type?: string
+  interviewer?: string
+  interviewer_role?: string
+  self_rating?: number | null
+  what_landed?: string[]
+  what_didnt?: string[]
+  verbatim_quotes?: Quote[]
+}
+
+type Payload = { total: number; upcoming: Interview[]; recent: Interview[] }
+
+function monoDate(dateStr?: string): string {
+  const m = String(dateStr || '').match(/^(\d{4})-(\d{2})-(\d{2})/)
+  if (!m) return ''
+  const months = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC']
+  return `${months[Number(m[2]) - 1]} ${Number(m[3])}`
+}
+
+function debriefLine(iv: Interview): string {
+  const q = iv.verbatim_quotes?.[0]
+  const quote = typeof q === 'string' ? q : q?.quote
+  if (quote) return `“${quote}”`
+  if (iv.what_landed?.[0]) return iv.what_landed[0]
+  if (iv.self_rating != null) return `Self-rating ${iv.self_rating}/10`
+  if (iv.what_didnt?.[0]) return iv.what_didnt[0]
+  return (iv.interview_type || '').replace(/_/g, ' ')
+}
+
+export default function Interviews() {
+  const load = useCallback(() => api<Payload>('/dashboard/interviews/data'), [])
+  const { data, loading, refreshing, error, refresh } = useDashData(load)
+
+  return (
+    <Screen refreshing={refreshing} onRefresh={refresh}>
+      <ScreenTitle>Interviews</ScreenTitle>
+
+      {loading && !data ? <LoadingState /> : null}
+      {error && !data ? <ErrorState message={error} onRetry={refresh} /> : null}
+
+      {data ? (
+        <>
+          <SectionLabel style={{ marginTop: 20 } as any}>Upcoming</SectionLabel>
+          {data.upcoming.length === 0 ? (
+            <EmptyState message="Nothing scheduled. Log the next one from your desktop and it shows up here." />
+          ) : (
+            data.upcoming.map((iv, i) => (
+              <Card key={iv.id ?? i} tint={i === 0 ? 'low' : undefined} raised={i !== 0} style={i === 0 ? styles.firstCard : undefined}>
+                <View style={styles.topRow}>
+                  <Text style={styles.title} numberOfLines={1}>
+                    {[iv.company, iv.role].filter(Boolean).join(' · ')}
+                  </Text>
+                  <Text style={[styles.countdown, { color: i === 0 ? t.cyanBright : t.textSecondary }]}>
+                    {countdownChip(iv.interview_date)}
+                  </Text>
+                </View>
+                <Text style={styles.meta}>{interviewTimeLine(iv)}</Text>
+                {iv.interviewer ? (
+                  <Text style={styles.interviewer} numberOfLines={1}>
+                    with {iv.interviewer}
+                    {iv.interviewer_role ? ` · ${iv.interviewer_role}` : ''}
+                  </Text>
+                ) : null}
+                <View style={styles.statusRow}>
+                  <View style={[styles.dot, { backgroundColor: t.amber }]} />
+                  <Text style={[styles.statusText, { color: t.amber }]}>Debrief pending</Text>
+                </View>
+              </Card>
+            ))
+          )}
+
+          <SectionLabel>Recent debriefs</SectionLabel>
+          {data.recent.length === 0 ? (
+            <EmptyState message="No debriefs logged yet." />
+          ) : (
+            data.recent.map((iv, i) => (
+              <Card key={iv.id ?? `r${i}`} style={styles.debriefRow}>
+                <View style={{ flex: 1, minWidth: 0 }}>
+                  <Text style={styles.debriefTitle} numberOfLines={1}>
+                    {[iv.company, (iv.interview_type || '').replace(/_/g, ' ')].filter(Boolean).join(' · ')}
+                  </Text>
+                  <Text style={styles.debriefSub} numberOfLines={1}>
+                    {debriefLine(iv)}
+                  </Text>
+                </View>
+                <Text style={styles.debriefDate}>{monoDate(iv.interview_date)}</Text>
+              </Card>
+            ))
+          )}
+        </>
+      ) : null}
+    </Screen>
+  )
+}
+
+const styles = StyleSheet.create({
+  firstCard: { backgroundColor: 'rgba(0,181,200,.13)', borderColor: 'rgba(0,181,200,.26)' },
+  topRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: 10 },
+  title: { fontSize: 16, fontWeight: '700', color: t.text, flex: 1 },
+  countdown: { fontSize: 11, fontWeight: '600', fontFamily: fonts.mono },
+  meta: { fontSize: 13, color: t.muted, marginTop: 4, textTransform: 'capitalize' },
+  interviewer: { fontSize: 12.5, color: t.faint, marginTop: 3 },
+  statusRow: { flexDirection: 'row', alignItems: 'center', gap: 6, marginTop: 12 },
+  dot: { width: 6, height: 6, borderRadius: 3 },
+  statusText: { fontSize: 12, fontWeight: '600' },
+  debriefRow: {
+    borderRadius: 14,
+    paddingVertical: 13,
+    paddingHorizontal: 14,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 10,
+    backgroundColor: 'rgba(255,255,255,.035)',
+    borderColor: t.hairline,
+    marginTop: 8,
+  },
+  debriefTitle: { fontSize: 14.5, fontWeight: '600', color: t.textBright, textTransform: 'capitalize' },
+  debriefSub: { fontSize: 12, color: t.muted, marginTop: 1 },
+  debriefDate: { fontSize: 11, color: t.faint, fontFamily: fonts.mono },
+})

--- a/mobile/src/screens/People.tsx
+++ b/mobile/src/screens/People.tsx
@@ -1,0 +1,233 @@
+// People — design layout: search, filter chips that filter the list live,
+// contact cards with colored-initial avatar, name, title, status chip, a
+// contact-history synopsis, and a mono last-touch line. Quick actions
+// (call / email / LinkedIn) are carried over from the previous Networking
+// screen so no functionality is lost.
+// Data: GET /dashboard/people/data → { people[], follow_up_queue[], recent[] }.
+import { useCallback, useMemo, useState } from 'react'
+import { Linking, Pressable, StyleSheet, Text, TextInput, View } from 'react-native'
+import { api } from '../api'
+import {
+  Card,
+  Chip,
+  EmptyState,
+  ErrorState,
+  LoadingState,
+  Screen,
+  ScreenTitle,
+  StatusChip,
+} from '../ui/primitives'
+import { avatarPalette, fonts, t } from '../ui/tokens'
+import { useDashData } from '../ui/useDashData'
+
+type Person = {
+  id: number
+  name: string
+  relationship?: string
+  company?: string
+  context?: string
+  contact_info?: string
+  outreach_status?: string
+  notes?: string
+  last_updated?: string
+  last_contacted?: string
+}
+
+type Payload = { total: number; follow_up_queue: Person[]; recent: Person[]; people?: Person[] }
+
+// outreach_status vocabulary: none | drafted | sent | responded (| follow-up)
+type Filter = { key: 'all' | 'warm' | 'awaiting' | 'todo'; label: string; match: string[] | null }
+const FILTERS: Filter[] = [
+  { key: 'all', label: 'All', match: null },
+  { key: 'warm', label: 'Warm', match: ['responded'] },
+  { key: 'awaiting', label: 'Awaiting', match: ['sent', 'follow-up'] },
+  { key: 'todo', label: 'To do', match: ['drafted', 'none', ''] },
+]
+type FilterKey = Filter['key']
+
+const STATUS_CHIP: Record<string, { label: string; color: string; bg: string }> = {
+  responded: { label: 'REPLIED', color: t.green, bg: 'rgba(111,211,160,.15)' },
+  'follow-up': { label: 'DUE', color: t.amber, bg: 'rgba(224,183,122,.15)' },
+  sent: { label: 'SENT', color: t.amber, bg: 'rgba(224,183,122,.15)' },
+  drafted: { label: 'DRAFT', color: '#9BB0D0', bg: 'rgba(255,255,255,.06)' },
+  none: { label: 'NEW', color: '#9BB0D0', bg: 'rgba(255,255,255,.06)' },
+}
+
+function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((w) => w[0].toUpperCase())
+    .join('')
+}
+
+function lastTouch(p: Person): string {
+  const status = (p.outreach_status || 'added').toUpperCase()
+  const date = (p.last_contacted || p.last_updated || '').slice(0, 10)
+  return date ? `${status} · ${date}` : status
+}
+
+function extractActions(p: Person) {
+  const info = `${p.contact_info || ''} ${p.notes || ''} ${p.context || ''}`
+  const email = info.match(/[\w.+-]+@[\w-]+\.[\w.]+/)?.[0]
+  const phone = info.match(/\+?1?[\s.-]?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}/)?.[0]
+  const linkedin = info.match(/(?:https?:\/\/)?(?:www\.)?linkedin\.com\/[^\s,)]+/i)?.[0]
+  return { email, phone, linkedin }
+}
+
+function PersonCard({ p, index }: { p: Person; index: number }) {
+  const chip = STATUS_CHIP[(p.outreach_status || 'none').toLowerCase()] || STATUS_CHIP.none
+  const { email, phone, linkedin } = extractActions(p)
+  const open = (url: string) => Linking.openURL(url).catch(() => {})
+  const history = p.context || p.notes || ''
+  return (
+    <Card style={styles.personCard}>
+      <View style={styles.personTop}>
+        <View style={[styles.avatar, { backgroundColor: avatarPalette[index % avatarPalette.length] }]}>
+          <Text style={styles.avatarText}>{initials(p.name)}</Text>
+        </View>
+        <View style={{ flex: 1, minWidth: 0 }}>
+          <Text style={styles.name} numberOfLines={1}>
+            {p.name}
+          </Text>
+          <Text style={styles.title} numberOfLines={1}>
+            {[p.relationship, p.company].filter(Boolean).join(' · ')}
+          </Text>
+        </View>
+        <StatusChip {...chip} />
+      </View>
+      {history ? (
+        <View style={styles.historyRow}>
+          <View style={[styles.historyDot, { backgroundColor: chip.color }]} />
+          <View style={{ flex: 1, minWidth: 0 }}>
+            <Text style={styles.history} numberOfLines={2}>
+              {history}
+            </Text>
+            <Text style={styles.last}>{lastTouch(p)}</Text>
+          </View>
+        </View>
+      ) : (
+        <Text style={[styles.last, { marginTop: 8 }]}>{lastTouch(p)}</Text>
+      )}
+      {(phone || email || linkedin) && (
+        <View style={styles.actions}>
+          {phone && (
+            <Pressable style={styles.action} onPress={() => open(`tel:${phone.replace(/[^+\d]/g, '')}`)}>
+              <Text style={styles.actionText}>Call</Text>
+            </Pressable>
+          )}
+          {email && (
+            <Pressable style={styles.action} onPress={() => open(`mailto:${email}`)}>
+              <Text style={styles.actionText}>Email</Text>
+            </Pressable>
+          )}
+          {linkedin && (
+            <Pressable
+              style={styles.action}
+              onPress={() => open(linkedin.startsWith('http') ? linkedin : `https://${linkedin}`)}
+            >
+              <Text style={styles.actionText}>LinkedIn</Text>
+            </Pressable>
+          )}
+        </View>
+      )}
+    </Card>
+  )
+}
+
+export default function People() {
+  const [filter, setFilter] = useState<FilterKey>('all')
+  const [query, setQuery] = useState('')
+  const load = useCallback(() => api<Payload>('/dashboard/people/data'), [])
+  const { data, loading, refreshing, error, refresh } = useDashData(load)
+
+  const shown = useMemo(() => {
+    // Prefer the full roster (newer API); fall back to the recent slice.
+    const roster = data?.people?.length ? data.people : data?.recent || []
+    const def = FILTERS.find((f) => f.key === filter)!
+    const q = query.trim().toLowerCase()
+    return roster.filter((p) => {
+      if (def.match && !def.match.includes((p.outreach_status || '').toLowerCase())) return false
+      if (!q) return true
+      return `${p.name} ${p.company} ${p.relationship} ${p.context} ${p.notes}`.toLowerCase().includes(q)
+    })
+  }, [data, filter, query])
+
+  return (
+    <Screen refreshing={refreshing} onRefresh={refresh}>
+      <ScreenTitle sub={data ? `${data.total} contacts` : undefined}>People</ScreenTitle>
+
+      <TextInput
+        style={styles.search}
+        value={query}
+        onChangeText={setQuery}
+        placeholder="Search contacts…"
+        placeholderTextColor={t.faint}
+        autoCapitalize="none"
+      />
+
+      <View style={styles.chipRow}>
+        {FILTERS.map((f) => (
+          <Chip key={f.key} label={f.label} active={filter === f.key} onPress={() => setFilter(f.key)} />
+        ))}
+      </View>
+
+      {loading && !data ? <LoadingState /> : null}
+      {error && !data ? <ErrorState message={error} onRetry={refresh} /> : null}
+      {data && shown.length === 0 ? (
+        <EmptyState
+          message={query ? `No matches for “${query}”.` : 'Nobody in this state right now.'}
+        />
+      ) : null}
+
+      <View style={{ marginTop: 6 }}>
+        {shown.map((p, i) => (
+          <PersonCard key={p.id ?? `${p.name}${i}`} p={p} index={i} />
+        ))}
+      </View>
+    </Screen>
+  )
+}
+
+const styles = StyleSheet.create({
+  search: {
+    marginTop: 14,
+    borderRadius: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    backgroundColor: t.chipBg,
+    borderWidth: 1,
+    borderColor: t.cardBorder,
+    fontSize: 14,
+    color: t.text,
+  },
+  chipRow: { flexDirection: 'row', gap: 8, marginTop: 12, flexWrap: 'wrap' },
+  personCard: { borderRadius: 14, paddingVertical: 13, paddingHorizontal: 14, marginTop: 8 },
+  personTop: { flexDirection: 'row', alignItems: 'center', gap: 12 },
+  avatar: { width: 40, height: 40, borderRadius: 20, alignItems: 'center', justifyContent: 'center' },
+  avatarText: { fontWeight: '700', fontSize: 15, color: t.cyanInk },
+  name: { fontSize: 15, fontWeight: '600', color: t.text },
+  title: { fontSize: 12.5, color: t.muted },
+  historyRow: {
+    marginTop: 11,
+    paddingTop: 11,
+    borderTopWidth: 1,
+    borderTopColor: t.hairline,
+    flexDirection: 'row',
+    gap: 9,
+  },
+  historyDot: { width: 5, height: 5, borderRadius: 2.5, marginTop: 5 },
+  history: { fontSize: 12.5, color: t.textSoft, lineHeight: 17.5 },
+  last: { fontSize: 10.5, color: t.faint, fontFamily: fonts.mono, marginTop: 4, textTransform: 'uppercase' },
+  actions: { flexDirection: 'row', gap: 8, marginTop: 10 },
+  action: {
+    backgroundColor: t.tintFillLo,
+    borderColor: t.tintBorderLo,
+    borderWidth: 1,
+    borderRadius: 9,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  actionText: { color: t.cyanBright, fontSize: 12, fontWeight: '600' },
+})

--- a/mobile/src/screens/Pipeline.tsx
+++ b/mobile/src/screens/Pipeline.tsx
@@ -1,87 +1,158 @@
-// Pipeline glance — the queue at phone altitude: score, status, summary.
-// Deep work (resumes, letters) stays on the desktop by design.
-import { useFocusEffect } from '@react-navigation/native'
-import { useCallback, useState } from 'react'
-import { FlatList, RefreshControl, StyleSheet, Text, View } from 'react-native'
+// Pipeline — design layout: segmented chips + application cards (initial
+// tile, company, role, right-aligned fit score, stage chip, next step).
+// Data: GET /dashboard/pipeline/data. The server's status vocabulary
+// (pending | evaluated | added | applied | dismissed) maps onto the design's
+// stage-chip palette in ui/tokens.stageStyle. Deep work (resumes, letters)
+// stays on the desktop by design.
+import { useCallback, useMemo, useState } from 'react'
+import { StyleSheet, Text, View } from 'react-native'
 import { api } from '../api'
-import { colors } from '../theme'
+import {
+  Card,
+  Chip,
+  EmptyState,
+  ErrorState,
+  LoadingState,
+  Screen,
+  ScreenTitle,
+  StatusChip,
+} from '../ui/primitives'
+import { fonts, stageStyle, t } from '../ui/tokens'
+import { useDashData } from '../ui/useDashData'
 
 type Job = {
   id: number
   company: string
   role: string
+  status?: string
   fitment_score?: string | number | null
   assessed?: boolean
   assessment_summary?: string
+  decision_notes?: string
   added_date?: string
 }
 
+const FILTERS = [
+  { key: 'all', label: 'All' },
+  { key: 'active', label: 'Active' },
+  { key: 'applied', label: 'Applied' },
+] as const
+type FilterKey = (typeof FILTERS)[number]['key']
+
+function scoreColor(score: number): string {
+  if (score >= 85) return t.cyanBright
+  if (score >= 78) return '#E0EAF7'
+  return '#9BB0D0'
+}
+
+function nextStep(j: Job): string {
+  if (j.status === 'applied') return 'Applied — awaiting reply'
+  if (j.status === 'added') return 'Ready to apply'
+  if (j.status === 'evaluated') return j.assessment_summary || 'Assessed — decide next'
+  if (j.status === 'dismissed') return j.decision_notes || 'Dismissed'
+  return 'Awaiting assessment'
+}
+
 export default function Pipeline() {
-  const [jobs, setJobs] = useState<Job[]>([])
-  const [refreshing, setRefreshing] = useState(false)
-  const [error, setError] = useState('')
-
-  const load = useCallback(async () => {
-    setRefreshing(true)
-    try {
-      const data = await api<{ jobs: Job[] }>('/dashboard/pipeline/data')
-      setJobs([...(data.jobs || [])].sort((a, b) => b.id - a.id))
-      setError('')
-    } catch (e: any) {
-      setError(e.message)
-    } finally {
-      setRefreshing(false)
-    }
-  }, [])
-
-  // Refetch on every tab focus — see Today.tsx (stale pre-sign-in state).
-  useFocusEffect(
-    useCallback(() => {
-      load()
-    }, [load]),
+  const [filter, setFilter] = useState<FilterKey>('all')
+  const load = useCallback(
+    () => api<{ jobs: Job[] }>('/dashboard/pipeline/data').then((d) => [...(d.jobs || [])].sort((a, b) => b.id - a.id)),
+    [],
   )
+  const { data: jobs, loading, refreshing, error, refresh } = useDashData(load)
+
+  const shown = useMemo(() => {
+    if (!jobs) return []
+    if (filter === 'active') return jobs.filter((j) => !['dismissed', 'applied'].includes(j.status || ''))
+    if (filter === 'applied') return jobs.filter((j) => j.status === 'applied')
+    return jobs
+  }, [jobs, filter])
+
+  const activeCount = jobs?.filter((j) => j.status !== 'dismissed').length ?? 0
+  const appliedCount = jobs?.filter((j) => j.status === 'applied').length ?? 0
 
   return (
-    <View style={styles.root}>
-      {error ? <Text style={styles.error}>{error}</Text> : null}
-      <FlatList
-        data={jobs}
-        keyExtractor={(j) => String(j.id)}
-        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={load} tintColor={colors.cyan} />}
-        ListEmptyComponent={!refreshing ? <Text style={styles.empty}>Queue is empty — share a job posting to jobContext to start one.</Text> : null}
-        renderItem={({ item }) => (
-          <View style={styles.card}>
-            <View style={styles.row}>
-              <Text style={styles.company} numberOfLines={1}>{item.company}</Text>
-              {item.fitment_score ? (
-                <Text style={styles.score}>{String(item.fitment_score)}</Text>
-              ) : (
-                <Text style={styles.pending}>unscored</Text>
-              )}
-            </View>
-            <Text style={styles.role} numberOfLines={1}>{item.role}</Text>
-            {item.assessment_summary ? (
-              <Text style={styles.summary} numberOfLines={2}>{item.assessment_summary}</Text>
-            ) : null}
-          </View>
-        )}
-      />
-    </View>
+    <Screen refreshing={refreshing} onRefresh={refresh}>
+      <ScreenTitle sub={jobs ? `${activeCount} active · ${appliedCount} applied` : undefined}>
+        Pipeline
+      </ScreenTitle>
+
+      <View style={styles.chipRow}>
+        {FILTERS.map((f) => (
+          <Chip key={f.key} label={f.label} active={filter === f.key} onPress={() => setFilter(f.key)} />
+        ))}
+      </View>
+
+      {loading && !jobs ? <LoadingState /> : null}
+      {error && !jobs ? <ErrorState message={error} onRetry={refresh} /> : null}
+      {jobs && shown.length === 0 ? (
+        <EmptyState
+          message={
+            filter === 'all'
+              ? 'Queue is empty — share a job posting to jobContext to start one.'
+              : 'Nothing in this stage right now.'
+          }
+        />
+      ) : null}
+
+      <View style={{ marginTop: 6 }}>
+        {shown.map((job) => {
+          const stage = stageStyle[job.status || 'pending'] || stageStyle.pending
+          const score = Number(job.fitment_score) || 0
+          return (
+            <Card key={job.id} style={{ marginTop: 10 }}>
+              <View style={styles.topRow}>
+                <View style={styles.initialTile}>
+                  <Text style={styles.initialText}>{(job.company || '?')[0].toUpperCase()}</Text>
+                </View>
+                <View style={{ flex: 1, minWidth: 0 }}>
+                  <Text style={styles.company} numberOfLines={1}>
+                    {job.company}
+                  </Text>
+                  <Text style={styles.role} numberOfLines={1}>
+                    {job.role}
+                  </Text>
+                </View>
+                {score > 0 ? (
+                  <View style={{ alignItems: 'flex-end' }}>
+                    <Text style={[styles.score, { color: scoreColor(score) }]}>{score}</Text>
+                    <Text style={styles.fitLabel}>FIT</Text>
+                  </View>
+                ) : (
+                  <Text style={styles.unscored}>unscored</Text>
+                )}
+              </View>
+              <View style={styles.bottomRow}>
+                <StatusChip label={stage.label} color={stage.color} bg={stage.bg} />
+                <Text style={styles.next} numberOfLines={1}>
+                  {nextStep(job)}
+                </Text>
+              </View>
+            </Card>
+          )
+        })}
+      </View>
+    </Screen>
   )
 }
 
 const styles = StyleSheet.create({
-  root: { flex: 1, backgroundColor: colors.bg },
-  card: {
-    backgroundColor: colors.surface, borderColor: colors.border, borderWidth: 1,
-    borderRadius: 12, padding: 14, marginHorizontal: 12, marginTop: 10,
+  chipRow: { flexDirection: 'row', gap: 8, marginTop: 16 },
+  topRow: { flexDirection: 'row', alignItems: 'center', gap: 12 },
+  initialTile: {
+    width: 38,
+    height: 38,
+    borderRadius: 11,
+    backgroundColor: 'rgba(255,255,255,.06)',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
-  row: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', gap: 8 },
-  company: { color: colors.text, fontWeight: '700', fontSize: 15, flex: 1 },
-  score: { color: colors.green, fontWeight: '700', fontSize: 14 },
-  pending: { color: colors.faint, fontSize: 12 },
-  role: { color: colors.muted, fontSize: 13, marginTop: 2 },
-  summary: { color: colors.faint, fontSize: 12, marginTop: 8, lineHeight: 17 },
-  empty: { color: colors.muted, textAlign: 'center', marginTop: 60, paddingHorizontal: 40, lineHeight: 20 },
-  error: { color: colors.danger, padding: 12, textAlign: 'center' },
+  initialText: { fontWeight: '700', color: t.textBody },
+  company: { fontSize: 15.5, fontWeight: '600', color: t.text },
+  role: { fontSize: 12.5, color: t.muted },
+  score: { fontSize: 17, fontWeight: '700' },
+  fitLabel: { fontSize: 9.5, color: t.faint, fontFamily: fonts.mono },
+  unscored: { fontSize: 12, color: t.faint },
+  bottomRow: { marginTop: 11, flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: 10 },
+  next: { fontSize: 12, color: t.textSecondary, flexShrink: 1 },
 })

--- a/mobile/src/screens/Posts.tsx
+++ b/mobile/src/screens/Posts.tsx
@@ -1,0 +1,241 @@
+// Posts — design layout: aggregate metrics strip + post cards (text,
+// hashtags, view/reaction/comment counts, Update button) with the
+// bottom-sheet Update-metrics editor. CSV import stays on desktop.
+// Data: GET /dashboard/posts/data; updates via POST /dashboard/posts/metrics.
+// The design's "Followers" tile has no counterpart in the payload, so the
+// strip shows Comments instead.
+import { useCallback, useState } from 'react'
+import { KeyboardAvoidingView, Modal, Platform, Pressable, StyleSheet, Text, TextInput, View } from 'react-native'
+import { api } from '../api'
+import {
+  Card,
+  EmptyState,
+  ErrorState,
+  LoadingState,
+  Screen,
+  ScreenTitle,
+  StatTile,
+} from '../ui/primitives'
+import { fmtK, fonts, t } from '../ui/tokens'
+import { useDashData } from '../ui/useDashData'
+
+type Post = {
+  id: number
+  text: string
+  title?: string
+  posted_date?: string
+  hashtags?: string[]
+  impressions: number
+  reactions: number
+  comments: number
+}
+
+type Payload = {
+  total: number
+  total_impressions: number
+  total_reactions: number
+  total_comments: number
+  posts: Post[]
+}
+
+type Draft = { imp: string; rx: string; cm: string }
+
+function digitsOnly(v: string): string {
+  return v.replace(/[^0-9]/g, '')
+}
+
+export default function Posts() {
+  const load = useCallback(() => api<Payload>('/dashboard/posts/data'), [])
+  const { data, loading, refreshing, error, refresh } = useDashData(load)
+
+  const [sheetPost, setSheetPost] = useState<Post | null>(null)
+  const [draft, setDraft] = useState<Draft>({ imp: '', rx: '', cm: '' })
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState('')
+
+  const openSheet = (p: Post) => {
+    setSheetPost(p)
+    setDraft({ imp: String(p.impressions || 0), rx: String(p.reactions || 0), cm: String(p.comments || 0) })
+    setSaveError('')
+  }
+
+  const save = async () => {
+    if (!sheetPost) return
+    setSaving(true)
+    setSaveError('')
+    try {
+      await api('/dashboard/posts/metrics', {
+        method: 'POST',
+        body: JSON.stringify({
+          post_id: sheetPost.id,
+          impressions: Number(draft.imp) || 0,
+          reactions: Number(draft.rx) || 0,
+          comments: Number(draft.cm) || 0,
+        }),
+      })
+      setSheetPost(null)
+      refresh()
+    } catch (e: any) {
+      setSaveError(e?.message || 'Could not save metrics.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Screen refreshing={refreshing} onRefresh={refresh}>
+      <ScreenTitle sub={data ? `${data.total} logged` : undefined}>Posts</ScreenTitle>
+
+      {loading && !data ? <LoadingState /> : null}
+      {error && !data ? <ErrorState message={error} onRetry={refresh} /> : null}
+
+      {data ? (
+        <>
+          <View style={styles.statsRow}>
+            <StatTile value={fmtK(data.total_impressions)} label="Impressions" />
+            <StatTile value={fmtK(data.total_reactions)} label="Reactions" />
+            <StatTile value={fmtK(data.total_comments)} label="Comments" accent />
+          </View>
+
+          {data.posts.length === 0 ? (
+            <EmptyState message="No posts logged yet — import your LinkedIn CSV from the desktop app." />
+          ) : (
+            data.posts.map((p) => (
+              <Card key={p.id} raised style={{ marginTop: 10 }}>
+                <Text style={styles.postText} numberOfLines={4}>
+                  {p.text}
+                </Text>
+                {p.hashtags && p.hashtags.length > 0 ? (
+                  <Text style={styles.tags} numberOfLines={1}>
+                    {p.hashtags.map((h) => (h.startsWith('#') ? h : `#${h}`)).join(' ')}
+                  </Text>
+                ) : p.posted_date ? (
+                  <Text style={styles.tags}>{p.posted_date.slice(0, 10)}</Text>
+                ) : null}
+                <View style={styles.metricsRow}>
+                  <View style={styles.metrics}>
+                    <Text style={styles.metric}>◎ {fmtK(p.impressions)}</Text>
+                    <Text style={styles.metric}>♥ {fmtK(p.reactions)}</Text>
+                    <Text style={styles.metric}>💬 {fmtK(p.comments)}</Text>
+                  </View>
+                  <Pressable style={styles.updateBtn} onPress={() => openSheet(p)}>
+                    <Text style={styles.updateText}>Update</Text>
+                  </Pressable>
+                </View>
+              </Card>
+            ))
+          )}
+        </>
+      ) : null}
+
+      {/* Update metrics bottom sheet */}
+      <Modal visible={sheetPost !== null} transparent animationType="slide" onRequestClose={() => setSheetPost(null)}>
+        <Pressable style={styles.backdrop} onPress={() => setSheetPost(null)}>
+          <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined} style={{ width: '100%' }}>
+            <Pressable style={styles.sheet} onPress={() => {}}>
+              <View style={styles.grabber} />
+              <View style={styles.sheetHeader}>
+                <Text style={styles.sheetTitle}>Update metrics</Text>
+                <Pressable onPress={() => setSheetPost(null)} hitSlop={10}>
+                  <Text style={styles.sheetClose}>×</Text>
+                </Pressable>
+              </View>
+              <Text style={styles.sheetText} numberOfLines={2}>
+                {sheetPost?.text}
+              </Text>
+              <Text style={styles.fieldLabel}>IMPRESSIONS</Text>
+              <TextInput
+                style={styles.input}
+                value={draft.imp}
+                onChangeText={(v) => setDraft((d) => ({ ...d, imp: digitsOnly(v) }))}
+                keyboardType="number-pad"
+              />
+              <View style={styles.fieldRow}>
+                <View style={{ flex: 1 }}>
+                  <Text style={styles.fieldLabel}>REACTIONS</Text>
+                  <TextInput
+                    style={styles.input}
+                    value={draft.rx}
+                    onChangeText={(v) => setDraft((d) => ({ ...d, rx: digitsOnly(v) }))}
+                    keyboardType="number-pad"
+                  />
+                </View>
+                <View style={{ flex: 1 }}>
+                  <Text style={styles.fieldLabel}>COMMENTS</Text>
+                  <TextInput
+                    style={styles.input}
+                    value={draft.cm}
+                    onChangeText={(v) => setDraft((d) => ({ ...d, cm: digitsOnly(v) }))}
+                    keyboardType="number-pad"
+                  />
+                </View>
+              </View>
+              {saveError ? <Text style={styles.saveError}>{saveError}</Text> : null}
+              <Pressable style={[styles.saveBtn, saving && { opacity: 0.6 }]} onPress={save} disabled={saving}>
+                <Text style={styles.saveBtnText}>{saving ? 'Saving…' : 'Save metrics'}</Text>
+              </Pressable>
+            </Pressable>
+          </KeyboardAvoidingView>
+        </Pressable>
+      </Modal>
+    </Screen>
+  )
+}
+
+const styles = StyleSheet.create({
+  statsRow: { flexDirection: 'row', gap: 10, marginTop: 16 },
+  postText: { fontSize: 14, color: t.textBright, lineHeight: 19.5 },
+  tags: { marginTop: 10, fontSize: 12, color: t.cyanBright, fontFamily: fonts.mono },
+  metricsRow: { marginTop: 12, flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  metrics: { flexDirection: 'row', gap: 16 },
+  metric: { fontSize: 12, color: t.muted, fontFamily: fonts.mono },
+  updateBtn: {
+    backgroundColor: 'rgba(0,181,200,.12)',
+    borderColor: t.tintBorder,
+    borderWidth: 1,
+    borderRadius: 9,
+    paddingHorizontal: 11,
+    paddingVertical: 5,
+  },
+  updateText: { fontSize: 11.5, fontWeight: '600', color: t.cyanBright },
+  backdrop: { flex: 1, backgroundColor: 'rgba(4,7,14,.62)', justifyContent: 'flex-end' },
+  sheet: {
+    width: '100%',
+    backgroundColor: t.sheet,
+    borderTopLeftRadius: 26,
+    borderTopRightRadius: 26,
+    borderTopWidth: 1,
+    borderColor: 'rgba(255,255,255,.1)',
+    paddingTop: 14,
+    paddingHorizontal: 20,
+    paddingBottom: 40,
+  },
+  grabber: { width: 38, height: 4, borderRadius: 999, backgroundColor: 'rgba(255,255,255,.18)', alignSelf: 'center', marginBottom: 16 },
+  sheetHeader: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  sheetTitle: { fontSize: 18, fontWeight: '700', color: t.text },
+  sheetClose: { color: t.muted, fontSize: 24, lineHeight: 24 },
+  sheetText: { marginTop: 6, fontSize: 12.5, color: t.muted, lineHeight: 17.5 },
+  fieldLabel: {
+    marginTop: 16,
+    fontSize: 11,
+    fontWeight: '600',
+    letterSpacing: 1,
+    color: t.muted2,
+    fontFamily: fonts.mono,
+  },
+  input: {
+    marginTop: 6,
+    backgroundColor: 'rgba(255,255,255,.05)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,.12)',
+    borderRadius: 12,
+    paddingHorizontal: 13,
+    paddingVertical: 11,
+    color: t.text,
+    fontSize: 15,
+  },
+  fieldRow: { flexDirection: 'row', gap: 12 },
+  saveError: { marginTop: 12, color: t.red, fontSize: 12.5 },
+  saveBtn: { marginTop: 20, backgroundColor: t.cyan, borderRadius: 14, paddingVertical: 13, alignItems: 'center' },
+  saveBtnText: { color: t.cyanInk, fontWeight: '700', fontSize: 15 },
+})

--- a/mobile/src/screens/Wellbeing.tsx
+++ b/mobile/src/screens/Wellbeing.tsx
@@ -1,0 +1,169 @@
+// Wellbeing — design layout: readiness card (big score), 7-day energy bars
+// (last bar solid cyan), recent check-ins. Data:
+//   GET /dashboard/health/data              check-ins (mood label, energy 1-10)
+//   GET /api/dashboard/oura/history?days=14 readiness (optional — card omitted
+//                                           when no ring data exists)
+// The design's emoji check-in row is a desktop/MCP write path
+// (log_mental_health_checkin); mobile is read-only here, so that slot is
+// omitted rather than faked.
+import { useCallback } from 'react'
+import { StyleSheet, Text, View } from 'react-native'
+import { api } from '../api'
+import {
+  Card,
+  EmptyState,
+  ErrorState,
+  LoadingState,
+  Screen,
+  ScreenTitle,
+  SectionLabel,
+} from '../ui/primitives'
+import { fonts, t } from '../ui/tokens'
+import { useDashData } from '../ui/useDashData'
+
+type Entry = { date: string; mood?: string; energy?: number; notes?: string; productive?: boolean }
+type HealthPayload = { total_entries: number; avg_mood: number | null; avg_energy: number | null; recent: Entry[] }
+type OuraDay = { date: string; readiness?: number }
+
+type Bundle = { health: HealthPayload; readiness: OuraDay | null }
+
+function readinessNote(score: number): string {
+  if (score >= 85) return 'High readiness — good day to push outreach'
+  if (score >= 70) return 'Balanced — steady progress day'
+  return 'Recovery day — keep the load light'
+}
+
+function dayLetter(dateStr: string): string {
+  const m = dateStr.match(/^(\d{4})-(\d{2})-(\d{2})/)
+  if (!m) return ''
+  const d = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]))
+  return ['S', 'M', 'T', 'W', 'T', 'F', 'S'][d.getDay()]
+}
+
+export default function Wellbeing() {
+  const load = useCallback(async (): Promise<Bundle> => {
+    const health = await api<HealthPayload>('/dashboard/health/data')
+    // Readiness is a bonus — older servers / no ring just omit the card.
+    let readiness: OuraDay | null = null
+    try {
+      const h = await api<{ days: OuraDay[] }>('/api/dashboard/oura/history?days=14')
+      const scored = (h.days || []).filter((d) => (d.readiness ?? 0) > 0)
+      readiness = scored[scored.length - 1] || null
+    } catch {
+      readiness = null
+    }
+    return { health, readiness }
+  }, [])
+  const { data, loading, refreshing, error, refresh } = useDashData(load)
+
+  // Oldest → newest, last 7 with an energy value, for the bar chart.
+  const bars = (data?.health.recent || [])
+    .filter((e) => typeof e.energy === 'number' && e.energy! > 0)
+    .slice(0, 7)
+    .reverse()
+
+  return (
+    <Screen refreshing={refreshing} onRefresh={refresh}>
+      <ScreenTitle sub={data ? `${data.health.total_entries} check-ins logged` : undefined}>
+        Wellbeing
+      </ScreenTitle>
+
+      {loading && !data ? <LoadingState /> : null}
+      {error && !data ? <ErrorState message={error} onRetry={refresh} /> : null}
+
+      {data ? (
+        <>
+          {data.readiness ? (
+            <Card tint="high" style={styles.readinessCard}>
+              <Text style={styles.readinessScore}>{data.readiness.readiness}</Text>
+              <View style={{ flex: 1 }}>
+                <Text style={styles.readinessTitle}>Oura readiness</Text>
+                <Text style={styles.readinessNote}>{readinessNote(data.readiness.readiness || 0)}</Text>
+              </View>
+            </Card>
+          ) : null}
+
+          {bars.length > 1 && (
+            <>
+              <SectionLabel>{`${bars.length}-day energy`}</SectionLabel>
+              <View style={styles.barRow}>
+                {bars.map((e, i) => (
+                  <View key={e.date + i} style={styles.barCol}>
+                    <View
+                      style={[
+                        styles.bar,
+                        {
+                          height: Math.max(8, ((e.energy || 0) / 10) * 90),
+                          backgroundColor: i === bars.length - 1 ? t.cyan : 'rgba(0,181,200,.35)',
+                        },
+                      ]}
+                    />
+                    <Text style={styles.barLabel}>{dayLetter(e.date)}</Text>
+                  </View>
+                ))}
+              </View>
+            </>
+          )}
+
+          <SectionLabel>Recent check-ins</SectionLabel>
+          {data.health.recent.length === 0 ? (
+            <EmptyState message="No check-ins yet — log one from your desktop (or the MCP tools) and trends appear here." />
+          ) : (
+            data.health.recent.slice(0, 10).map((e, i) => (
+              <Card key={e.date + i} style={styles.entryCard}>
+                <View style={styles.entryTop}>
+                  <Text style={styles.entryMood}>{e.mood || '—'}</Text>
+                  <Text style={styles.entryDate}>{e.date?.slice(0, 10)}</Text>
+                </View>
+                {typeof e.energy === 'number' ? (
+                  <View style={styles.meterRow}>
+                    <Text style={styles.meterLabel}>ENERGY</Text>
+                    <View style={styles.meterTrack}>
+                      <View style={[styles.meterFill, { width: `${Math.min(e.energy, 10) * 10}%` }]} />
+                    </View>
+                    <Text style={styles.meterVal}>{e.energy}/10</Text>
+                  </View>
+                ) : null}
+                {e.notes ? (
+                  <Text style={styles.entryNotes} numberOfLines={2}>
+                    {e.notes}
+                  </Text>
+                ) : null}
+              </Card>
+            ))
+          )}
+        </>
+      ) : null}
+    </Screen>
+  )
+}
+
+const styles = StyleSheet.create({
+  readinessCard: {
+    borderRadius: 18,
+    padding: 17,
+    marginTop: 18,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 16,
+    backgroundColor: 'rgba(0,181,200,.14)',
+    borderColor: 'rgba(0,181,200,.26)',
+  },
+  readinessScore: { fontSize: 40, fontWeight: '700', color: t.cyanBright, letterSpacing: -1 },
+  readinessTitle: { fontSize: 14, fontWeight: '600', color: t.text },
+  readinessNote: { fontSize: 12.5, color: t.cyanMuted, marginTop: 2 },
+  barRow: { flexDirection: 'row', alignItems: 'flex-end', gap: 8, height: 110, marginTop: 12 },
+  barCol: { flex: 1, alignItems: 'center', justifyContent: 'flex-end', gap: 6 },
+  bar: { width: '100%', borderRadius: 6 },
+  barLabel: { fontSize: 9.5, color: t.faint, fontFamily: fonts.mono },
+  entryCard: { borderRadius: 14, paddingVertical: 13, paddingHorizontal: 14, marginTop: 8 },
+  entryTop: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  entryMood: { fontSize: 14.5, fontWeight: '600', color: t.textBright, textTransform: 'capitalize' },
+  entryDate: { fontSize: 11, color: t.faint, fontFamily: fonts.mono },
+  meterRow: { flexDirection: 'row', alignItems: 'center', gap: 10, marginTop: 10 },
+  meterLabel: { fontSize: 9.5, color: t.muted2, fontFamily: fonts.mono, letterSpacing: 1 },
+  meterTrack: { flex: 1, height: 6, borderRadius: 3, backgroundColor: 'rgba(255,255,255,.07)', overflow: 'hidden' },
+  meterFill: { height: '100%', borderRadius: 3, backgroundColor: t.cyan },
+  meterVal: { fontSize: 11, fontWeight: '600', color: t.textSecondary, fontFamily: fonts.mono },
+  entryNotes: { marginTop: 8, fontSize: 12.5, color: t.textSoft, lineHeight: 17.5 },
+})

--- a/mobile/src/theme.ts
+++ b/mobile/src/theme.ts
@@ -1,14 +1,16 @@
-// Brand palette — mirrors the dashboard SPA's dark theme.
+// Brand palette — aligned with the design-handoff navy/cyan tokens
+// (see src/ui/tokens.ts for the full design system). Kept for the legacy
+// screens (Inbox/Activity, Settings) so they blend with the new tab shell.
 export const colors = {
-  bg: '#0b1117',
-  surface: '#111a24',
-  surfaceRaised: '#16222f',
-  border: '#223049',
-  text: '#e6edf3',
-  muted: '#8b949e',
-  faint: '#5c6873',
+  bg: '#0A0F1C',
+  surface: 'rgba(255,255,255,.04)',
+  surfaceRaised: 'rgba(255,255,255,.07)',
+  border: 'rgba(255,255,255,.09)',
+  text: '#F0F5FF',
+  muted: '#8A99B5',
+  faint: '#6B7A96',
   cyan: '#00b5c8',
-  cyanSoft: '#66d5e0',
-  green: '#3fb950',
-  danger: '#f85149',
+  cyanSoft: '#6FE0EE',
+  green: '#6FD3A0',
+  danger: '#E39393',
 }

--- a/mobile/src/ui/Splash.tsx
+++ b/mobile/src/ui/Splash.tsx
@@ -1,0 +1,211 @@
+// Animated launch screen — reproduces the design handoff's splash timeline
+// (jobContext Splash.dc.html) with the RN Animated API:
+//   badge disc scales in bouncy (.6s, delay .15s) → cyan ring "draws"
+//   (approximated: rotate + fade, since react-native-svg is not a dependency)
+//   → mark pops in → wordmark rises (1.5s) → tagline (1.95s) → progress bar
+//   fills over 2.1s while the mono label blinks.
+// Shown as an overlay while the app boots / auth resolves (see App.tsx).
+import { useEffect, useRef } from 'react'
+import { Animated, Easing, StyleSheet, Text, View } from 'react-native'
+import { fonts, t } from './tokens'
+
+const BADGE = 128
+const BAR_W = 196
+
+export default function Splash() {
+  const disc = useRef(new Animated.Value(0)).current
+  const ring = useRef(new Animated.Value(0)).current
+  const innerRing = useRef(new Animated.Value(0)).current
+  const glow = useRef(new Animated.Value(0)).current
+  const markC = useRef(new Animated.Value(0)).current
+  const markJ = useRef(new Animated.Value(0)).current
+  const word = useRef(new Animated.Value(0)).current
+  const tag = useRef(new Animated.Value(0)).current
+  const progressBlock = useRef(new Animated.Value(0)).current
+  const bar = useRef(new Animated.Value(0)).current
+  const blink = useRef(new Animated.Value(0.35)).current
+
+  useEffect(() => {
+    const back = Easing.bezier(0.34, 1.56, 0.64, 1) // design's bouncy cubic-bezier
+    Animated.parallel([
+      Animated.timing(disc, { toValue: 1, duration: 600, delay: 150, easing: back, useNativeDriver: true }),
+      Animated.timing(glow, { toValue: 1, duration: 900, delay: 100, useNativeDriver: true }),
+      Animated.timing(ring, { toValue: 1, duration: 1000, delay: 450, easing: Easing.ease, useNativeDriver: true }),
+      Animated.timing(innerRing, { toValue: 1, duration: 600, delay: 1150, useNativeDriver: true }),
+      Animated.timing(markC, { toValue: 1, duration: 500, delay: 950, easing: back, useNativeDriver: true }),
+      Animated.timing(markJ, { toValue: 1, duration: 500, delay: 1300, easing: back, useNativeDriver: true }),
+      Animated.timing(word, { toValue: 1, duration: 700, delay: 1500, easing: Easing.bezier(0.2, 0.7, 0.2, 1), useNativeDriver: true }),
+      Animated.timing(tag, { toValue: 1, duration: 700, delay: 1950, easing: Easing.bezier(0.2, 0.7, 0.2, 1), useNativeDriver: true }),
+      Animated.timing(progressBlock, { toValue: 1, duration: 600, delay: 1500, useNativeDriver: true }),
+      Animated.timing(bar, { toValue: 1, duration: 2100, delay: 1550, easing: Easing.bezier(0.45, 0.05, 0.2, 1), useNativeDriver: true }),
+    ]).start()
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(blink, { toValue: 1, duration: 900, useNativeDriver: true }),
+        Animated.timing(blink, { toValue: 0.35, duration: 900, useNativeDriver: true }),
+      ]),
+    )
+    loop.start()
+    return () => loop.stop()
+  }, [])
+
+  const rise = (v: Animated.Value) => ({
+    opacity: v,
+    transform: [{ translateY: v.interpolate({ inputRange: [0, 1], outputRange: [18, 0] }) }],
+  })
+  const pop = (v: Animated.Value) => ({
+    opacity: v,
+    transform: [{ scale: v.interpolate({ inputRange: [0, 1], outputRange: [0.5, 1] }) }],
+  })
+
+  return (
+    <View style={styles.root}>
+      <View style={styles.center}>
+        {/* Badge */}
+        <View style={styles.badgeWrap}>
+          <Animated.View
+            style={[
+              styles.glow,
+              { opacity: glow.interpolate({ inputRange: [0, 1], outputRange: [0, 0.55] }) },
+            ]}
+          />
+          <Animated.View style={[styles.disc, pop(disc)]}>
+            {/* Inner faint ring */}
+            <Animated.View style={[styles.innerRing, { opacity: innerRing.interpolate({ inputRange: [0, 1], outputRange: [0, 0.35] }) }]} />
+            {/* The mark: white j + cyan C (favicon.svg recreated as type — no SVG dep) */}
+            <View style={styles.markRow}>
+              <Animated.Text style={[styles.markJ, pop(markJ)]}>j</Animated.Text>
+              <Animated.Text style={[styles.markC, pop(markC)]}>C</Animated.Text>
+            </View>
+          </Animated.View>
+          {/* Cyan ring: draw approximated by a rotating fade-in of the full ring */}
+          <Animated.View
+            style={[
+              styles.ring,
+              {
+                opacity: ring,
+                transform: [
+                  { rotate: ring.interpolate({ inputRange: [0, 1], outputRange: ['-120deg', '0deg'] }) },
+                ],
+              },
+            ]}
+          />
+        </View>
+
+        {/* Wordmark */}
+        <Animated.View style={[styles.wordRow, rise(word)]}>
+          <Text style={styles.wordJob}>job</Text>
+          <Text style={styles.wordContext}>Context</Text>
+        </Animated.View>
+
+        {/* Tagline */}
+        <Animated.Text style={[styles.tagline, rise(tag)]}>
+          The memory layer for your career.
+        </Animated.Text>
+      </View>
+
+      {/* Progress block */}
+      <Animated.View style={[styles.progressBlock, { opacity: progressBlock }]}>
+        <Animated.Text style={[styles.progressLabel, { opacity: blink }]}>
+          RESTORING YOUR CONTEXT
+        </Animated.Text>
+        <View style={styles.track}>
+          <Animated.View
+            style={[
+              styles.fill,
+              {
+                transform: [
+                  // scaleX from the left edge: shift half-width out and back
+                  { translateX: bar.interpolate({ inputRange: [0, 1], outputRange: [-BAR_W / 2, 0] }) },
+                  { scaleX: bar },
+                ],
+              },
+            ]}
+          />
+        </View>
+      </Animated.View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  root: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    // Design: linear-gradient(165deg, #0A0F1C, #0B1220) — solid navy without
+    // a gradient dependency; the two stops are nearly identical on-device.
+    backgroundColor: t.bg,
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 100,
+  },
+  center: { alignItems: 'center' },
+  badgeWrap: { width: BADGE, height: BADGE, alignItems: 'center', justifyContent: 'center', marginBottom: 40 },
+  glow: {
+    position: 'absolute',
+    width: 200,
+    height: 200,
+    borderRadius: 100,
+    backgroundColor: 'rgba(0,181,200,.22)',
+  },
+  disc: {
+    width: BADGE,
+    height: BADGE,
+    borderRadius: BADGE / 2,
+    backgroundColor: t.bg,
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: t.cyan,
+    shadowOpacity: 0.5,
+    shadowRadius: 22,
+    shadowOffset: { width: 0, height: 0 },
+    elevation: 12,
+  },
+  ring: {
+    position: 'absolute',
+    width: BADGE,
+    height: BADGE,
+    borderRadius: BADGE / 2,
+    borderWidth: 4,
+    borderColor: t.cyan,
+  },
+  innerRing: {
+    position: 'absolute',
+    width: BADGE - 12,
+    height: BADGE - 12,
+    borderRadius: (BADGE - 12) / 2,
+    borderWidth: 1,
+    borderColor: t.cyan,
+  },
+  markRow: { flexDirection: 'row', alignItems: 'center' },
+  markJ: { color: '#FFFFFF', fontSize: 56, fontWeight: '700', letterSpacing: -2, fontFamily: fonts.display },
+  markC: { color: t.cyan, fontSize: 56, fontWeight: '700', letterSpacing: -2, fontFamily: fonts.display },
+  wordRow: { flexDirection: 'row', alignItems: 'baseline' },
+  wordJob: { fontSize: 44, fontWeight: '700', letterSpacing: -1.6, color: '#FFFFFF', fontFamily: fonts.display },
+  wordContext: { fontSize: 44, fontWeight: '700', letterSpacing: -1.6, color: t.cyan, fontFamily: fonts.display },
+  tagline: { marginTop: 14, fontSize: 15, fontWeight: '500', color: '#D7E3F8', opacity: 0.82, letterSpacing: 0.1 },
+  progressBlock: { position: 'absolute', bottom: 84, alignItems: 'center', gap: 16 },
+  progressLabel: {
+    fontFamily: fonts.mono,
+    fontSize: 11,
+    fontWeight: '500',
+    letterSpacing: 3,
+    color: t.cyanBright,
+  },
+  track: {
+    width: BAR_W,
+    height: 4,
+    borderRadius: 999,
+    backgroundColor: 'rgba(215,227,248,.12)',
+    overflow: 'hidden',
+  },
+  fill: {
+    height: '100%',
+    width: BAR_W,
+    borderRadius: 999,
+    backgroundColor: t.cyan,
+  },
+})

--- a/mobile/src/ui/format.ts
+++ b/mobile/src/ui/format.ts
@@ -1,0 +1,34 @@
+// Date/label formatting shared by the design screens.
+
+/** "IN 5D" / "TODAY" / "TOMORROW" countdown chip from an ISO-ish date. */
+export function countdownChip(dateStr?: string): string {
+  const m = String(dateStr || '').match(/^(\d{4})-(\d{2})-(\d{2})/)
+  if (!m) return ''
+  // Parse as a LOCAL calendar date — new Date('2026-07-02') is UTC midnight,
+  // which is the previous day west of UTC.
+  const then = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]))
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const diff = Math.round((then.getTime() - today.getTime()) / 86400000)
+  if (diff === 0) return 'TODAY'
+  if (diff === 1) return 'TOMORROW'
+  if (diff > 1) return `IN ${diff}D`
+  return `${-diff}D AGO`
+}
+
+/** "hiring manager · Tue 14:00" line from an interview record. */
+export function interviewTimeLine(iv: {
+  interview_type?: string
+  interview_date?: string
+}): string {
+  const type = (iv.interview_type || '').replace(/_/g, ' ')
+  const raw = String(iv.interview_date || '')
+  const timePart = raw.includes(' ') ? raw.split(' ')[1]?.slice(0, 5) : ''
+  const m = raw.match(/^(\d{4})-(\d{2})-(\d{2})/)
+  let dayName = ''
+  if (m) {
+    const d = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]))
+    dayName = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][d.getDay()]
+  }
+  return [type, [dayName, timePart].filter(Boolean).join(' ')].filter(Boolean).join(' · ')
+}

--- a/mobile/src/ui/icons.tsx
+++ b/mobile/src/ui/icons.tsx
@@ -1,0 +1,202 @@
+// Tab-bar line icons. The design uses currentColor stroke SVGs; react-native-svg
+// is not a dependency, so these approximate the same 22px line icons with
+// border-drawn Views tinted by the navigator's color prop.
+import { View } from 'react-native'
+
+type P = { color: string; size?: number }
+const W = 1.8 // stroke width
+
+export function HomeIcon({ color, size = 22 }: P) {
+  return (
+    <View style={{ width: size, height: size, alignItems: 'center', justifyContent: 'flex-end' }}>
+      <View
+        style={{
+          position: 'absolute',
+          top: 2,
+          width: size * 0.56,
+          height: size * 0.56,
+          borderTopWidth: W,
+          borderLeftWidth: W,
+          borderColor: color,
+          transform: [{ rotate: '45deg' }],
+        }}
+      />
+      <View
+        style={{
+          width: size * 0.55,
+          height: size * 0.42,
+          borderLeftWidth: W,
+          borderRightWidth: W,
+          borderBottomWidth: W,
+          borderColor: color,
+        }}
+      />
+    </View>
+  )
+}
+
+export function PipelineIcon({ color, size = 22 }: P) {
+  const row = (key: number) => (
+    <View key={key} style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+      <View style={{ width: 4, height: 4, borderRadius: 2, borderWidth: 1.4, borderColor: color }} />
+      <View style={{ flex: 1, height: W, borderRadius: 1, backgroundColor: color }} />
+    </View>
+  )
+  return (
+    <View style={{ width: size, height: size, justifyContent: 'space-evenly', paddingVertical: 2 }}>
+      {[0, 1, 2].map(row)}
+    </View>
+  )
+}
+
+export function InterviewsIcon({ color, size = 22 }: P) {
+  return (
+    <View style={{ width: size, height: size, alignItems: 'center', justifyContent: 'center' }}>
+      <View
+        style={{
+          width: size * 0.78,
+          height: size * 0.68,
+          borderWidth: W,
+          borderColor: color,
+          borderRadius: 3.5,
+          marginTop: 3,
+        }}
+      >
+        <View style={{ height: size * 0.16, borderBottomWidth: W, borderColor: color }} />
+      </View>
+      <View style={{ position: 'absolute', top: 1, left: size * 0.3, width: W, height: 5, backgroundColor: color }} />
+      <View style={{ position: 'absolute', top: 1, right: size * 0.3, width: W, height: 5, backgroundColor: color }} />
+    </View>
+  )
+}
+
+export function PeopleIcon({ color, size = 22 }: P) {
+  return (
+    <View style={{ width: size, height: size }}>
+      <View
+        style={{
+          position: 'absolute',
+          top: 1,
+          left: 3,
+          width: size * 0.34,
+          height: size * 0.34,
+          borderRadius: size * 0.17,
+          borderWidth: W,
+          borderColor: color,
+        }}
+      />
+      <View
+        style={{
+          position: 'absolute',
+          bottom: 1,
+          left: 0,
+          width: size * 0.56,
+          height: size * 0.3,
+          borderTopLeftRadius: size * 0.28,
+          borderTopRightRadius: size * 0.28,
+          borderTopWidth: W,
+          borderLeftWidth: W,
+          borderRightWidth: W,
+          borderColor: color,
+        }}
+      />
+      <View
+        style={{
+          position: 'absolute',
+          top: 4,
+          right: 2,
+          width: size * 0.24,
+          height: size * 0.24,
+          borderRadius: size * 0.12,
+          borderWidth: 1.5,
+          borderColor: color,
+          opacity: 0.85,
+        }}
+      />
+      <View
+        style={{
+          position: 'absolute',
+          bottom: 1,
+          right: 0,
+          width: size * 0.34,
+          height: size * 0.22,
+          borderTopLeftRadius: size * 0.18,
+          borderTopRightRadius: size * 0.18,
+          borderTopWidth: 1.5,
+          borderRightWidth: 1.5,
+          borderColor: color,
+          opacity: 0.85,
+        }}
+      />
+    </View>
+  )
+}
+
+export function PostsIcon({ color, size = 22 }: P) {
+  const ring = (d: number, o: number) => (
+    <View
+      key={d}
+      style={{
+        position: 'absolute',
+        width: d,
+        height: d,
+        borderRadius: d / 2,
+        borderWidth: 1.5,
+        borderColor: color,
+        opacity: o,
+      }}
+    />
+  )
+  return (
+    <View style={{ width: size, height: size, alignItems: 'center', justifyContent: 'center' }}>
+      {ring(size * 0.95, 0.45)}
+      {ring(size * 0.6, 0.75)}
+      <View style={{ width: 5, height: 5, borderRadius: 2.5, backgroundColor: color }} />
+    </View>
+  )
+}
+
+export function WellbeingIcon({ color, size = 22 }: P) {
+  // A line heart is not drawable with plain View borders, so this one is the
+  // filled silhouette (two lobes + rotated square) in the tint color.
+  const lobe = size * 0.38
+  return (
+    <View style={{ width: size, height: size, alignItems: 'center', justifyContent: 'center' }}>
+      <View style={{ width: size * 0.72, height: size * 0.66 }}>
+        <View
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: lobe,
+            height: lobe,
+            borderRadius: lobe / 2,
+            backgroundColor: color,
+          }}
+        />
+        <View
+          style={{
+            position: 'absolute',
+            top: 0,
+            right: 0,
+            width: lobe,
+            height: lobe,
+            borderRadius: lobe / 2,
+            backgroundColor: color,
+          }}
+        />
+        <View
+          style={{
+            position: 'absolute',
+            top: lobe * 0.32,
+            left: (size * 0.72 - lobe * 1.02) / 2,
+            width: lobe * 1.02,
+            height: lobe * 1.02,
+            backgroundColor: color,
+            transform: [{ rotate: '45deg' }],
+          }}
+        />
+      </View>
+    </View>
+  )
+}

--- a/mobile/src/ui/primitives.tsx
+++ b/mobile/src/ui/primitives.tsx
@@ -1,0 +1,216 @@
+// Shared building blocks for the design screens: screen shell with the
+// jc-screenIn enter animation, section labels, cards, chips, and the
+// loading / error / empty states every data screen shares.
+import { useFocusEffect } from '@react-navigation/native'
+import { ReactNode, useCallback, useRef } from 'react'
+import {
+  ActivityIndicator,
+  Animated,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+  ViewStyle,
+} from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { fonts, t } from './tokens'
+
+/** Screen shell: navy bg, safe-area padding, pull-to-refresh, and the
+ *  design's fade + rise (translateY 10 → 0, .3s) on every tab focus. */
+export function Screen({
+  children,
+  refreshing = false,
+  onRefresh,
+}: {
+  children: ReactNode
+  refreshing?: boolean
+  onRefresh?: () => void
+}) {
+  const insets = useSafeAreaInsets()
+  const anim = useRef(new Animated.Value(0)).current
+  useFocusEffect(
+    useCallback(() => {
+      anim.setValue(0)
+      Animated.timing(anim, { toValue: 1, duration: 300, useNativeDriver: true }).start()
+    }, [anim]),
+  )
+  return (
+    <View style={styles.root}>
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{ paddingTop: insets.top + 14, paddingHorizontal: 18, paddingBottom: 28 }}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          onRefresh ? <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={t.cyan} /> : undefined
+        }
+      >
+        <Animated.View
+          style={{
+            opacity: anim,
+            transform: [{ translateY: anim.interpolate({ inputRange: [0, 1], outputRange: [10, 0] }) }],
+          }}
+        >
+          {children}
+        </Animated.View>
+      </ScrollView>
+    </View>
+  )
+}
+
+export function ScreenTitle({ children, sub }: { children: string; sub?: string }) {
+  return (
+    <View>
+      <Text style={styles.title}>{children}</Text>
+      {sub ? <Text style={styles.titleSub}>{sub}</Text> : null}
+    </View>
+  )
+}
+
+/** Mono uppercase micro-label ("FOLLOW-UPS DUE"). */
+export function SectionLabel({ children, style }: { children: string; style?: ViewStyle }) {
+  return <Text style={[styles.section, style as any]}>{children}</Text>
+}
+
+export function Card({
+  children,
+  tint,
+  raised,
+  style,
+}: {
+  children: ReactNode
+  /** cyan-tinted accent card */
+  tint?: 'low' | 'high'
+  raised?: boolean
+  style?: ViewStyle
+}) {
+  const base: ViewStyle = tint
+    ? {
+        backgroundColor: tint === 'high' ? t.tintFillHi : t.tintFillLo,
+        borderColor: tint === 'high' ? t.tintBorderHi : t.tintBorderLo,
+      }
+    : {
+        backgroundColor: raised ? t.cardRaised : t.card,
+        borderColor: raised ? t.cardBorderRaised : t.cardBorder,
+      }
+  return <View style={[styles.card, base, style]}>{children}</View>
+}
+
+/** Pill chip; active = solid cyan with ink text (design segmented chips). */
+export function Chip({
+  label,
+  active,
+  onPress,
+}: {
+  label: string
+  active?: boolean
+  onPress?: () => void
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={[styles.chip, { backgroundColor: active ? t.cyan : t.chipBg }]}
+    >
+      <Text style={[styles.chipText, { color: active ? t.cyanInk : t.textSecondary }]}>{label}</Text>
+    </Pressable>
+  )
+}
+
+/** Small mono status chip (e.g. "5D OVERDUE", stage chips). */
+export function StatusChip({ label, color, bg }: { label: string; color: string; bg: string }) {
+  return (
+    <View style={[styles.statusChip, { backgroundColor: bg }]}>
+      <Text style={[styles.statusChipText, { color }]}>{label}</Text>
+    </View>
+  )
+}
+
+export function StatTile({
+  value,
+  label,
+  accent,
+}: {
+  value: string | number
+  label: string
+  accent?: boolean
+}) {
+  return (
+    <View
+      style={[
+        styles.statTile,
+        accent
+          ? { backgroundColor: t.tintFill, borderColor: 'rgba(0,181,200,.22)' }
+          : { backgroundColor: t.card, borderColor: t.cardBorder },
+      ]}
+    >
+      <Text style={[styles.statValue, { color: accent ? t.cyanBright : t.text }]}>{value}</Text>
+      <Text style={[styles.statLabel, { color: accent ? t.cyanMuted : t.muted }]}>{label}</Text>
+    </View>
+  )
+}
+
+export function LoadingState() {
+  return (
+    <View style={styles.centerBox}>
+      <ActivityIndicator color={t.cyan} />
+      <Text style={styles.centerText}>Loading…</Text>
+    </View>
+  )
+}
+
+export function ErrorState({ message, onRetry }: { message: string; onRetry?: () => void }) {
+  return (
+    <View style={styles.centerBox}>
+      <Text style={styles.errorText}>{message}</Text>
+      {onRetry ? (
+        <Pressable onPress={onRetry} style={styles.retry}>
+          <Text style={styles.retryText}>Try again</Text>
+        </Pressable>
+      ) : null}
+    </View>
+  )
+}
+
+export function EmptyState({ message }: { message: string }) {
+  return (
+    <View style={styles.centerBox}>
+      <Text style={styles.centerText}>{message}</Text>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1, backgroundColor: t.bg },
+  title: { fontSize: 27, fontWeight: '700', color: t.text, letterSpacing: -0.6, fontFamily: fonts.display },
+  titleSub: { fontSize: 13, color: t.muted, marginTop: 2 },
+  section: {
+    fontSize: 12,
+    fontWeight: '600',
+    letterSpacing: 1.2,
+    color: t.muted2,
+    fontFamily: fonts.mono,
+    textTransform: 'uppercase',
+    marginTop: 22,
+  },
+  card: { borderRadius: 16, padding: 15, borderWidth: 1, marginTop: 10 },
+  chip: { paddingHorizontal: 14, paddingVertical: 7, borderRadius: 999 },
+  chipText: { fontSize: 12.5, fontWeight: '600' },
+  statusChip: { paddingHorizontal: 8, paddingVertical: 4, borderRadius: 8 },
+  statusChipText: { fontSize: 10.5, fontWeight: '600', fontFamily: fonts.mono, letterSpacing: 0.5 },
+  statTile: { flex: 1, borderRadius: 16, padding: 13, borderWidth: 1, alignItems: 'center' },
+  statValue: { fontSize: 20, fontWeight: '700' },
+  statLabel: { fontSize: 10.5, marginTop: 2 },
+  centerBox: { alignItems: 'center', paddingVertical: 48, gap: 10 },
+  centerText: { color: t.muted, fontSize: 13, textAlign: 'center', lineHeight: 19, paddingHorizontal: 24 },
+  errorText: { color: t.red, fontSize: 13, textAlign: 'center', lineHeight: 19, paddingHorizontal: 24 },
+  retry: {
+    backgroundColor: t.tintFill,
+    borderColor: t.tintBorder,
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  retryText: { color: t.cyanBright, fontSize: 13, fontWeight: '600' },
+})

--- a/mobile/src/ui/tokens.ts
+++ b/mobile/src/ui/tokens.ts
@@ -1,0 +1,80 @@
+// Design tokens from the jobContext design handoff (README "Design Tokens").
+// Navy-ink background, cyan accent, mono micro-labels.
+import { Platform } from 'react-native'
+
+export const t = {
+  // Backgrounds. The design is a 165° gradient #0A0F1C → #0B1220; without
+  // expo-linear-gradient we use the midpoint as a solid base (the two ends
+  // are nearly indistinguishable at phone size).
+  bg: '#0A0F1C',
+  bgEnd: '#0B1220',
+  sheet: '#0E1524',
+
+  // Accent
+  cyan: '#00B5C8',
+  cyanBright: '#6FE0EE',
+  cyanInk: '#04222A', // text on cyan buttons
+
+  // Text
+  text: '#F0F5FF',
+  textBright: '#E8EFFB',
+  textBody: '#C9D6EC',
+  textSoft: '#B7C6E0',
+  textSecondary: '#A9B6CE',
+  muted: '#8A99B5',
+  muted2: '#7C8AA6',
+  faint: '#6B7A96',
+  cyanMuted: '#8AB6C4',
+
+  // Status
+  green: '#6FD3A0',
+  amber: '#E0B77A',
+  red: '#E39393',
+
+  // Surfaces
+  card: 'rgba(255,255,255,.04)',
+  cardRaised: 'rgba(255,255,255,.045)',
+  cardBorder: 'rgba(255,255,255,.07)',
+  cardBorderRaised: 'rgba(255,255,255,.08)',
+  chipBg: 'rgba(255,255,255,.05)',
+  hairline: 'rgba(255,255,255,.06)',
+
+  // Cyan tints
+  tintFillLo: 'rgba(0,181,200,.06)',
+  tintFill: 'rgba(0,181,200,.10)',
+  tintFillHi: 'rgba(0,181,200,.16)',
+  tintBorderLo: 'rgba(0,181,200,.16)',
+  tintBorder: 'rgba(0,181,200,.24)',
+  tintBorderHi: 'rgba(0,181,200,.28)',
+
+  // Tab bar
+  tabBg: 'rgba(10,15,28,.96)',
+  tabInactive: 'rgba(215,227,248,.45)',
+}
+
+// TODO(fonts): the design specifies Space Grotesk (display) + JetBrains Mono
+// (labels). The app does not currently load custom fonts (no expo-font /
+// @expo-google-fonts dependency), so we fall back to the system stack and
+// the platform monospace face until the fonts are added.
+export const fonts = {
+  display: undefined as string | undefined, // system default
+  mono: Platform.select({ ios: 'Menlo', android: 'monospace', default: 'monospace' }),
+}
+
+// Pipeline stage chip palette (design: Offer green, Onsite cyan, Screen
+// amber, Applied/Interested neutral), mapped onto the server's real status
+// vocabulary: pending | evaluated | added | applied | dismissed.
+export const stageStyle: Record<string, { label: string; color: string; bg: string }> = {
+  applied: { label: 'APPLIED', color: '#6FE0EE', bg: 'rgba(0,181,200,.14)' },
+  added: { label: 'READY', color: '#6FD3A0', bg: 'rgba(111,211,160,.14)' },
+  evaluated: { label: 'ASSESSED', color: '#E0B77A', bg: 'rgba(224,183,122,.14)' },
+  pending: { label: 'NEW', color: '#9BB0D0', bg: 'rgba(255,255,255,.06)' },
+  dismissed: { label: 'DISMISSED', color: '#8A99B5', bg: 'rgba(255,255,255,.05)' },
+}
+
+export const avatarPalette = ['#6FE0EE', '#9BE0C0', '#E0C98A', '#C7A9E8', '#E8A9B4']
+
+export function fmtK(n: number | null | undefined): string {
+  const v = Number(n) || 0
+  return v >= 1000 ? `${(v / 1000).toFixed(1).replace(/\.0$/, '')}k` : String(v)
+}

--- a/mobile/src/ui/useDashData.ts
+++ b/mobile/src/ui/useDashData.ts
@@ -1,0 +1,44 @@
+// Shared fetch lifecycle for design screens: loading → error → data, with
+// pull-to-refresh and a refetch on every tab focus (a screen mounted while
+// signed out must not keep a stale "Not signed in" error after sign-in).
+import { useFocusEffect } from '@react-navigation/native'
+import { useCallback, useRef, useState } from 'react'
+
+export function useDashData<T>(loader: () => Promise<T>) {
+  const [data, setData] = useState<T | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+  const [error, setError] = useState('')
+  const seq = useRef(0)
+
+  const load = useCallback(
+    async (asRefresh = false) => {
+      const mySeq = ++seq.current
+      if (asRefresh) setRefreshing(true)
+      try {
+        const result = await loader()
+        if (mySeq !== seq.current) return
+        setData(result)
+        setError('')
+      } catch (e: any) {
+        if (mySeq !== seq.current) return
+        setError(e?.message || 'Something went wrong.')
+      } finally {
+        if (mySeq === seq.current) {
+          setLoading(false)
+          setRefreshing(false)
+        }
+      }
+    },
+    [loader],
+  )
+
+  useFocusEffect(
+    useCallback(() => {
+      load()
+    }, [load]),
+  )
+
+  const refresh = useCallback(() => load(true), [load])
+  return { data, loading, refreshing, error, refresh }
+}

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -267,6 +267,56 @@ class TestDashboardEndpoints:
         assert "total_reactions" in body
         assert "posts" in body
 
+    def test_posts_import_persists_rows_and_metrics(self, http_client_noauth):
+        r = http_client_noauth.post("/dashboard/posts/import", json={
+            "posts": [
+                {"text": "Shipped v1.2 of my job-search memory tool. #buildinpublic",
+                 "posted_date": "2026-07-01", "hashtags": ["buildinpublic"]},
+                {"text": "Interview prep is just context assembly.",
+                 "impressions": 1200, "reactions": 40, "comments": 7},
+                {"text": "   "},  # blank text rows are skipped
+            ],
+        })
+        assert r.status_code == 200
+        body = r.json()
+        assert body["logged"] == 2
+        assert body["with_metrics"] == 1
+
+        data = http_client_noauth.get("/dashboard/posts/data").json()
+        assert data["total"] >= 2
+        by_text = {p["text"]: p for p in data["posts"]}
+        metric_post = by_text["Interview prep is just context assembly."]
+        assert metric_post["impressions"] == 1200
+        assert metric_post["reactions"] == 40
+        assert metric_post["comments"] == 7
+        tagged = by_text["Shipped v1.2 of my job-search memory tool. #buildinpublic"]
+        assert tagged["hashtags"] == ["buildinpublic"]
+        assert tagged["posted_date"] == "2026-07-01"
+
+    def test_posts_import_rejects_empty(self, http_client_noauth):
+        r = http_client_noauth.post("/dashboard/posts/import", json={"posts": [{"text": " "}]})
+        assert r.status_code == 422
+
+    def test_posts_metrics_updates_one_post(self, http_client_noauth):
+        http_client_noauth.post("/dashboard/posts/import", json={
+            "posts": [{"text": "Metrics target post"}],
+        })
+        data = http_client_noauth.get("/dashboard/posts/data").json()
+        target = next(p for p in data["posts"] if p["text"] == "Metrics target post")
+
+        r = http_client_noauth.post("/dashboard/posts/metrics", json={
+            "post_id": target["id"], "impressions": 900, "reactions": 31, "comments": 4,
+        })
+        assert r.status_code == 200
+
+        refreshed = http_client_noauth.get("/dashboard/posts/data").json()
+        updated = next(p for p in refreshed["posts"] if p["id"] == target["id"])
+        assert (updated["impressions"], updated["reactions"], updated["comments"]) == (900, 31, 4)
+
+    def test_posts_metrics_unknown_id_404(self, http_client_noauth):
+        r = http_client_noauth.post("/dashboard/posts/metrics", json={"post_id": 99999, "impressions": 1})
+        assert r.status_code == 404
+
     def test_people_dashboard_page_renders(self, http_client_noauth):
         r = http_client_noauth.get("/dashboard/people")
         assert r.status_code == 200

--- a/transport/http/routes/dashboard/posts.py
+++ b/transport/http/routes/dashboard/posts.py
@@ -1,8 +1,14 @@
-"""LinkedIn Posts pipeline dashboard — GET /dashboard/posts and /dashboard/posts/data."""
+"""LinkedIn Posts pipeline dashboard.
+
+GET  /dashboard/posts, /dashboard/posts/data
+POST /dashboard/posts/import  — LinkedIn CSV import (rows parsed client-side)
+POST /dashboard/posts/metrics — the Posts screen's Update-metrics sheet
+"""
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import HTMLResponse, JSONResponse
+from pydantic import BaseModel, Field
 
 from lib import config
 from lib.io import _load_json
@@ -31,6 +37,8 @@ def _posts_payload() -> dict:
 
     enriched = [
         {
+            "id": p.get("id"),
+            "text": p.get("text", ""),
             "source": p.get("source", ""),
             "title": p.get("title", ""),
             "posted_date": p.get("posted_date", ""),
@@ -55,6 +63,88 @@ def _posts_payload() -> dict:
 @router.get("/posts/data")
 async def posts_data() -> JSONResponse:
     return JSONResponse(_posts_payload())
+
+
+class ImportPost(BaseModel):
+    text: str
+    title: str = ""
+    posted_date: str = ""
+    url: str = ""
+    hashtags: list[str] = Field(default_factory=list)
+    impressions: int | None = None
+    reactions: int | None = None
+    comments: int | None = None
+
+
+class ImportRequest(BaseModel):
+    posts: list[ImportPost]
+    source: str = "linkedin_csv_import"
+
+
+@router.post("/posts/import")
+async def posts_import(request: ImportRequest) -> dict:
+    """Persist client-parsed LinkedIn CSV rows via the posts tools.
+
+    Each row goes through log_linkedin_post (which also ingests the text as
+    a tone sample) and, when the CSV carried engagement columns, through
+    update_post_metrics. This is the real integration point behind the
+    desktop import flow's step 3.
+    """
+    from tools.posts import log_linkedin_post, update_post_metrics
+
+    rows = [p for p in request.posts if p.text.strip()]
+    if not rows:
+        raise HTTPException(status_code=422, detail="No rows with post text to import.")
+
+    logged = 0
+    with_metrics = 0
+    for post in rows:
+        log_linkedin_post(
+            text=post.text.strip(),
+            source=request.source,
+            posted_date=post.posted_date.strip(),
+            url=post.url.strip(),
+            hashtags=[h.lstrip("#") for h in post.hashtags if h.strip("#")],
+            title=post.title.strip() or post.text.strip().replace("\n", " ")[:80],
+        )
+        logged += 1
+        if any(v is not None for v in (post.impressions, post.reactions, post.comments)):
+            # log_linkedin_post always creates a new record here (no post_id /
+            # url match), so the newest id in the store is the row just logged.
+            data = _load_json(config.LINKEDIN_POSTS_FILE, {"posts": []})
+            new_id = max((p.get("id") or 0) for p in data.get("posts", [{}]))
+            update_post_metrics(
+                post_id=new_id,
+                impressions=post.impressions,
+                reactions=post.reactions,
+                comments=post.comments,
+            )
+            with_metrics += 1
+
+    return {"status": "imported", "logged": logged, "with_metrics": with_metrics}
+
+
+class MetricsRequest(BaseModel):
+    post_id: int
+    impressions: int | None = None
+    reactions: int | None = None
+    comments: int | None = None
+
+
+@router.post("/posts/metrics")
+async def posts_metrics(request: MetricsRequest) -> dict:
+    """Update engagement numbers on one post (the Posts screen's Update sheet)."""
+    from tools.posts import update_post_metrics
+
+    result = update_post_metrics(
+        post_id=request.post_id,
+        impressions=request.impressions,
+        reactions=request.reactions,
+        comments=request.comments,
+    )
+    if result.startswith("✗"):
+        raise HTTPException(status_code=404, detail=result)
+    return {"status": "saved", "detail": result}
 
 
 @router.get("/posts")


### PR DESCRIPTION
Implements the full `design_handoff_jobcontext_app` bundle across all three surfaces. Six commits, one per deliverable slice.

> **Base note:** #124 merged while this was in flight, so the branch is rebased onto current qa (clean, re-verified). Mobile changes ride along here but ship from main per the usual mobile process (deploy.yml ignores `mobile/**`).

## 1 · Animated splash (`desktop/splash/index.html`)
Badge disc scale-in → cyan ring stroke-draw → C/j glyph reveal → wordmark sheen → tagline → "restoring your context" progress bar, exactly per the handoff timeline. The `#status` element the Tauri shell writes startup failures into is preserved; fonts degrade to system stacks offline. Verified live: all 15 animations with spec-exact values (44px/-1.6px wordmark, 2.1s/1.55s bar fill, bouncy disc bezier).

## 2 · Desktop SPA redesign (`frontend/`)
- **Shell:** 236px sidebar (gradient-glass active pills, cyan accent bar, TOOLS section for routes the design doesn't cover, pinned Settings, LOCAL·SQLITE / CLOUD status card) + sticky toolbar with a slot screens project actions into (`useToolbarSlot`). Narrow viewports keep the old header+tabs via matchMedia (single Outlet — no double-mounting).
- **Screens:** Home, Pipeline, Interviews, People, Posts, Wellbeing re-skinned to the handoff layouts with **zero functionality loss** — every action button, modal, and data contract preserved; design slots the real payloads can't fill are documented in commit messages (e.g. no prep-status field on interviews, no offer stage in the queue vocabulary). Settings intentionally kept on its just-refactored layout (richer than the design's simplified page).

## 3 · LinkedIn CSV import (the core feature)
- `POST /dashboard/posts/import` → `log_linkedin_post` (+ tone-sample ingestion) + `update_post_metrics` per row; `POST /dashboard/posts/metrics` backs the Update sheet. 4 new tests.
- 3-step flow per spec: drop zone (real DnD), column mapping with auto-detection + live 5-row preview + REQUIRED/MAPPED tags, done screen with stat tiles. Parser handles quoted fields, escaped quotes, embedded newlines, all line endings.
- **Verified end-to-end in the running app:** sample Shares.csv → auto-map → import → 4 posts persisted with dates + extracted hashtags → metrics sheet saved 12.4k impressions and re-rendered.

## 4 · Mobile 6-tab app (`mobile/`)
Tab navigator (Home digest variant, Pipeline, Interviews, People, Posts, Wellbeing) fetching the real dashboard endpoints through the existing auth client; Animated-API splash gating on auth; share capture / auth / pageExtract untouched. SVG ring-draw, gradients, and brand fonts approximated with TODOs (would need react-native-svg / expo-linear-gradient / expo-font).

## Verification
- Backend: 1443 passed (post-rebase, includes qa's new sync-route tests), 17 skipped (`pytest -m "not live_llm"`)
- Frontend: eslint clean (one pre-existing Chat.jsx warning), vite build green
- Mobile: `tsc --noEmit` clean
- Live browser pass on the desktop app: shell nav, Home/Pipeline/Wellbeing render on real data, import flow + metrics sheet exercised end-to-end, zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
