### PR TITLE
feat(tools): edit the master resume in place from MCP clients

### DIFF
--- a/server.py
+++ b/server.py
@@ -199,6 +199,7 @@ get_job_hunt_status = job_hunt.get_job_hunt_status
 update_application = job_hunt.update_application
 
 read_master_resume = resume.read_master_resume
+update_master_resume = resume.update_master_resume
 list_existing_materials = resume.list_existing_materials
 read_existing_resume = resume.read_existing_resume
 read_reference_file = resume.read_reference_file

--- a/tests/test_consolidated_tools.py
+++ b/tests/test_consolidated_tools.py
@@ -34,9 +34,11 @@ def test_action_count_covers_legacy_surface():
     # 86 actions ≙ the 87 legacy tools minus get_session_context's dual role
     # (session startup is folded into insights.session_context). Bumped from
     # 85/84 when stories gained update/delete (a wrong fact could only be
-    # superseded by a second entry before, never corrected in place).
+    # superseded by a second entry before, never corrected in place); bumped
+    # again when materials gained update_master_resume (stale metrics could
+    # only be read, never fixed, from MCP clients).
     total = sum(len(a) for a in DOMAINS.values())
-    assert total == 87, f"action count changed: {total} — update this pin deliberately"
+    assert total == 88, f"action count changed: {total} — update this pin deliberately"
 
 
 def test_facade_params_cover_every_target_param():
@@ -146,9 +148,9 @@ def test_chat_allowlist_matches_domain_names():
     assert set(CHAT_TOOL_ALLOWLIST) == set(FACADES)
 
 
-@pytest.mark.parametrize("flag,expected", [("", 11), ("1", 87)])
+@pytest.mark.parametrize("flag,expected", [("", 11), ("1", 88)])
 def test_server_surface_size(flag, expected, tmp_path):
-    """server.py registers 11 consolidated tools by default, 87 legacy ones
+    """server.py registers 11 consolidated tools by default, 88 legacy ones
     behind JOBCONTEXT_LEGACY_TOOLS=1.
 
     Runs in a subprocess: re-importing server inside the test process would
@@ -299,6 +301,65 @@ class TestStoriesUpdateDelete:
     def test_update_unknown_id_returns_clean_error(self, isolated_server):
         out = FACADES["stories"](action="update", story_id="999", story="X.")
         assert "999" in out and "✗" in out
+
+
+class TestMasterResumeUpdate:
+    """Stale-metrics bug: the master resume was readable but not editable from
+    MCP clients, so drifted numbers (test counts, coverage, clone counts)
+    could never be corrected in chat."""
+
+    def test_update_replaces_exact_match_in_place(self, isolated_server):
+        import server as srv
+
+        srv.MASTER_RESUME.write_text(
+            "PROJECTS\njobContextMCP — 312 tests, 84% coverage\n", encoding="utf-8"
+        )
+        out = FACADES["materials"](
+            action="update_master_resume",
+            old_text="312 tests, 84% coverage",
+            new_text="405 tests, 87% coverage",
+        )
+        assert "✓" in out
+        content = srv.MASTER_RESUME.read_text(encoding="utf-8")
+        assert "405 tests, 87% coverage" in content
+        assert "312 tests" not in content
+
+    def test_not_found_returns_clean_error_and_leaves_file_untouched(self, isolated_server):
+        import server as srv
+
+        before = srv.MASTER_RESUME.read_text(encoding="utf-8")
+        out = FACADES["materials"](
+            action="update_master_resume", old_text="no such text", new_text="x"
+        )
+        assert "✗" in out and "not found" in out
+        assert srv.MASTER_RESUME.read_text(encoding="utf-8") == before
+
+    def test_ambiguous_match_reports_occurrence_count(self, isolated_server):
+        import server as srv
+
+        srv.MASTER_RESUME.write_text("95% SLA\nother line\n95% SLA\n", encoding="utf-8")
+        out = FACADES["materials"](
+            action="update_master_resume", old_text="95% SLA", new_text="98% SLA"
+        )
+        assert "✗" in out and "2 times" in out
+        assert "98% SLA" not in srv.MASTER_RESUME.read_text(encoding="utf-8")
+
+    def test_snippet_from_appended_reference_section_names_the_real_file(self, isolated_server, tmp_path):
+        """read_master_resume appends ACHIEVEMENTS from a separate reference
+        file — an edit targeting that text must say where it actually lives."""
+        from lib import config as cfg
+
+        ref_dir = cfg.get_active_reference_materials_dir()
+        ref_dir.mkdir(parents=True, exist_ok=True)
+        (ref_dir / "achievements.txt").write_text(
+            "Quarterly award for platform work.", encoding="utf-8"
+        )
+        out = FACADES["materials"](
+            action="update_master_resume",
+            old_text="Quarterly award for platform work.",
+            new_text="x",
+        )
+        assert "✗" in out and "achievements.txt" in out
 
 
 def test_outreach_status_enum_choices_surfaced_in_generated_docs():

--- a/tools/consolidated.py
+++ b/tools/consolidated.py
@@ -98,6 +98,7 @@ DOMAINS: dict[str, dict[str, tuple]] = {
     },
     "materials": {
         "read_master_resume": (resume.read_master_resume, "Read the master resume."),
+        "update_master_resume": (resume.update_master_resume, "Edit the master resume in place (exact-match find/replace)."),
         "read_resume": (resume.read_existing_resume, "Read an existing resume file."),
         "read_reference": (resume.read_reference_file, "Read a reference-materials file."),
         "read_latex_asset": (read_latex_asset, "Read a LaTeX template/section asset."),
@@ -356,13 +357,15 @@ def documents(
 
 
 def materials(
-    action: Literal["read_master_resume", "read_resume", "read_reference", "read_latex_asset", "list", "search", "reindex", "reindex_stories"],
+    action: Literal["read_master_resume", "update_master_resume", "read_resume", "read_reference", "read_latex_asset", "list", "search", "reindex", "reindex_stories"],
     filename: str | None = None,
     company: str | None = None,
     query: str | None = None,
     category: str | None = None,
+    old_text: str | None = None,
+    new_text: str | None = None,
 ) -> str:
-    """Read and search your existing materials: master resume, saved resumes/letters, reference files, LaTeX assets, and the semantic index."""
+    """Read, search, and maintain your existing materials: master resume (read and in-place edit), saved resumes/letters, reference files, LaTeX assets, and the semantic index."""
     return _run("materials", action, locals())
 
 

--- a/tools/resume.py
+++ b/tools/resume.py
@@ -46,6 +46,72 @@ def read_master_resume() -> str:
     return _load_master_context()
 
 
+def update_master_resume(old_text: str, new_text: str) -> str:
+    """
+    Edit the master source resume in place — replace one exact occurrence of
+    old_text with new_text. Use this to keep the master resume current, e.g.
+    refreshing a metric that has drifted (test counts, coverage numbers,
+    clone/view counts).
+
+    old_text must match the file exactly (including whitespace and line
+    breaks) and appear exactly once — include enough surrounding text to make
+    the match unique. Read the master resume first to copy the exact text.
+
+    Args:
+        old_text: Exact text currently in the master resume to replace.
+        new_text: Replacement text.
+
+    Returns:
+        Confirmation with the replaced text, or an actionable error.
+    """
+    master_path = config.get_active_master_resume_path()
+    if not master_path.exists():
+        return (
+            f"✗ Master resume not found: {master_path.name}. "
+            "Run workspace check to diagnose."
+        )
+    if not old_text:
+        return "✗ old_text is required — pass the exact current text to replace."
+
+    content = master_path.read_text(encoding="utf-8")
+    count = content.count(old_text)
+
+    if count == 0:
+        # read_master_resume() appends ACHIEVEMENTS / PEER FEEDBACK sections
+        # from separate reference files — a snippet copied from those sections
+        # will never match the master resume file itself.
+        for label, ref_name in (
+            ("ACHIEVEMENTS", config.get_config_value("achievements_path", "")
+             or config.get_config_value("gm_awards_path", "Achievements.txt")),
+            ("PEER FEEDBACK", config.get_config_value("feedback_received_path", "Feedback_Received.txt")),
+        ):
+            ref_path = config.get_active_reference_materials_dir() / str(ref_name).split("/")[-1]
+            if ref_path.exists() and old_text in ref_path.read_text(encoding="utf-8"):
+                return (
+                    f"✗ old_text not found in the master resume — it is in the {label} "
+                    f"section, which read_master_resume appends from the separate reference "
+                    f"file {ref_path.name}. That file can't be edited with this action."
+                )
+        return (
+            "✗ old_text not found in the master resume. It must match exactly, "
+            "including whitespace and line breaks — read the master resume and "
+            "copy the text verbatim."
+        )
+    if count > 1:
+        return (
+            f"✗ old_text appears {count} times in the master resume — include "
+            "more surrounding text so the match is unique."
+        )
+
+    master_path.write_text(content.replace(old_text, new_text, 1), encoding="utf-8")
+    return (
+        f"✓ Master resume updated ({master_path.name}):\n"
+        f"  - {old_text}\n"
+        f"  + {new_text}\n"
+        "If you rely on semantic search, run materials reindex to refresh the index."
+    )
+
+
 def list_existing_materials(company: str = "") -> str:
     """List all existing resume and cover letter files. Optionally filter by company name to see materials for a specific target company."""
     optimized_dir = config.get_active_optimized_resumes_dir()
@@ -199,6 +265,7 @@ def resume_diff(file_a: str, file_b: str) -> str:
 
 def register(mcp) -> None:
     mcp.tool()(read_master_resume)
+    mcp.tool()(update_master_resume)
     mcp.tool()(list_existing_materials)
     mcp.tool()(read_existing_resume)
     mcp.tool()(read_reference_file)


### PR DESCRIPTION
## Problem

The `materials` MCP domain exposes `read_master_resume` but no write path, so Claude chat (and every other MCP client) could see stale numbers in the master resume — test counts, coverage, clone counts — but never fix them. They just kept going stale.

## Fix

New `materials.update_master_resume` action: exact-match, single-occurrence find/replace against `config.get_active_master_resume_path()` (tenant-resolved, so cloud users edit their own partition's file).

Guardrails instead of a full-overwrite save:
- `old_text` must match verbatim and appear exactly once — no clobbering the whole file, no fuzzy edits.
- Not-found errors explain the verbatim-match requirement; ambiguous matches report the occurrence count.
- If the snippet actually lives in the appended ACHIEVEMENTS / PEER FEEDBACK sections (separate reference files that `read_master_resume` concatenates), the error names the real file instead of a bare "not found".

## Surface bookkeeping

- Facade gains `old_text` / `new_text` params (facade-coverage test enforces this).
- Action-count pin 87 → 88; legacy surface pin 87 → 88; `server.py` alias added.

## Tests

4 new behavior tests through the facade (in-place edit, untouched-on-miss, ambiguity count, reference-section hint). Full suite: 1481 passed, 17 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)