### PR TITLE
mobile + desktop home: detail pages, global search, timeline; actionable dashboard

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@react-navigation/bottom-tabs": "^7.18.8",
         "@react-navigation/native": "^7.3.8",
+        "@react-navigation/native-stack": "^7.18.5",
         "@types/react": "~19.2.4",
         "expo": "^57.0.4",
         "expo-asset": "~57.0.3",
@@ -1915,12 +1916,12 @@
       }
     },
     "node_modules/@react-navigation/core": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.21.5.tgz",
-      "integrity": "sha512-3hpV7uR41LBW+GHDoLhztZCb/i5ySRJISZ/rez4d7DCHSZo6ej4gNxYclaS6LRguoLiKG7SOCNa6O390AQklZQ==",
+      "version": "7.21.10",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.21.10.tgz",
+      "integrity": "sha512-nDZsbhUnGT0rjfBSWqsWHjN9pA9qSH/O9CgiSDe9XgS/EcprS6KD5+sxpYbvh17BBiQs7Kls/VnEa4042fMtHw==",
       "license": "MIT",
       "dependencies": {
-        "@react-navigation/routers": "^7.6.0",
+        "@react-navigation/routers": "^7.6.4",
         "escape-string-regexp": "^4.0.0",
         "fast-deep-equal": "^3.1.3",
         "nanoid": "^3.3.11",
@@ -1934,15 +1935,15 @@
       }
     },
     "node_modules/@react-navigation/core/node_modules/react-is": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
-      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
       "license": "MIT"
     },
     "node_modules/@react-navigation/elements": {
-      "version": "2.9.30",
-      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.9.30.tgz",
-      "integrity": "sha512-2isleieiRMmP4WNMV2Q1u3qP1M47ZqsJ2hJ/Og11FeKXK8YmUTHya7PW7ecsgAh2CXKTxAcbfJDFTSvq2D++Tw==",
+      "version": "2.9.35",
+      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.9.35.tgz",
+      "integrity": "sha512-e+ggAFhqlHILDERiKvTwzfz/mPfhhtEgbbDVtuul9BBChj+gVtieR6lxClMtbnO5t/vH/IJJzrwISj2QRkSa4g==",
       "license": "MIT",
       "dependencies": {
         "color": "^4.2.3",
@@ -1951,7 +1952,7 @@
       },
       "peerDependencies": {
         "@react-native-masked-view/masked-view": ">= 0.2.0",
-        "@react-navigation/native": "^7.3.8",
+        "@react-navigation/native": "^7.3.13",
         "react": ">= 18.2.0",
         "react-native": "*",
         "react-native-safe-area-context": ">= 4.0.0"
@@ -1963,16 +1964,16 @@
       }
     },
     "node_modules/@react-navigation/native": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.3.8.tgz",
-      "integrity": "sha512-zHmQcxWBT8GOwsofEOmHqpdM5twkwE/esa9JFGlW4hpXeQTTe/dRcPSLjwsvePtolbDKz0YZbK+I5KrW3j63LQ==",
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.3.13.tgz",
+      "integrity": "sha512-eiNUieNCJxCdHSVBUJWwoACspqlUGULHj36Z8CQRlymwPxOD8fXA23vXAqdWJ6VT3MmVh7akLLPvs9aKMArgxg==",
       "license": "MIT",
       "dependencies": {
-        "@react-navigation/core": "^7.21.5",
+        "@react-navigation/core": "^7.21.10",
         "escape-string-regexp": "^4.0.0",
         "fast-deep-equal": "^3.1.3",
         "nanoid": "^3.3.11",
-        "standard-navigation": "^0.0.7",
+        "standard-navigation": "^0.0.8",
         "use-latest-callback": "^0.2.4"
       },
       "peerDependencies": {
@@ -1980,10 +1981,29 @@
         "react-native": "*"
       }
     },
+    "node_modules/@react-navigation/native-stack": {
+      "version": "7.18.5",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-7.18.5.tgz",
+      "integrity": "sha512-zrmcOm8437zt5gMdqYjFXnM5axsTFEh63vVWdqhZZdfc9M1FkVrEXmrUjGYNLoAxxuBiw+jpvoYWTqyvJWILyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/elements": "^2.9.35",
+        "color": "^4.2.3",
+        "sf-symbols-typescript": "^2.1.0",
+        "warn-once": "^0.1.1"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^7.3.13",
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 4.0.0",
+        "react-native-screens": ">= 4.0.0"
+      }
+    },
     "node_modules/@react-navigation/routers": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-7.6.0.tgz",
-      "integrity": "sha512-lblhDXfS75jLc7G2K7BZGM+7cjqQXk13X/MA4fq/12r62zM+fBhhreLzYflSitrDDXFRJpSvJXy0ziiGU04Xow==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-7.6.4.tgz",
+      "integrity": "sha512-GI7eJm8/KsZUQaYcXvEExikKurRZRgEsSzyZ7faENfi65yqJBCXjDMwyN1pF6pNW1MoLH1ErDwDivFxY6BzD3w==",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.11"
@@ -5997,10 +6017,13 @@
       }
     },
     "node_modules/standard-navigation": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/standard-navigation/-/standard-navigation-0.0.7.tgz",
-      "integrity": "sha512-NCGLCNyuXrFOkGHxdNZFnpsehGtiq1oXbPhKl7ZuxFO5J//H2evqqOchmD4YwEUJnkjO4kH9Xp4hQX6hdAYCKQ==",
-      "license": "MIT"
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/standard-navigation/-/standard-navigation-0.0.8.tgz",
+      "integrity": "sha512-TyVbo7INUDWtsUWDFn8RR7kwR87U0S4xHfLfbbnyeC581TmmyqQ+eM+nPw8rQTSD8QitRVcYfPaSHr/QJiUy1g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/statuses": {
       "version": "1.5.0",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@react-navigation/bottom-tabs": "^7.18.8",
     "@react-navigation/native": "^7.3.8",
+    "@react-navigation/native-stack": "^7.18.5",
     "@types/react": "~19.2.4",
     "expo": "^57.0.4",
     "expo-asset": "~57.0.3",

--- a/mobile/src/App.tsx
+++ b/mobile/src/App.tsx
@@ -1,13 +1,15 @@
-// jobContext mobile — capture reality, glance at state. Deep work lives on
-// the desktop; this app is the share sheet, the inbox, and the notification.
+// jobContext mobile — capture reality, glance at state, and now explore
+// what was captured. Deep work (generation, editing) stays on the desktop.
 //
-// UI per the design handoff: 6 tabs (Home, Pipeline, Interviews, People,
-// Posts, Wellbeing) on a navy-ink theme with cyan active states, plus an
-// animated splash while the app boots. The previous Inbox and Settings
-// screens stay mounted as chromeless routes (reached from Home) so the
-// activity feed and the API-key connect flow keep working unchanged.
+// Navigation is a root native stack over the 6-tab bar: tabs glance, and
+// every card pushes a detail page (jobs, interviews, people, companies,
+// posts, check-ins) so cards are never dead ends. Global search and the
+// activity/timeline feed live on the stack too. The previous Inbox and
+// Settings screens keep working unchanged as stack routes reached from
+// Home.
 import { NavigationContainer, DarkTheme } from '@react-navigation/native'
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs'
+import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import { StatusBar } from 'expo-status-bar'
 import * as SplashScreen from 'expo-splash-screen'
 import { useEffect, useState } from 'react'
@@ -22,6 +24,14 @@ import Posts from './screens/Posts'
 import Wellbeing from './screens/Wellbeing'
 import Inbox from './screens/Inbox'
 import Settings from './screens/Settings'
+import Search from './screens/Search'
+import Timeline from './screens/Timeline'
+import JobDetail from './screens/detail/JobDetail'
+import InterviewDetail from './screens/detail/InterviewDetail'
+import PersonDetail from './screens/detail/PersonDetail'
+import CompanyDetail from './screens/detail/CompanyDetail'
+import PostDetail from './screens/detail/PostDetail'
+import CheckinDetail from './screens/detail/CheckinDetail'
 import { captureUrl, isConnected } from './api'
 import { extractJobPage } from './pageExtract'
 import { ensurePushRegistration } from './push'
@@ -41,6 +51,7 @@ import { t } from './ui/tokens'
 SplashScreen.preventAutoHideAsync().catch(() => {})
 
 const Tab = createBottomTabNavigator()
+const Stack = createNativeStackNavigator()
 
 const theme = {
   ...DarkTheme,
@@ -123,6 +134,64 @@ function CaptureBanner() {
   )
 }
 
+function Tabs() {
+  return (
+    <Tab.Navigator
+      screenOptions={{
+        headerShown: false,
+        tabBarStyle: {
+          backgroundColor: t.tabBg,
+          borderTopColor: t.hairline,
+          borderTopWidth: 1,
+        },
+        tabBarActiveTintColor: t.cyan,
+        tabBarInactiveTintColor: t.tabInactive,
+        tabBarLabelStyle: { fontSize: 9.5, fontWeight: '500' },
+      }}
+    >
+      <Tab.Screen
+        name="Home"
+        component={Home}
+        options={{ tabBarIcon: ({ color }) => <HomeIcon color={color} /> }}
+      />
+      <Tab.Screen
+        name="Pipeline"
+        component={Pipeline}
+        options={{ tabBarIcon: ({ color }) => <PipelineIcon color={color} /> }}
+      />
+      <Tab.Screen
+        name="Interviews"
+        component={Interviews}
+        options={{ tabBarIcon: ({ color }) => <InterviewsIcon color={color} /> }}
+      />
+      <Tab.Screen
+        name="People"
+        component={People}
+        options={{ tabBarIcon: ({ color }) => <PeopleIcon color={color} /> }}
+      />
+      <Tab.Screen
+        name="Posts"
+        component={Posts}
+        options={{ tabBarIcon: ({ color }) => <PostsIcon color={color} /> }}
+      />
+      <Tab.Screen
+        name="Wellbeing"
+        component={Wellbeing}
+        options={{ tabBarIcon: ({ color }) => <WellbeingIcon color={color} /> }}
+      />
+    </Tab.Navigator>
+  )
+}
+
+// Native-stack header styling for the routes that keep a system header.
+const headered = (title: string) => ({
+  headerShown: true,
+  headerTitle: title,
+  headerStyle: { backgroundColor: t.bg },
+  headerTitleStyle: { color: t.text },
+  headerTintColor: t.cyan,
+})
+
 export default function App() {
   useIncomingShares()
   const [booted, setBooted] = useState(false)
@@ -144,75 +213,26 @@ export default function App() {
       <NavigationContainer theme={theme}>
         <StatusBar style="light" />
         <CaptureBanner />
-        <Tab.Navigator
+        <Stack.Navigator
           screenOptions={{
             headerShown: false,
-            tabBarStyle: {
-              backgroundColor: t.tabBg,
-              borderTopColor: t.hairline,
-              borderTopWidth: 1,
-            },
-            tabBarActiveTintColor: t.cyan,
-            tabBarInactiveTintColor: t.tabInactive,
-            tabBarLabelStyle: { fontSize: 9.5, fontWeight: '500' },
+            animation: 'slide_from_right',
+            contentStyle: { backgroundColor: t.bg },
           }}
         >
-          <Tab.Screen
-            name="Home"
-            component={Home}
-            options={{ tabBarIcon: ({ color }) => <HomeIcon color={color} /> }}
-          />
-          <Tab.Screen
-            name="Pipeline"
-            component={Pipeline}
-            options={{ tabBarIcon: ({ color }) => <PipelineIcon color={color} /> }}
-          />
-          <Tab.Screen
-            name="Interviews"
-            component={Interviews}
-            options={{ tabBarIcon: ({ color }) => <InterviewsIcon color={color} /> }}
-          />
-          <Tab.Screen
-            name="People"
-            component={People}
-            options={{ tabBarIcon: ({ color }) => <PeopleIcon color={color} /> }}
-          />
-          <Tab.Screen
-            name="Posts"
-            component={Posts}
-            options={{ tabBarIcon: ({ color }) => <PostsIcon color={color} /> }}
-          />
-          <Tab.Screen
-            name="Wellbeing"
-            component={Wellbeing}
-            options={{ tabBarIcon: ({ color }) => <WellbeingIcon color={color} /> }}
-          />
-          {/* Chromeless routes — no tab-bar item; reached from Home. */}
-          <Tab.Screen
-            name="Activity"
-            component={Inbox}
-            options={{
-              tabBarItemStyle: { display: 'none' },
-              headerShown: true,
-              headerTitle: 'Activity',
-              headerStyle: { backgroundColor: t.bg },
-              headerTitleStyle: { color: t.text },
-              headerTintColor: t.cyan,
-            }}
-          />
-          <Tab.Screen
-            name="Settings"
-            component={Settings}
-            options={{
-              tabBarItemStyle: { display: 'none' },
-              headerShown: true,
-              headerTitle: 'Settings',
-              headerStyle: { backgroundColor: t.bg },
-              headerTitleStyle: { color: t.text },
-              headerTintColor: t.cyan,
-            }}
-          />
-        </Tab.Navigator>
+          <Stack.Screen name="Tabs" component={Tabs} />
+          {/* Detail pages draw their own chrome (back + share). */}
+          <Stack.Screen name="JobDetail" component={JobDetail} />
+          <Stack.Screen name="InterviewDetail" component={InterviewDetail} />
+          <Stack.Screen name="PersonDetail" component={PersonDetail} />
+          <Stack.Screen name="CompanyDetail" component={CompanyDetail} />
+          <Stack.Screen name="PostDetail" component={PostDetail} />
+          <Stack.Screen name="CheckinDetail" component={CheckinDetail} />
+          <Stack.Screen name="Search" component={Search} options={{ animation: 'fade_from_bottom' }} />
+          <Stack.Screen name="Timeline" component={Timeline} options={headered('Timeline')} />
+          <Stack.Screen name="Activity" component={Inbox} options={headered('Activity')} />
+          <Stack.Screen name="Settings" component={Settings} options={headered('Settings')} />
+        </Stack.Navigator>
       </NavigationContainer>
       {!booted && <Splash />}
     </SafeAreaProvider>

--- a/mobile/src/lib/insights.ts
+++ b/mobile/src/lib/insights.ts
@@ -1,0 +1,194 @@
+// Executive-summary sentences for every detail page, composed on-device
+// from the joined datasets. Deterministic heuristics, not an LLM call: the
+// cloud has no summary endpoint yet, and the phone already holds every fact
+// these sentences state (counts, gaps, scores, relationships). When a server
+// endpoint exists, detail pages can prefer it and keep this as the offline
+// fallback.
+import {
+  Checkin,
+  CompanyBundle,
+  Datasets,
+  Interview,
+  Job,
+  Person,
+  Post,
+  Quote,
+  companyBundle,
+  contactChannels,
+  daysSince,
+  normName,
+} from './store'
+
+const plural = (n: number, word: string) => `${n} ${word}${n === 1 ? '' : 's'}`
+
+function quoteText(q?: Quote): string {
+  if (!q) return ''
+  return typeof q === 'string' ? q : q.quote || ''
+}
+
+export function jobSummary(job: Job, ds: Datasets): string[] {
+  const out: string[] = []
+  const score = Number(job.fitment_score) || 0
+  const status = (job.status || 'pending').toLowerCase()
+  const co = companyBundle(ds, job.company)
+
+  if (score >= 85) out.push(`Excellent fit — this role scores ${score}, near the top of your pipeline.`)
+  else if (score >= 75) out.push(`Solid fit at ${score} — worth pursuing with a tailored resume.`)
+  else if (score > 0) out.push(`Moderate fit at ${score} — weigh it against stronger openings before investing time.`)
+  else out.push('Not yet assessed — run the assessment to get a fit score and recommendation.')
+
+  const age = daysSince(job.added_date)
+  if (status === 'applied') out.push(`You applied${age != null ? ` ${plural(age, 'day')} ago` : ''} and are awaiting a reply.`)
+  else if (status === 'added') out.push('It is queued and ready to apply.')
+  else if (status === 'dismissed') out.push(`You dismissed it${job.decision_notes ? `: ${job.decision_notes}` : '.'}`)
+  else if (age != null && age > 7) out.push(`It has sat in the pipeline for ${plural(age, 'day')} without an application.`)
+
+  const others = co.jobs.filter((j) => j.id !== job.id)
+  if (others.length) out.push(`${job.company} has ${plural(others.length, 'other opening')} in your pipeline.`)
+  if (co.interviews.length) out.push(`You have already interviewed with ${job.company} ${plural(co.interviews.length, 'time')}.`)
+  if (co.people.length) out.push(`You know ${plural(co.people.length, 'contact')} there — warm intros beat cold applications.`)
+  else if (status !== 'applied' && status !== 'dismissed') out.push('No contacts at this company yet — finding one before applying would strengthen your odds.')
+
+  return out.slice(0, 5)
+}
+
+export function interviewSummary(iv: Interview, ds: Datasets): string[] {
+  const out: string[] = []
+  const co = iv.company ? companyBundle(ds, iv.company) : null
+  const days = daysSince(iv.interview_date)
+  const type = (iv.interview_type || 'interview').replace(/_/g, ' ')
+
+  if (iv.upcoming) {
+    if (days != null && days <= 0) {
+      out.push(days === 0 ? `Your ${type} at ${iv.company} is today.` : `Your ${type} at ${iv.company} is in ${plural(-days, 'day')}.`)
+    } else out.push(`Upcoming ${type} at ${iv.company}.`)
+    if (iv.interviewer) out.push(`You will meet ${iv.interviewer}${iv.interviewer_role ? `, ${iv.interviewer_role}` : ''}.`)
+    const past = (co?.interviews || []).filter((i) => !i.upcoming)
+    if (past.length) out.push(`You have ${plural(past.length, 'previous debrief')} with this company — review them before the call.`)
+    else out.push('First conversation with this company — research their interview process beforehand.')
+  } else {
+    if (iv.self_rating != null) {
+      if (iv.self_rating >= 8) out.push(`Strong performance — you rated it ${iv.self_rating}/10.`)
+      else if (iv.self_rating >= 6) out.push(`Decent showing at ${iv.self_rating}/10 with clear room to improve.`)
+      else out.push(`Tough one — you rated it ${iv.self_rating}/10.`)
+    } else out.push(`Debrief logged for this ${type} at ${iv.company}.`)
+    if (iv.what_landed?.length) out.push(`What landed: ${iv.what_landed[0]}`)
+    if (iv.what_didnt?.length) out.push(`Weak spot to drill: ${iv.what_didnt[0]}`)
+    const q = quoteText(iv.verbatim_quotes?.[0])
+    if (q) out.push(`Worth remembering — “${q}”`)
+  }
+  return out.slice(0, 5)
+}
+
+export function personSummary(p: Person, ds: Datasets): string[] {
+  const out: string[] = []
+  const co = p.company ? companyBundle(ds, p.company) : null
+  const status = (p.outreach_status || '').toLowerCase()
+  const gap = daysSince(p.last_contacted || p.last_updated)
+
+  out.push(
+    `${p.name} is ${p.relationship ? `a ${p.relationship}` : 'a contact'}${p.company ? ` at ${p.company}` : ''}.`,
+  )
+  if (status === 'responded') out.push('They replied to your last outreach — the ball is in your court.')
+  else if (status === 'sent') out.push('Your last message is awaiting a reply.')
+  else if (status === 'follow-up') out.push('A follow-up is due.')
+  else if (status === 'drafted') out.push('You drafted outreach but have not sent it yet.')
+  else out.push('You have not reached out yet.')
+
+  if (gap != null && gap > 14) out.push(`No contact in ${plural(gap, 'day')} — the relationship is going cold.`)
+  else if (gap != null && gap >= 0) out.push(`Last touch was ${gap === 0 ? 'today' : `${plural(gap, 'day')} ago`}.`)
+
+  if (co) {
+    const active = co.jobs.filter((j) => !['dismissed'].includes((j.status || '').toLowerCase()))
+    if (active.length) out.push(`${p.company} has ${plural(active.length, 'live opening')} in your pipeline — a concrete reason to reconnect.`)
+    if (co.interviews.length) out.push(`You have interviewed there ${plural(co.interviews.length, 'time')}.`)
+  }
+  const { email, phone, linkedin } = contactChannels(p)
+  if (!email && !phone && !linkedin) out.push('No contact channel on file — add an email or LinkedIn from the desktop.')
+  return out.slice(0, 5)
+}
+
+export function companySummary(co: CompanyBundle): string[] {
+  const out: string[] = []
+  const active = co.jobs.filter((j) => (j.status || '').toLowerCase() !== 'dismissed')
+  const applied = co.jobs.filter((j) => (j.status || '').toLowerCase() === 'applied')
+  const scores = co.jobs.map((j) => Number(j.fitment_score) || 0).filter((s) => s > 0)
+  const best = scores.length ? Math.max(...scores) : 0
+
+  out.push(
+    `${co.name} touches ${plural(co.jobs.length, 'job')}, ${plural(co.interviews.length, 'interview')}, and ${plural(co.people.length, 'contact')} in your search.`,
+  )
+  if (applied.length) out.push(`${plural(applied.length, 'application')} in flight.`)
+  if (best >= 85) out.push(`Your best fit there scores ${best} — one of your strongest matches.`)
+  else if (best > 0) out.push(`Best fit score there is ${best}.`)
+  const upcoming = co.interviews.filter((i) => i.upcoming)
+  if (upcoming.length) out.push(`${plural(upcoming.length, 'interview')} coming up — prep time is now.`)
+  else if (co.interviews.length) out.push(`You have completed ${plural(co.interviews.length, 'interview')} with them — the debriefs hold their question style.`)
+  if (!co.people.length && active.length) out.push('No contacts here yet — networking in would derisk the applications.')
+  return out.slice(0, 5)
+}
+
+export function postSummary(post: Post, ds: Datasets): string[] {
+  const out: string[] = []
+  const n = ds.posts.length || 1
+  const avgImp = ds.postTotals.impressions / n
+  const avgRx = ds.postTotals.reactions / n
+  const rate = post.impressions > 0 ? ((post.reactions + post.comments) / post.impressions) * 100 : 0
+
+  if (post.impressions === 0 && post.reactions === 0) {
+    out.push('No metrics logged yet — update them from LinkedIn to see how this post performed.')
+  } else {
+    if (avgImp > 0 && post.impressions >= avgImp * 1.5) out.push(`Top performer — ${Math.round((post.impressions / avgImp) * 100 - 100)}% more impressions than your average post.`)
+    else if (avgImp > 0 && post.impressions < avgImp * 0.5) out.push('This one reached well under your average — timing or topic may not have landed.')
+    else out.push('Reach was in line with your usual audience.')
+    if (rate > 0) out.push(`Engagement rate ${rate.toFixed(1)}% (${post.reactions} reactions, ${post.comments} comments).`)
+    if (avgRx > 0 && post.reactions > avgRx * 1.5) out.push('Reactions ran hot — this topic resonates; consider a follow-up post.')
+  }
+  if (post.hashtags?.length) out.push(`Tagged ${post.hashtags.slice(0, 3).map((h) => (h.startsWith('#') ? h : `#${h}`)).join(' ')}.`)
+  const age = daysSince(post.posted_date)
+  if (age != null && age >= 0) out.push(`Published ${age === 0 ? 'today' : `${plural(age, 'day')} ago`}.`)
+  return out.slice(0, 5)
+}
+
+export function checkinSummary(entry: Checkin, ds: Datasets): string[] {
+  const out: string[] = []
+  const energies = ds.checkins.map((c) => c.energy || 0).filter((e) => e > 0)
+  const avg = energies.length ? energies.reduce((a, b) => a + b, 0) / energies.length : 0
+
+  if (entry.mood) out.push(`You logged feeling ${entry.mood}.`)
+  if (typeof entry.energy === 'number') {
+    if (avg > 0 && entry.energy >= avg + 1.5) out.push(`Energy ${entry.energy}/10 — well above your ${avg.toFixed(1)} average. Days like this are for outreach and interviews.`)
+    else if (avg > 0 && entry.energy <= avg - 1.5) out.push(`Energy ${entry.energy}/10 — below your ${avg.toFixed(1)} average. Keep the load light.`)
+    else out.push(`Energy ${entry.energy}/10, close to your recent average.`)
+  }
+  out.push(entry.productive ? 'You marked it a productive day.' : 'Not marked productive — that is signal, not failure.')
+  if (entry.notes) out.push('Your journal entry below has the context.')
+  return out.slice(0, 5)
+}
+
+/** Cross-cutting observations for search/timeline empty moments and the
+ *  company screen footer — "surface observations, not just data". */
+export function globalInsights(ds: Datasets): string[] {
+  const out: string[] = []
+  const stale = ds.people.filter((p) => {
+    const s = (p.outreach_status || '').toLowerCase()
+    const gap = daysSince(p.last_contacted || p.last_updated)
+    return ['sent', 'responded', 'follow-up'].includes(s) && gap != null && gap > 14
+  })
+  if (stale.length) out.push(`${plural(stale.length, 'conversation')} have gone quiet for 2+ weeks.`)
+  const unassessed = ds.jobs.filter((j) => !j.assessed && (j.status || 'pending') === 'pending')
+  if (unassessed.length) out.push(`${plural(unassessed.length, 'captured job')} still await assessment.`)
+  const counts = new Map<string, number>()
+  ds.interviews.forEach((i) => {
+    const k = normName(i.company)
+    if (k) counts.set(k, (counts.get(k) || 0) + 1)
+  })
+  for (const [key, count] of counts) {
+    if (count >= 3) {
+      const name = ds.interviews.find((i) => normName(i.company) === key)?.company
+      out.push(`You have interviewed at ${name} ${count} times.`)
+      break
+    }
+  }
+  return out
+}

--- a/mobile/src/lib/store.ts
+++ b/mobile/src/lib/store.ts
@@ -1,0 +1,200 @@
+// Shared cross-domain data layer for detail pages, global search, and the
+// timeline. The cloud API only exposes per-domain listing payloads (no
+// per-object GET), so every "detail" view hydrates from these lists and the
+// relationships are joined client-side by company name. One short-lived
+// cache keeps a tab full of detail pushes from re-fetching five endpoints
+// per screen; pull-to-refresh forces through it.
+import { api, InboxEvent } from '../api'
+
+export type Job = {
+  id: number
+  company: string
+  role: string
+  status?: string
+  source?: string
+  added_date?: string
+  fitment_score?: string | number | null
+  decision_notes?: string
+  assessed?: boolean
+  assessment_summary?: string
+  assessment_detail?: string
+  recommended_resume?: string
+  selected_resume?: string
+  last_edited_resume?: string
+  last_edited_cover_letter?: string
+}
+
+export type Quote = string | { speaker?: string; quote?: string }
+export type Interview = {
+  id?: number
+  company?: string
+  role?: string
+  interview_date?: string
+  interview_type?: string
+  interviewer?: string
+  interviewer_role?: string
+  self_rating?: number | null
+  what_landed?: string[]
+  what_didnt?: string[]
+  verbatim_quotes?: Quote[]
+  upcoming?: boolean // set client-side from which payload bucket it came in
+}
+
+export type Person = {
+  id: number
+  name: string
+  relationship?: string
+  company?: string
+  context?: string
+  contact_info?: string
+  outreach_status?: string
+  notes?: string
+  tags?: string[]
+  last_updated?: string
+  last_contacted?: string
+}
+
+export type Post = {
+  id: number
+  text: string
+  title?: string
+  source?: string
+  posted_date?: string
+  url?: string
+  hashtags?: string[]
+  impressions: number
+  reactions: number
+  comments: number
+}
+
+export type Checkin = {
+  date: string
+  mood?: string
+  energy?: number
+  notes?: string
+  productive?: boolean
+}
+
+export type Datasets = {
+  jobs: Job[]
+  interviews: Interview[]
+  people: Person[]
+  posts: Post[]
+  postTotals: { impressions: number; reactions: number; comments: number }
+  checkins: Checkin[]
+  events: InboxEvent[]
+}
+
+const TTL_MS = 60_000
+let cache: { at: number; data: Datasets } | null = null
+let inflight: Promise<Datasets> | null = null
+
+/** Fetch every domain the app knows about. Sections fail independently —
+ *  a broken endpoint empties its slice instead of sinking the whole page —
+ *  but if literally everything failed, surface the first error. */
+export async function loadDatasets(force = false): Promise<Datasets> {
+  if (!force && cache && Date.now() - cache.at < TTL_MS) return cache.data
+  if (inflight) return inflight
+  inflight = (async () => {
+    const [jobsR, ivR, peopleR, postsR, healthR, eventsR] = await Promise.allSettled([
+      api<{ jobs: Job[] }>('/dashboard/pipeline/data'),
+      api<{ upcoming: Interview[]; recent: Interview[] }>('/dashboard/interviews/data'),
+      api<{ people?: Person[]; recent: Person[] }>('/dashboard/people/data'),
+      api<{
+        posts: Post[]
+        total_impressions: number
+        total_reactions: number
+        total_comments: number
+      }>('/dashboard/posts/data'),
+      api<{ recent: Checkin[] }>('/dashboard/health/data'),
+      api<{ events: InboxEvent[] }>('/api/events'),
+    ])
+    const settled = [jobsR, ivR, peopleR, postsR, healthR, eventsR]
+    if (settled.every((r) => r.status === 'rejected')) {
+      throw (settled[0] as PromiseRejectedResult).reason
+    }
+    const iv = ivR.status === 'fulfilled' ? ivR.value : { upcoming: [], recent: [] }
+    const posts = postsR.status === 'fulfilled' ? postsR.value : null
+    const people = peopleR.status === 'fulfilled' ? peopleR.value : null
+    const data: Datasets = {
+      jobs: jobsR.status === 'fulfilled' ? jobsR.value.jobs || [] : [],
+      interviews: [
+        ...(iv.upcoming || []).map((i) => ({ ...i, upcoming: true })),
+        ...(iv.recent || []).map((i) => ({ ...i, upcoming: false })),
+      ],
+      people: people ? (people.people?.length ? people.people : people.recent) || [] : [],
+      posts: posts?.posts || [],
+      postTotals: {
+        impressions: posts?.total_impressions || 0,
+        reactions: posts?.total_reactions || 0,
+        comments: posts?.total_comments || 0,
+      },
+      checkins: healthR.status === 'fulfilled' ? healthR.value.recent || [] : [],
+      events: eventsR.status === 'fulfilled' ? eventsR.value.events || [] : [],
+    }
+    cache = { at: Date.now(), data }
+    return data
+  })()
+  try {
+    return await inflight
+  } finally {
+    inflight = null
+  }
+}
+
+export const normName = (s?: string) => (s || '').trim().toLowerCase()
+
+/** Everything the app knows about one company, joined by name. */
+export type CompanyBundle = {
+  name: string
+  jobs: Job[]
+  interviews: Interview[]
+  people: Person[]
+  events: InboxEvent[]
+}
+
+export function companyBundle(ds: Datasets, name: string): CompanyBundle {
+  const key = normName(name)
+  return {
+    name,
+    jobs: ds.jobs.filter((j) => normName(j.company) === key),
+    interviews: ds.interviews.filter((i) => normName(i.company) === key),
+    people: ds.people.filter((p) => normName(p.company) === key),
+    events: ds.events.filter((e) => normName(e.company) === key),
+  }
+}
+
+/** Distinct companies across all domains, most-connected first. */
+export function allCompanies(ds: Datasets): string[] {
+  const seen = new Map<string, { name: string; count: number }>()
+  const add = (name?: string) => {
+    const key = normName(name)
+    if (!key) return
+    const cur = seen.get(key)
+    if (cur) cur.count += 1
+    else seen.set(key, { name: (name || '').trim(), count: 1 })
+  }
+  ds.jobs.forEach((j) => add(j.company))
+  ds.interviews.forEach((i) => add(i.company))
+  ds.people.forEach((p) => add(p.company))
+  return [...seen.values()].sort((a, b) => b.count - a.count).map((c) => c.name)
+}
+
+/** Whole days elapsed since an ISO-ish date string; null when unparsable. */
+export function daysSince(dateStr?: string): number | null {
+  const m = String(dateStr || '').match(/^(\d{4})-(\d{2})-(\d{2})/)
+  if (!m) return null
+  const then = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]))
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  return Math.round((today.getTime() - then.getTime()) / 86400000)
+}
+
+/** Email / phone / LinkedIn URL mined from a contact's free-text fields. */
+export function contactChannels(p: Person) {
+  const info = `${p.contact_info || ''} ${p.notes || ''} ${p.context || ''}`
+  const email = info.match(/[\w.+-]+@[\w-]+\.[\w.]+/)?.[0]
+  const phone = info.match(/\+?1?[\s.-]?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}/)?.[0]
+  const linkedin = info.match(/(?:https?:\/\/)?(?:www\.)?linkedin\.com\/[^\s,)]+/i)?.[0]
+  return { email, phone, linkedin }
+}

--- a/mobile/src/screens/Home.tsx
+++ b/mobile/src/screens/Home.tsx
@@ -107,10 +107,20 @@ export default function Home() {
               : ''}
           </Text>
         </View>
-        <Pressable style={styles.avatar} onPress={() => nav.navigate('Settings')}>
-          <Text style={styles.avatarText}>{(data?.home.welcomeName || '·')[0].toUpperCase()}</Text>
-        </Pressable>
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+          <Pressable style={styles.searchBtn} onPress={() => nav.navigate('Search')} hitSlop={6}>
+            <Text style={styles.searchIcon}>⌕</Text>
+          </Pressable>
+          <Pressable style={styles.avatar} onPress={() => nav.navigate('Settings')}>
+            <Text style={styles.avatarText}>{(data?.home.welcomeName || '·')[0].toUpperCase()}</Text>
+          </Pressable>
+        </View>
       </View>
+
+      {/* Global search — one box over jobs, people, companies, everything */}
+      <Pressable onPress={() => nav.navigate('Search')} style={styles.searchPill}>
+        <Text style={styles.searchPillText}>⌕  Search jobs, people, companies…</Text>
+      </Pressable>
 
       {loading && !data ? <LoadingState /> : null}
       {error && !data ? <ErrorState message={error} onRetry={refresh} /> : null}
@@ -143,15 +153,17 @@ export default function Home() {
                 {data.followups.map((p) => {
                   const chip = followupChip(p.outreach_status)
                   return (
-                    <Card key={p.id} style={styles.followRow}>
-                      <View style={{ flex: 1, minWidth: 0 }}>
-                        <Text style={styles.followName}>{p.company || p.name}</Text>
-                        <Text style={styles.followSub} numberOfLines={1}>
-                          {p.company ? p.name : p.outreach_status || ''}
-                        </Text>
-                      </View>
-                      <StatusChip {...chip} />
-                    </Card>
+                    <Pressable key={p.id} onPress={() => nav.navigate('PersonDetail', { person: p })}>
+                      <Card style={styles.followRow}>
+                        <View style={{ flex: 1, minWidth: 0 }}>
+                          <Text style={styles.followName}>{p.company || p.name}</Text>
+                          <Text style={styles.followSub} numberOfLines={1}>
+                            {p.company ? p.name : p.outreach_status || ''}
+                          </Text>
+                        </View>
+                        <StatusChip {...chip} />
+                      </Card>
+                    </Pressable>
                   )
                 })}
               </View>
@@ -162,20 +174,24 @@ export default function Home() {
           {data.nextInterview && (
             <>
               <SectionLabel>Next interview</SectionLabel>
-              <Card raised style={{ marginTop: 4 }}>
-                <View style={styles.ivTop}>
-                  <Text style={styles.ivTitle} numberOfLines={1}>
-                    {[data.nextInterview.company, data.nextInterview.role]
-                      .filter(Boolean)
-                      .join(' · ')}
-                  </Text>
-                  <Text style={styles.ivCountdown}>{countdownChip(data.nextInterview.interview_date)}</Text>
-                </View>
-                <Text style={styles.ivMeta}>{interviewTimeLine(data.nextInterview)}</Text>
-                <Pressable onPress={() => nav.navigate('Interviews')}>
-                  <Text style={styles.ivLink}>View in Interviews →</Text>
-                </Pressable>
-              </Card>
+              <Pressable
+                onPress={() =>
+                  nav.navigate('InterviewDetail', { interview: { ...data.nextInterview, upcoming: true } })
+                }
+              >
+                <Card raised style={{ marginTop: 4 }}>
+                  <View style={styles.ivTop}>
+                    <Text style={styles.ivTitle} numberOfLines={1}>
+                      {[data.nextInterview.company, data.nextInterview.role]
+                        .filter(Boolean)
+                        .join(' · ')}
+                    </Text>
+                    <Text style={styles.ivCountdown}>{countdownChip(data.nextInterview.interview_date)}</Text>
+                  </View>
+                  <Text style={styles.ivMeta}>{interviewTimeLine(data.nextInterview)}</Text>
+                  <Text style={styles.ivLink}>Open interview →</Text>
+                </Card>
+              </Pressable>
             </>
           )}
 
@@ -187,9 +203,15 @@ export default function Home() {
             </Card>
           ) : null}
 
-          {/* Recent activity → Inbox feed (kept from the previous app) */}
-          <Pressable onPress={() => nav.navigate('Activity')}>
+          {/* Feeds: everything chronological, and the raw sync journal */}
+          <Pressable onPress={() => nav.navigate('Timeline')}>
             <Card style={styles.activityRow}>
+              <Text style={styles.activityText}>Timeline — your whole search, in order</Text>
+              <Text style={styles.activityArrow}>→</Text>
+            </Card>
+          </Pressable>
+          <Pressable onPress={() => nav.navigate('Activity')}>
+            <Card style={{ ...styles.activityRow, marginTop: 8 }}>
               <Text style={styles.activityText}>Recent activity</Text>
               <Text style={styles.activityArrow}>→</Text>
             </Card>
@@ -215,6 +237,27 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   avatarText: { fontWeight: '700', color: t.cyanBright },
+  searchBtn: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: t.chipBg,
+    borderWidth: 1,
+    borderColor: t.cardBorder,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  searchIcon: { color: t.textSecondary, fontSize: 19, lineHeight: 22 },
+  searchPill: {
+    marginTop: 14,
+    borderRadius: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 11,
+    backgroundColor: t.chipBg,
+    borderWidth: 1,
+    borderColor: t.cardBorder,
+  },
+  searchPillText: { color: t.faint, fontSize: 13.5 },
   prioLabel: { fontSize: 11, fontWeight: '600', letterSpacing: 1.5, color: t.cyanBright, fontFamily: fonts.mono },
   prioRow: { flexDirection: 'row', alignItems: 'center', gap: 11 },
   checkbox: { width: 18, height: 18, borderRadius: 6, borderWidth: 2, borderColor: 'rgba(215,227,248,.35)' },

--- a/mobile/src/screens/Interviews.tsx
+++ b/mobile/src/screens/Interviews.tsx
@@ -5,9 +5,11 @@
 // payload, so upcoming cards show a debrief-pending dot instead; recent rows
 // surface the debrief signal that does exist (self_rating / what_landed /
 // verbatim_quotes).
+import { useNavigation } from '@react-navigation/native'
 import { useCallback } from 'react'
 import { StyleSheet, Text, View } from 'react-native'
 import { api } from '../api'
+import { PressableScale } from '../ui/detail'
 import {
   Card,
   EmptyState,
@@ -56,8 +58,11 @@ function debriefLine(iv: Interview): string {
 }
 
 export default function Interviews() {
+  const nav = useNavigation<any>()
   const load = useCallback(() => api<Payload>('/dashboard/interviews/data'), [])
   const { data, loading, refreshing, error, refresh } = useDashData(load)
+  const open = (iv: Interview, upcoming: boolean) =>
+    nav.navigate('InterviewDetail', { interview: { ...iv, upcoming } })
 
   return (
     <Screen refreshing={refreshing} onRefresh={refresh}>
@@ -70,30 +75,37 @@ export default function Interviews() {
         <>
           <SectionLabel style={{ marginTop: 20 } as any}>Upcoming</SectionLabel>
           {data.upcoming.length === 0 ? (
-            <EmptyState message="Nothing scheduled. Log the next one from your desktop and it shows up here." />
+            <EmptyState
+              message="You're interview-free."
+              suggestions={['Practice STAR stories', 'Reach out to a recruiter', 'Review your pipeline']}
+              actionLabel="Review pipeline"
+              onAction={() => nav.navigate('Pipeline')}
+            />
           ) : (
             data.upcoming.map((iv, i) => (
-              <Card key={iv.id ?? i} tint={i === 0 ? 'low' : undefined} raised={i !== 0} style={i === 0 ? styles.firstCard : undefined}>
-                <View style={styles.topRow}>
-                  <Text style={styles.title} numberOfLines={1}>
-                    {[iv.company, iv.role].filter(Boolean).join(' · ')}
-                  </Text>
-                  <Text style={[styles.countdown, { color: i === 0 ? t.cyanBright : t.textSecondary }]}>
-                    {countdownChip(iv.interview_date)}
-                  </Text>
-                </View>
-                <Text style={styles.meta}>{interviewTimeLine(iv)}</Text>
-                {iv.interviewer ? (
-                  <Text style={styles.interviewer} numberOfLines={1}>
-                    with {iv.interviewer}
-                    {iv.interviewer_role ? ` · ${iv.interviewer_role}` : ''}
-                  </Text>
-                ) : null}
-                <View style={styles.statusRow}>
-                  <View style={[styles.dot, { backgroundColor: t.amber }]} />
-                  <Text style={[styles.statusText, { color: t.amber }]}>Debrief pending</Text>
-                </View>
-              </Card>
+              <PressableScale key={iv.id ?? i} onPress={() => open(iv, true)}>
+                <Card tint={i === 0 ? 'low' : undefined} raised={i !== 0} style={i === 0 ? styles.firstCard : undefined}>
+                  <View style={styles.topRow}>
+                    <Text style={styles.title} numberOfLines={1}>
+                      {[iv.company, iv.role].filter(Boolean).join(' · ')}
+                    </Text>
+                    <Text style={[styles.countdown, { color: i === 0 ? t.cyanBright : t.textSecondary }]}>
+                      {countdownChip(iv.interview_date)}
+                    </Text>
+                  </View>
+                  <Text style={styles.meta}>{interviewTimeLine(iv)}</Text>
+                  {iv.interviewer ? (
+                    <Text style={styles.interviewer} numberOfLines={1}>
+                      with {iv.interviewer}
+                      {iv.interviewer_role ? ` · ${iv.interviewer_role}` : ''}
+                    </Text>
+                  ) : null}
+                  <View style={styles.statusRow}>
+                    <View style={[styles.dot, { backgroundColor: t.amber }]} />
+                    <Text style={[styles.statusText, { color: t.amber }]}>Debrief pending</Text>
+                  </View>
+                </Card>
+              </PressableScale>
             ))
           )}
 
@@ -102,17 +114,19 @@ export default function Interviews() {
             <EmptyState message="No debriefs logged yet." />
           ) : (
             data.recent.map((iv, i) => (
-              <Card key={iv.id ?? `r${i}`} style={styles.debriefRow}>
-                <View style={{ flex: 1, minWidth: 0 }}>
-                  <Text style={styles.debriefTitle} numberOfLines={1}>
-                    {[iv.company, (iv.interview_type || '').replace(/_/g, ' ')].filter(Boolean).join(' · ')}
-                  </Text>
-                  <Text style={styles.debriefSub} numberOfLines={1}>
-                    {debriefLine(iv)}
-                  </Text>
-                </View>
-                <Text style={styles.debriefDate}>{monoDate(iv.interview_date)}</Text>
-              </Card>
+              <PressableScale key={iv.id ?? `r${i}`} onPress={() => open(iv, false)}>
+                <Card style={styles.debriefRow}>
+                  <View style={{ flex: 1, minWidth: 0 }}>
+                    <Text style={styles.debriefTitle} numberOfLines={1}>
+                      {[iv.company, (iv.interview_type || '').replace(/_/g, ' ')].filter(Boolean).join(' · ')}
+                    </Text>
+                    <Text style={styles.debriefSub} numberOfLines={1}>
+                      {debriefLine(iv)}
+                    </Text>
+                  </View>
+                  <Text style={styles.debriefDate}>{monoDate(iv.interview_date)}</Text>
+                </Card>
+              </PressableScale>
             ))
           )}
         </>

--- a/mobile/src/screens/People.tsx
+++ b/mobile/src/screens/People.tsx
@@ -4,9 +4,11 @@
 // (call / email / LinkedIn) are carried over from the previous Networking
 // screen so no functionality is lost.
 // Data: GET /dashboard/people/data → { people[], follow_up_queue[], recent[] }.
+import { useNavigation } from '@react-navigation/native'
 import { useCallback, useMemo, useState } from 'react'
 import { Linking, Pressable, StyleSheet, Text, TextInput, View } from 'react-native'
 import { api } from '../api'
+import { PressableScale } from '../ui/detail'
 import {
   Card,
   Chip,
@@ -76,13 +78,14 @@ function extractActions(p: Person) {
   return { email, phone, linkedin }
 }
 
-function PersonCard({ p, index }: { p: Person; index: number }) {
+function PersonCard({ p, index, onOpen }: { p: Person; index: number; onOpen: () => void }) {
   const chip = STATUS_CHIP[(p.outreach_status || 'none').toLowerCase()] || STATUS_CHIP.none
   const { email, phone, linkedin } = extractActions(p)
   const open = (url: string) => Linking.openURL(url).catch(() => {})
   const history = p.context || p.notes || ''
   return (
-    <Card style={styles.personCard}>
+    <PressableScale onPress={onOpen}>
+      <Card style={styles.personCard}>
       <View style={styles.personTop}>
         <View style={[styles.avatar, { backgroundColor: avatarPalette[index % avatarPalette.length] }]}>
           <Text style={styles.avatarText}>{initials(p.name)}</Text>
@@ -132,11 +135,13 @@ function PersonCard({ p, index }: { p: Person; index: number }) {
           )}
         </View>
       )}
-    </Card>
+      </Card>
+    </PressableScale>
   )
 }
 
 export default function People() {
+  const nav = useNavigation<any>()
   const [filter, setFilter] = useState<FilterKey>('all')
   const [query, setQuery] = useState('')
   const load = useCallback(() => api<Payload>('/dashboard/people/data'), [])
@@ -178,12 +183,20 @@ export default function People() {
       {data && shown.length === 0 ? (
         <EmptyState
           message={query ? `No matches for “${query}”.` : 'Nobody in this state right now.'}
+          suggestions={query ? undefined : ['Add contacts from the desktop', 'Search everything instead']}
+          actionLabel={query ? undefined : 'Search everything'}
+          onAction={query ? undefined : () => nav.navigate('Search')}
         />
       ) : null}
 
       <View style={{ marginTop: 6 }}>
         {shown.map((p, i) => (
-          <PersonCard key={p.id ?? `${p.name}${i}`} p={p} index={i} />
+          <PersonCard
+            key={p.id ?? `${p.name}${i}`}
+            p={p}
+            index={i}
+            onOpen={() => nav.navigate('PersonDetail', { person: p })}
+          />
         ))}
       </View>
     </Screen>

--- a/mobile/src/screens/Pipeline.tsx
+++ b/mobile/src/screens/Pipeline.tsx
@@ -2,11 +2,15 @@
 // tile, company, role, right-aligned fit score, stage chip, next step).
 // Data: GET /dashboard/pipeline/data. The server's status vocabulary
 // (pending | evaluated | added | applied | dismissed) maps onto the design's
-// stage-chip palette in ui/tokens.stageStyle. Deep work (resumes, letters)
-// stays on the desktop by design.
+// stage-chip palette in ui/tokens.stageStyle. The "All" view groups cards
+// by stage so the list reads as a funnel, and every card pushes JobDetail.
+// Deep work (resumes, letters) stays on the desktop by design.
+import { useNavigation } from '@react-navigation/native'
 import { useCallback, useMemo, useState } from 'react'
 import { StyleSheet, Text, View } from 'react-native'
 import { api } from '../api'
+import { Job } from '../lib/store'
+import { PressableScale } from '../ui/detail'
 import {
   Card,
   Chip,
@@ -15,22 +19,11 @@ import {
   LoadingState,
   Screen,
   ScreenTitle,
+  SectionLabel,
   StatusChip,
 } from '../ui/primitives'
 import { fonts, stageStyle, t } from '../ui/tokens'
 import { useDashData } from '../ui/useDashData'
-
-type Job = {
-  id: number
-  company: string
-  role: string
-  status?: string
-  fitment_score?: string | number | null
-  assessed?: boolean
-  assessment_summary?: string
-  decision_notes?: string
-  added_date?: string
-}
 
 const FILTERS = [
   { key: 'all', label: 'All' },
@@ -53,7 +46,56 @@ function nextStep(j: Job): string {
   return 'Awaiting assessment'
 }
 
+// Funnel order for the grouped "All" view — most actionable stages first.
+const STAGE_ORDER = ['applied', 'added', 'evaluated', 'pending', 'dismissed']
+const STAGE_HEADING: Record<string, string> = {
+  applied: 'Applied',
+  added: 'Ready to apply',
+  evaluated: 'Assessed',
+  pending: 'Awaiting assessment',
+  dismissed: 'Dismissed',
+}
+
+function JobCard({ job, onPress }: { job: Job; onPress: () => void }) {
+  const stage = stageStyle[job.status || 'pending'] || stageStyle.pending
+  const score = Number(job.fitment_score) || 0
+  return (
+    <PressableScale onPress={onPress}>
+      <Card style={{ marginTop: 10 }}>
+        <View style={styles.topRow}>
+          <View style={styles.initialTile}>
+            <Text style={styles.initialText}>{(job.company || '?')[0].toUpperCase()}</Text>
+          </View>
+          <View style={{ flex: 1, minWidth: 0 }}>
+            <Text style={styles.company} numberOfLines={1}>
+              {job.company}
+            </Text>
+            <Text style={styles.role} numberOfLines={1}>
+              {job.role}
+            </Text>
+          </View>
+          {score > 0 ? (
+            <View style={{ alignItems: 'flex-end' }}>
+              <Text style={[styles.score, { color: scoreColor(score) }]}>{score}</Text>
+              <Text style={styles.fitLabel}>FIT</Text>
+            </View>
+          ) : (
+            <Text style={styles.unscored}>unscored</Text>
+          )}
+        </View>
+        <View style={styles.bottomRow}>
+          <StatusChip label={stage.label} color={stage.color} bg={stage.bg} />
+          <Text style={styles.next} numberOfLines={1}>
+            {nextStep(job)}
+          </Text>
+        </View>
+      </Card>
+    </PressableScale>
+  )
+}
+
 export default function Pipeline() {
+  const nav = useNavigation<any>()
   const [filter, setFilter] = useState<FilterKey>('all')
   const load = useCallback(
     () => api<{ jobs: Job[] }>('/dashboard/pipeline/data').then((d) => [...(d.jobs || [])].sort((a, b) => b.id - a.id)),
@@ -68,8 +110,20 @@ export default function Pipeline() {
     return jobs
   }, [jobs, filter])
 
+  // Grouped "All" view: sections in funnel order, so the flat stack of
+  // equally-weighted cards reads as stages of one process.
+  const groups = useMemo(() => {
+    if (filter !== 'all') return null
+    return STAGE_ORDER.map((key) => ({
+      key,
+      heading: STAGE_HEADING[key],
+      jobs: shown.filter((j) => (j.status || 'pending') === key),
+    })).filter((g) => g.jobs.length > 0)
+  }, [shown, filter])
+
   const activeCount = jobs?.filter((j) => j.status !== 'dismissed').length ?? 0
   const appliedCount = jobs?.filter((j) => j.status === 'applied').length ?? 0
+  const open = (job: Job) => nav.navigate('JobDetail', { job })
 
   return (
     <Screen refreshing={refreshing} onRefresh={refresh}>
@@ -87,50 +141,28 @@ export default function Pipeline() {
       {error && !jobs ? <ErrorState message={error} onRetry={refresh} /> : null}
       {jobs && shown.length === 0 ? (
         <EmptyState
-          message={
+          message={filter === 'all' ? 'Your pipeline is clear.' : 'Nothing in this stage right now.'}
+          suggestions={
             filter === 'all'
-              ? 'Queue is empty — share a job posting to jobContext to start one.'
-              : 'Nothing in this stage right now.'
+              ? ['Share a job posting from any app to capture it', 'Browse roles your contacts posted about']
+              : undefined
           }
+          actionLabel={filter === 'all' ? 'See who could refer you' : undefined}
+          onAction={filter === 'all' ? () => nav.navigate('People') : undefined}
         />
       ) : null}
 
       <View style={{ marginTop: 6 }}>
-        {shown.map((job) => {
-          const stage = stageStyle[job.status || 'pending'] || stageStyle.pending
-          const score = Number(job.fitment_score) || 0
-          return (
-            <Card key={job.id} style={{ marginTop: 10 }}>
-              <View style={styles.topRow}>
-                <View style={styles.initialTile}>
-                  <Text style={styles.initialText}>{(job.company || '?')[0].toUpperCase()}</Text>
-                </View>
-                <View style={{ flex: 1, minWidth: 0 }}>
-                  <Text style={styles.company} numberOfLines={1}>
-                    {job.company}
-                  </Text>
-                  <Text style={styles.role} numberOfLines={1}>
-                    {job.role}
-                  </Text>
-                </View>
-                {score > 0 ? (
-                  <View style={{ alignItems: 'flex-end' }}>
-                    <Text style={[styles.score, { color: scoreColor(score) }]}>{score}</Text>
-                    <Text style={styles.fitLabel}>FIT</Text>
-                  </View>
-                ) : (
-                  <Text style={styles.unscored}>unscored</Text>
-                )}
+        {groups
+          ? groups.map((g) => (
+              <View key={g.key}>
+                <SectionLabel>{g.heading}</SectionLabel>
+                {g.jobs.map((job) => (
+                  <JobCard key={job.id} job={job} onPress={() => open(job)} />
+                ))}
               </View>
-              <View style={styles.bottomRow}>
-                <StatusChip label={stage.label} color={stage.color} bg={stage.bg} />
-                <Text style={styles.next} numberOfLines={1}>
-                  {nextStep(job)}
-                </Text>
-              </View>
-            </Card>
-          )
-        })}
+            ))
+          : shown.map((job) => <JobCard key={job.id} job={job} onPress={() => open(job)} />)}
       </View>
     </Screen>
   )

--- a/mobile/src/screens/Posts.tsx
+++ b/mobile/src/screens/Posts.tsx
@@ -4,9 +4,11 @@
 // Data: GET /dashboard/posts/data; updates via POST /dashboard/posts/metrics.
 // The design's "Followers" tile has no counterpart in the payload, so the
 // strip shows Comments instead.
+import { useNavigation } from '@react-navigation/native'
 import { useCallback, useState } from 'react'
 import { KeyboardAvoidingView, Modal, Platform, Pressable, StyleSheet, Text, TextInput, View } from 'react-native'
 import { api } from '../api'
+import { PressableScale } from '../ui/detail'
 import {
   Card,
   EmptyState,
@@ -45,6 +47,7 @@ function digitsOnly(v: string): string {
 }
 
 export default function Posts() {
+  const nav = useNavigation<any>()
   const load = useCallback(() => api<Payload>('/dashboard/posts/data'), [])
   const { data, loading, refreshing, error, refresh } = useDashData(load)
 
@@ -98,31 +101,36 @@ export default function Posts() {
           </View>
 
           {data.posts.length === 0 ? (
-            <EmptyState message="No posts logged yet — import your LinkedIn CSV from the desktop app." />
+            <EmptyState
+              message="No posts logged yet."
+              suggestions={['Import your LinkedIn CSV from the desktop app', 'Posting after interviews tends to earn the most engagement']}
+            />
           ) : (
             data.posts.map((p) => (
-              <Card key={p.id} raised style={{ marginTop: 10 }}>
-                <Text style={styles.postText} numberOfLines={4}>
-                  {p.text}
-                </Text>
-                {p.hashtags && p.hashtags.length > 0 ? (
-                  <Text style={styles.tags} numberOfLines={1}>
-                    {p.hashtags.map((h) => (h.startsWith('#') ? h : `#${h}`)).join(' ')}
+              <PressableScale key={p.id} onPress={() => nav.navigate('PostDetail', { post: p })}>
+                <Card raised style={{ marginTop: 10 }}>
+                  <Text style={styles.postText} numberOfLines={4}>
+                    {p.text}
                   </Text>
-                ) : p.posted_date ? (
-                  <Text style={styles.tags}>{p.posted_date.slice(0, 10)}</Text>
-                ) : null}
-                <View style={styles.metricsRow}>
-                  <View style={styles.metrics}>
-                    <Text style={styles.metric}>◎ {fmtK(p.impressions)}</Text>
-                    <Text style={styles.metric}>♥ {fmtK(p.reactions)}</Text>
-                    <Text style={styles.metric}>💬 {fmtK(p.comments)}</Text>
+                  {p.hashtags && p.hashtags.length > 0 ? (
+                    <Text style={styles.tags} numberOfLines={1}>
+                      {p.hashtags.map((h) => (h.startsWith('#') ? h : `#${h}`)).join(' ')}
+                    </Text>
+                  ) : p.posted_date ? (
+                    <Text style={styles.tags}>{p.posted_date.slice(0, 10)}</Text>
+                  ) : null}
+                  <View style={styles.metricsRow}>
+                    <View style={styles.metrics}>
+                      <Text style={styles.metric}>◎ {fmtK(p.impressions)}</Text>
+                      <Text style={styles.metric}>♥ {fmtK(p.reactions)}</Text>
+                      <Text style={styles.metric}>💬 {fmtK(p.comments)}</Text>
+                    </View>
+                    <Pressable style={styles.updateBtn} onPress={() => openSheet(p)}>
+                      <Text style={styles.updateText}>Update</Text>
+                    </Pressable>
                   </View>
-                  <Pressable style={styles.updateBtn} onPress={() => openSheet(p)}>
-                    <Text style={styles.updateText}>Update</Text>
-                  </Pressable>
-                </View>
-              </Card>
+                </Card>
+              </PressableScale>
             ))
           )}
         </>

--- a/mobile/src/screens/Search.tsx
+++ b/mobile/src/screens/Search.tsx
@@ -1,0 +1,349 @@
+// Global search — one box over everything: jobs, companies, people,
+// interviews, posts, check-ins. Grouped results with match highlighting,
+// recent searches, and cross-cutting insights while the box is empty.
+// Word-prefix scoring ("sta fa" finds "State Farm") with substring fallback.
+import { useNavigation } from '@react-navigation/native'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { globalInsights } from '../lib/insights'
+import { Datasets, allCompanies } from '../lib/store'
+import { PressableScale } from '../ui/detail'
+import { EmptyState, ErrorState, LoadingState } from '../ui/primitives'
+import { fonts, t } from '../ui/tokens'
+import { useDatasets } from '../ui/useDatasets'
+
+// Session-scoped recent searches. Deliberately not persisted: search terms
+// can name people/companies and the keychain is reserved for credentials.
+let recentSearches: string[] = []
+
+type Hit = {
+  key: string
+  group: string
+  title: string
+  sub?: string
+  right?: string
+  score: number
+  go: (nav: any) => void
+}
+
+/** Every query word must prefix some word (or substring) of the haystack. */
+function matchScore(query: string, haystack: string): number {
+  const hay = haystack.toLowerCase()
+  const words = query.toLowerCase().split(/\s+/).filter(Boolean)
+  if (!words.length) return 0
+  let score = 0
+  for (const w of words) {
+    const idx = hay.indexOf(w)
+    if (idx === -1) return 0
+    // Word-boundary hits beat mid-word hits; early hits beat late ones.
+    score += (idx === 0 || /[\s·,.-]/.test(hay[idx - 1] || '') ? 2 : 1) + 1 / (idx + 1)
+  }
+  return score
+}
+
+function buildHits(ds: Datasets, q: string): Hit[] {
+  const hits: Hit[] = []
+  const add = (h: Omit<Hit, 'score'>, haystack: string) => {
+    const score = matchScore(q, haystack)
+    if (score > 0) hits.push({ ...h, score })
+  }
+
+  allCompanies(ds).forEach((name) =>
+    add(
+      {
+        key: `co:${name}`,
+        group: 'Companies',
+        title: name,
+        go: (nav) => nav.push('CompanyDetail', { name }),
+      },
+      name,
+    ),
+  )
+  ds.jobs.forEach((j) =>
+    add(
+      {
+        key: `job:${j.id}`,
+        group: 'Jobs',
+        title: j.role || 'Untitled role',
+        sub: j.company,
+        right: Number(j.fitment_score) ? `${Number(j.fitment_score)} FIT` : undefined,
+        go: (nav) => nav.push('JobDetail', { job: j }),
+      },
+      `${j.role} ${j.company} ${j.status}`,
+    ),
+  )
+  ds.people.forEach((p) =>
+    add(
+      {
+        key: `p:${p.id}`,
+        group: 'People',
+        title: p.name,
+        sub: [p.relationship, p.company].filter(Boolean).join(' · '),
+        go: (nav) => nav.push('PersonDetail', { person: p }),
+      },
+      `${p.name} ${p.company} ${p.relationship} ${p.context} ${p.notes}`,
+    ),
+  )
+  ds.interviews.forEach((iv, i) =>
+    add(
+      {
+        key: `iv:${iv.id ?? i}`,
+        group: 'Interviews',
+        title: [iv.company, (iv.interview_type || '').replace(/_/g, ' ')].filter(Boolean).join(' · '),
+        sub: iv.upcoming ? 'upcoming' : 'debriefed',
+        right: (iv.interview_date || '').slice(0, 10),
+        go: (nav) => nav.push('InterviewDetail', { interview: iv }),
+      },
+      `${iv.company} ${iv.role} ${iv.interview_type} ${iv.interviewer}`,
+    ),
+  )
+  ds.posts.forEach((p) =>
+    add(
+      {
+        key: `post:${p.id}`,
+        group: 'Posts',
+        title: p.title || p.text.slice(0, 60),
+        sub: (p.posted_date || '').slice(0, 10),
+        go: (nav) => nav.push('PostDetail', { post: p }),
+      },
+      `${p.title} ${p.text} ${(p.hashtags || []).join(' ')}`,
+    ),
+  )
+  ds.checkins.forEach((c, i) =>
+    add(
+      {
+        key: `ci:${c.date}${i}`,
+        group: 'Wellbeing',
+        title: `${c.mood || 'Check-in'} · ${c.date.slice(0, 10)}`,
+        sub: c.notes?.slice(0, 80),
+        go: (nav) => nav.push('CheckinDetail', { entry: c }),
+      },
+      `${c.mood} ${c.notes} ${c.date}`,
+    ),
+  )
+  return hits.sort((a, b) => b.score - a.score)
+}
+
+/** Bold the query-word matches inside a result line. */
+function Highlight({ text, query, style }: { text: string; query: string; style: any }) {
+  const words = query.toLowerCase().split(/\s+/).filter(Boolean)
+  if (!words.length) return <Text style={style}>{text}</Text>
+  const escaped = words.map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+  const splitter = new RegExp(`(${escaped.join('|')})`, 'ig')
+  // Separate anchored tester — reusing the /g splitter for .test() would
+  // carry lastIndex state between parts and mis-highlight.
+  const tester = new RegExp(`^(?:${escaped.join('|')})$`, 'i')
+  const parts = text.split(splitter)
+  return (
+    <Text style={style} numberOfLines={1}>
+      {parts.map((part, i) =>
+        tester.test(part) ? (
+          <Text key={i} style={{ color: t.cyanBright, fontWeight: '700' }}>
+            {part}
+          </Text>
+        ) : (
+          part
+        ),
+      )}
+    </Text>
+  )
+}
+
+const GROUP_ORDER = ['Companies', 'Jobs', 'People', 'Interviews', 'Posts', 'Wellbeing']
+
+export default function Search({ route }: any) {
+  const nav = useNavigation<any>()
+  const insets = useSafeAreaInsets()
+  const [query, setQuery] = useState<string>(route.params?.initialQuery || '')
+  const { data: ds, loading, error, refresh } = useDatasets()
+  const inputRef = useRef<TextInput>(null)
+  useEffect(() => {
+    const timer = setTimeout(() => inputRef.current?.focus(), 350) // after push animation
+    return () => clearTimeout(timer)
+  }, [])
+
+  const hits = useMemo(() => (ds && query.trim() ? buildHits(ds, query.trim()) : []), [ds, query])
+  const grouped = useMemo(() => {
+    const map = new Map<string, Hit[]>()
+    hits.forEach((h) => {
+      if (!map.has(h.group)) map.set(h.group, [])
+      map.get(h.group)!.push(h)
+    })
+    return GROUP_ORDER.filter((g) => map.has(g)).map((g) => ({ group: g, hits: map.get(g)!.slice(0, 5) }))
+  }, [hits])
+
+  const commit = (h: Hit) => {
+    const q = query.trim()
+    if (q) recentSearches = [q, ...recentSearches.filter((r) => r !== q)].slice(0, 8)
+    h.go(nav)
+  }
+
+  return (
+    <View style={[styles.root, { paddingTop: insets.top + 8 }]}>
+      <View style={styles.searchRow}>
+        <Pressable onPress={() => nav.goBack()} hitSlop={12} style={styles.backBtn}>
+          <Text style={styles.backText}>‹</Text>
+        </Pressable>
+        <TextInput
+          ref={inputRef}
+          style={styles.input}
+          value={query}
+          onChangeText={setQuery}
+          placeholder="Search jobs, people, companies, notes…"
+          placeholderTextColor={t.faint}
+          autoCapitalize="none"
+          autoCorrect={false}
+          returnKeyType="search"
+        />
+        {query ? (
+          <Pressable onPress={() => setQuery('')} hitSlop={10}>
+            <Text style={styles.clear}>×</Text>
+          </Pressable>
+        ) : null}
+      </View>
+
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{ paddingHorizontal: 18, paddingBottom: 28 }}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        {loading && !ds ? <LoadingState /> : null}
+        {error && !ds ? <ErrorState message={error} onRetry={refresh} /> : null}
+
+        {ds && !query.trim() ? (
+          <>
+            {recentSearches.length ? (
+              <>
+                <Text style={styles.section}>RECENT</Text>
+                <View style={styles.recentWrap}>
+                  {recentSearches.map((r) => (
+                    <Pressable key={r} onPress={() => setQuery(r)} style={styles.recentChip}>
+                      <Text style={styles.recentText}>{r}</Text>
+                    </Pressable>
+                  ))}
+                </View>
+              </>
+            ) : null}
+            {globalInsights(ds).length ? (
+              <>
+                <Text style={styles.section}>WHILE YOU'RE HERE</Text>
+                {globalInsights(ds).map((s) => (
+                  <View key={s} style={styles.insightCard}>
+                    <Text style={styles.insightText}>{s}</Text>
+                  </View>
+                ))}
+              </>
+            ) : null}
+            <Text style={styles.hint}>
+              One search covers your whole search: pipeline, contacts, interviews, posts, and journal.
+            </Text>
+          </>
+        ) : null}
+
+        {ds && query.trim() && !hits.length ? (
+          <EmptyState
+            message={`No matches for “${query.trim()}”.`}
+            suggestions={['Try fewer words', 'Company names and people work best']}
+          />
+        ) : null}
+
+        {grouped.map(({ group, hits: rows }) => (
+          <View key={group}>
+            <Text style={styles.section}>{group.toUpperCase()}</Text>
+            {rows.map((h) => (
+              <PressableScale key={h.key} onPress={() => commit(h)} style={styles.hitRow}>
+                <View style={{ flex: 1, minWidth: 0 }}>
+                  <Highlight text={h.title} query={query} style={styles.hitTitle} />
+                  {h.sub ? <Highlight text={h.sub} query={query} style={styles.hitSub} /> : null}
+                </View>
+                {h.right ? <Text style={styles.hitRight}>{h.right}</Text> : null}
+                <Text style={styles.hitArrow}>›</Text>
+              </PressableScale>
+            ))}
+          </View>
+        ))}
+      </ScrollView>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1, backgroundColor: t.bg },
+  searchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    paddingHorizontal: 18,
+    paddingBottom: 12,
+  },
+  backBtn: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: t.chipBg,
+    borderWidth: 1,
+    borderColor: t.cardBorder,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  backText: { color: t.textBright, fontSize: 22, lineHeight: 24, fontWeight: '600' },
+  input: {
+    flex: 1,
+    borderRadius: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    backgroundColor: t.chipBg,
+    borderWidth: 1,
+    borderColor: t.tintBorder,
+    fontSize: 15,
+    color: t.text,
+  },
+  clear: { color: t.muted, fontSize: 22, paddingHorizontal: 4 },
+  section: {
+    fontSize: 11.5,
+    fontWeight: '600',
+    letterSpacing: 1.2,
+    color: t.muted2,
+    fontFamily: fonts.mono,
+    marginTop: 20,
+    marginBottom: 4,
+  },
+  recentWrap: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginTop: 6 },
+  recentChip: {
+    backgroundColor: t.chipBg,
+    borderRadius: 999,
+    paddingHorizontal: 13,
+    paddingVertical: 7,
+    borderWidth: 1,
+    borderColor: t.cardBorder,
+  },
+  recentText: { color: t.textSecondary, fontSize: 12.5 },
+  insightCard: {
+    marginTop: 8,
+    borderRadius: 14,
+    padding: 13,
+    backgroundColor: t.tintFillLo,
+    borderWidth: 1,
+    borderColor: t.tintBorderLo,
+  },
+  insightText: { color: t.textBody, fontSize: 13, lineHeight: 18.5 },
+  hint: { color: t.faint, fontSize: 12.5, lineHeight: 18, marginTop: 24, textAlign: 'center', paddingHorizontal: 20 },
+  hitRow: {
+    marginTop: 8,
+    borderRadius: 14,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    backgroundColor: t.card,
+    borderWidth: 1,
+    borderColor: t.cardBorder,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  hitTitle: { fontSize: 14, fontWeight: '600', color: t.text },
+  hitSub: { fontSize: 12, color: t.muted, marginTop: 1 },
+  hitRight: { fontSize: 10.5, color: t.cyanBright, fontFamily: fonts.mono, fontWeight: '600' },
+  hitArrow: { fontSize: 16, color: t.muted2 },
+})

--- a/mobile/src/screens/Timeline.tsx
+++ b/mobile/src/screens/Timeline.tsx
@@ -1,0 +1,219 @@
+// Global timeline — one chronological feed of the whole search: sync
+// journal events, interviews, applications, posts, and check-ins, with
+// type filters. Every row navigates to its detail page.
+import { useNavigation } from '@react-navigation/native'
+import { useMemo, useState } from 'react'
+import { ScrollView, StyleSheet, Text, View } from 'react-native'
+import { Datasets } from '../lib/store'
+import { PressableScale } from '../ui/detail'
+import { Chip, EmptyState, ErrorState, LoadingState } from '../ui/primitives'
+import { fonts, t } from '../ui/tokens'
+import { useDatasets } from '../ui/useDatasets'
+
+type Item = {
+  key: string
+  ts: string // ISO-ish, used for ordering + display
+  kind: 'activity' | 'job' | 'interview' | 'post' | 'checkin'
+  icon: string
+  title: string
+  sub?: string
+  go?: (nav: any) => void
+}
+
+const FILTERS = [
+  { key: 'all', label: 'All' },
+  { key: 'job', label: 'Jobs' },
+  { key: 'interview', label: 'Interviews' },
+  { key: 'post', label: 'Posts' },
+  { key: 'checkin', label: 'Wellbeing' },
+  { key: 'activity', label: 'Activity' },
+] as const
+type FilterKey = (typeof FILTERS)[number]['key']
+
+function buildItems(ds: Datasets): Item[] {
+  const items: Item[] = []
+  ds.events.forEach((e) =>
+    items.push({
+      key: `ev${e.id}`,
+      ts: e.ts || '',
+      kind: 'activity',
+      icon: '·',
+      title: e.title,
+      sub: e.subtitle,
+      go: e.company ? (nav) => nav.push('CompanyDetail', { name: e.company }) : undefined,
+    }),
+  )
+  ds.jobs.forEach((j) => {
+    if (!j.added_date) return
+    items.push({
+      key: `job${j.id}`,
+      ts: j.added_date,
+      kind: 'job',
+      icon: '▸',
+      title: `Captured ${j.role} at ${j.company}`,
+      sub: j.status,
+      go: (nav) => nav.push('JobDetail', { job: j }),
+    })
+  })
+  ds.interviews.forEach((iv, i) => {
+    if (!iv.interview_date) return
+    items.push({
+      key: `iv${iv.id ?? i}`,
+      ts: iv.interview_date,
+      kind: 'interview',
+      icon: '◆',
+      title: `${(iv.interview_type || 'Interview').replace(/_/g, ' ')} · ${iv.company}`,
+      sub: iv.upcoming ? 'upcoming' : 'debriefed',
+      go: (nav) => nav.push('InterviewDetail', { interview: iv }),
+    })
+  })
+  ds.posts.forEach((p) => {
+    if (!p.posted_date) return
+    items.push({
+      key: `post${p.id}`,
+      ts: p.posted_date,
+      kind: 'post',
+      icon: '◎',
+      title: p.title || p.text.slice(0, 60),
+      sub: 'LinkedIn post',
+      go: (nav) => nav.push('PostDetail', { post: p }),
+    })
+  })
+  ds.checkins.forEach((c, i) =>
+    items.push({
+      key: `ci${c.date}${i}`,
+      ts: c.date,
+      kind: 'checkin',
+      icon: '♥',
+      title: `Check-in · ${c.mood || '—'}`,
+      sub: typeof c.energy === 'number' ? `energy ${c.energy}/10` : undefined,
+      go: (nav) => nav.push('CheckinDetail', { entry: c }),
+    }),
+  )
+  return items.filter((i) => i.ts).sort((a, b) => b.ts.localeCompare(a.ts))
+}
+
+const KIND_COLOR: Record<Item['kind'], string> = {
+  activity: t.muted,
+  job: t.cyanBright,
+  interview: t.amber,
+  post: t.green,
+  checkin: '#C7A9E8',
+}
+
+// Rendered under a native stack header, so no manual safe-area inset.
+export default function Timeline() {
+  const nav = useNavigation<any>()
+  const [filter, setFilter] = useState<FilterKey>('all')
+  const { data: ds, loading, refreshing, error, refresh } = useDatasets()
+
+  const items = useMemo(() => (ds ? buildItems(ds) : []), [ds])
+  const shown = useMemo(
+    () => (filter === 'all' ? items : items.filter((i) => i.kind === filter)).slice(0, 120),
+    [items, filter],
+  )
+
+  // Month headers ("JULY 2026") between groups.
+  const withHeaders = useMemo(() => {
+    const out: (Item | { header: string; key: string })[] = []
+    let last = ''
+    for (const it of shown) {
+      const m = it.ts.slice(0, 7)
+      if (m !== last) {
+        last = m
+        const [y, mo] = m.split('-')
+        const months = ['JANUARY','FEBRUARY','MARCH','APRIL','MAY','JUNE','JULY','AUGUST','SEPTEMBER','OCTOBER','NOVEMBER','DECEMBER']
+        out.push({ header: `${months[Number(mo) - 1] || m} ${y}`, key: `h${m}` })
+      }
+      out.push(it)
+    }
+    return out
+  }, [shown])
+
+  return (
+    <View style={styles.root}>
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{ paddingHorizontal: 18, paddingBottom: 28, paddingTop: 10 }}
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={styles.chipRow}>
+          {FILTERS.map((f) => (
+            <Chip key={f.key} label={f.label} active={filter === f.key} onPress={() => setFilter(f.key)} />
+          ))}
+        </View>
+
+        {loading && !ds ? <LoadingState /> : null}
+        {error && !ds ? <ErrorState message={error} onRetry={refresh} /> : null}
+        {ds && !shown.length ? (
+          <EmptyState
+            message="Nothing here yet."
+            suggestions={['Share a job posting to start the pipeline', 'Log a check-in from Wellbeing']}
+            actionLabel="Go to Wellbeing"
+            onAction={() => nav.navigate('Tabs', { screen: 'Wellbeing' })}
+          />
+        ) : null}
+
+        {withHeaders.map((row) =>
+          'header' in row ? (
+            <Text key={row.key} style={styles.monthHeader}>
+              {row.header}
+            </Text>
+          ) : (
+            <PressableScale
+              key={row.key}
+              onPress={row.go ? () => row.go!(nav) : undefined}
+              disabled={!row.go}
+              style={styles.row}
+            >
+              <Text style={[styles.icon, { color: KIND_COLOR[row.kind] }]}>{row.icon}</Text>
+              <View style={{ flex: 1, minWidth: 0 }}>
+                <Text style={styles.title} numberOfLines={1}>
+                  {row.title}
+                </Text>
+                {row.sub ? (
+                  <Text style={styles.sub} numberOfLines={1}>
+                    {row.sub}
+                  </Text>
+                ) : null}
+              </View>
+              <Text style={styles.ts}>{row.ts.slice(5, 10)}</Text>
+              {row.go ? <Text style={styles.arrow}>›</Text> : null}
+            </PressableScale>
+          ),
+        )}
+      </ScrollView>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1, backgroundColor: t.bg },
+  chipRow: { flexDirection: 'row', gap: 8, flexWrap: 'wrap' },
+  monthHeader: {
+    fontSize: 11,
+    fontWeight: '600',
+    letterSpacing: 1.4,
+    color: t.muted2,
+    fontFamily: fonts.mono,
+    marginTop: 20,
+    marginBottom: 2,
+  },
+  row: {
+    marginTop: 8,
+    borderRadius: 14,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    backgroundColor: t.card,
+    borderWidth: 1,
+    borderColor: t.cardBorder,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 11,
+  },
+  icon: { fontSize: 14, width: 16, textAlign: 'center' },
+  title: { fontSize: 13.5, fontWeight: '600', color: t.textBright },
+  sub: { fontSize: 11.5, color: t.muted, marginTop: 1, textTransform: 'capitalize' },
+  ts: { fontSize: 10.5, color: t.faint, fontFamily: fonts.mono },
+  arrow: { fontSize: 15, color: t.muted2 },
+})

--- a/mobile/src/screens/Wellbeing.tsx
+++ b/mobile/src/screens/Wellbeing.tsx
@@ -5,9 +5,11 @@
 //                                           when no ring data exists)
 // The check-in form POSTs /dashboard/health/checkin (the same tool the web
 // and MCP clients use), so all three surfaces write identical entries.
+import { useNavigation } from '@react-navigation/native'
 import { useCallback, useState } from 'react'
 import { Pressable, StyleSheet, Switch, Text, TextInput, View } from 'react-native'
 import { api, logCheckin } from '../api'
+import { PressableScale } from '../ui/detail'
 import {
   Card,
   EmptyState,
@@ -127,6 +129,7 @@ function CheckinForm({ onSaved }: { onSaved: () => void }) {
 }
 
 export default function Wellbeing() {
+  const nav = useNavigation<any>()
   const load = useCallback(async (): Promise<Bundle> => {
     const health = await api<HealthPayload>('/dashboard/health/data')
     // Readiness is a bonus — older servers / no ring just omit the card.
@@ -198,26 +201,28 @@ export default function Wellbeing() {
             <EmptyState message="No check-ins yet — use the form above and your trends appear here." />
           ) : (
             data.health.recent.slice(0, 10).map((e, i) => (
-              <Card key={e.date + i} style={styles.entryCard}>
-                <View style={styles.entryTop}>
-                  <Text style={styles.entryMood}>{e.mood || '—'}</Text>
-                  <Text style={styles.entryDate}>{e.date?.slice(0, 10)}</Text>
-                </View>
-                {typeof e.energy === 'number' ? (
-                  <View style={styles.meterRow}>
-                    <Text style={styles.meterLabel}>ENERGY</Text>
-                    <View style={styles.meterTrack}>
-                      <View style={[styles.meterFill, { width: `${Math.min(e.energy, 10) * 10}%` }]} />
-                    </View>
-                    <Text style={styles.meterVal}>{e.energy}/10</Text>
+              <PressableScale key={e.date + i} onPress={() => nav.navigate('CheckinDetail', { entry: e })}>
+                <Card style={styles.entryCard}>
+                  <View style={styles.entryTop}>
+                    <Text style={styles.entryMood}>{e.mood || '—'}</Text>
+                    <Text style={styles.entryDate}>{e.date?.slice(0, 10)}</Text>
                   </View>
-                ) : null}
-                {e.notes ? (
-                  <Text style={styles.entryNotes} numberOfLines={2}>
-                    {e.notes}
-                  </Text>
-                ) : null}
-              </Card>
+                  {typeof e.energy === 'number' ? (
+                    <View style={styles.meterRow}>
+                      <Text style={styles.meterLabel}>ENERGY</Text>
+                      <View style={styles.meterTrack}>
+                        <View style={[styles.meterFill, { width: `${Math.min(e.energy, 10) * 10}%` }]} />
+                      </View>
+                      <Text style={styles.meterVal}>{e.energy}/10</Text>
+                    </View>
+                  ) : null}
+                  {e.notes ? (
+                    <Text style={styles.entryNotes} numberOfLines={2}>
+                      {e.notes}
+                    </Text>
+                  ) : null}
+                </Card>
+              </PressableScale>
             ))
           )}
         </>

--- a/mobile/src/screens/detail/CheckinDetail.tsx
+++ b/mobile/src/screens/detail/CheckinDetail.tsx
@@ -1,0 +1,98 @@
+// Wellbeing check-in detail — one entry with its journal text in full,
+// energy vs your recent average, and the surrounding week's trend.
+import { useNavigation } from '@react-navigation/native'
+import { Text, View } from 'react-native'
+import { checkinSummary } from '../../lib/insights'
+import { Checkin } from '../../lib/store'
+import { ActionRow, DetailShell, MetaGrid, Meter, Section, SummaryBlock } from '../../ui/detail'
+import { ErrorState, LoadingState } from '../../ui/primitives'
+import { fonts, t } from '../../ui/tokens'
+import { useDatasets } from '../../ui/useDatasets'
+
+export default function CheckinDetail({ route }: any) {
+  const entry: Checkin = route.params.entry
+  const nav = useNavigation<any>()
+  const { data: ds, loading, refreshing, error, refresh } = useDatasets()
+
+  // The week around this entry, oldest first, for the mini trend.
+  const idx = ds?.checkins.findIndex((c) => c.date === entry.date) ?? -1
+  const week = idx >= 0 ? ds!.checkins.slice(idx, idx + 7).reverse() : []
+  const energies = (ds?.checkins || []).map((c) => c.energy || 0).filter((e) => e > 0)
+  const avg = energies.length ? energies.reduce((a, b) => a + b, 0) / energies.length : 0
+
+  return (
+    <DetailShell
+      kicker="Check-in"
+      title={(entry.mood || 'Check-in').replace(/^\w/, (c) => c.toUpperCase())}
+      subtitle={(entry.date || '').slice(0, 10)}
+      shareText={`Check-in ${entry.date?.slice(0, 10)}: ${entry.mood || ''}${entry.energy ? `, energy ${entry.energy}/10` : ''}`}
+      refreshing={refreshing}
+      onRefresh={refresh}
+    >
+      {loading && !ds ? <LoadingState /> : null}
+      {error && !ds ? <ErrorState message={error} onRetry={refresh} /> : null}
+
+      {ds ? <SummaryBlock sentences={checkinSummary(entry, ds)} /> : null}
+
+      <Section label="Levels">
+        <View style={card}>
+          {typeof entry.energy === 'number' ? <Meter label="Energy" value={entry.energy} /> : null}
+          {avg > 0 ? <Meter label="Your average" value={Number(avg.toFixed(1))} /> : null}
+        </View>
+      </Section>
+
+      {entry.notes ? (
+        <Section label="Journal">
+          <View style={card}>
+            <Text style={{ color: t.textBody, fontSize: 13.5, lineHeight: 20 }}>{entry.notes}</Text>
+          </View>
+        </Section>
+      ) : null}
+
+      <Section label="Details" initiallyOpen={false}>
+        <MetaGrid
+          rows={[
+            { label: 'Date', value: (entry.date || '').slice(0, 10) },
+            { label: 'Mood', value: entry.mood },
+            { label: 'Productive', value: entry.productive == null ? undefined : entry.productive ? 'Yes' : 'No' },
+          ]}
+        />
+      </Section>
+
+      {week.length > 1 ? (
+        <Section label="That week">
+          <View style={[card, { flexDirection: 'row', alignItems: 'flex-end', gap: 8, height: 110 }]}>
+            {week.map((c, i) => (
+              <View key={c.date + i} style={{ flex: 1, alignItems: 'center', justifyContent: 'flex-end', gap: 6 }}>
+                <View
+                  style={{
+                    width: '100%',
+                    borderRadius: 6,
+                    height: Math.max(6, ((c.energy || 0) / 10) * 64),
+                    backgroundColor: c.date === entry.date ? t.cyan : 'rgba(0,181,200,.35)',
+                  }}
+                />
+                <Text style={{ fontSize: 9, color: t.faint, fontFamily: fonts.mono }}>{c.date.slice(5, 10)}</Text>
+              </View>
+            ))}
+          </View>
+        </Section>
+      ) : null}
+
+      <Section label="Quick actions">
+        <ActionRow
+          actions={[{ label: 'New check-in', onPress: () => nav.navigate('Tabs', { screen: 'Wellbeing' }), primary: true }]}
+        />
+      </Section>
+    </DetailShell>
+  )
+}
+
+const card = {
+  marginTop: 10,
+  borderRadius: 16,
+  borderWidth: 1,
+  borderColor: t.cardBorder,
+  backgroundColor: t.card,
+  padding: 15,
+} as const

--- a/mobile/src/screens/detail/CompanyDetail.tsx
+++ b/mobile/src/screens/detail/CompanyDetail.tsx
@@ -1,0 +1,123 @@
+// Company detail — companies become first-class objects, assembled
+// client-side by joining jobs, interviews, people, and events on the
+// company name. Reached from any card that mentions a company.
+import { useNavigation } from '@react-navigation/native'
+import { Text, View } from 'react-native'
+import { companySummary } from '../../lib/insights'
+import { companyBundle } from '../../lib/store'
+import {
+  ActionRow,
+  DetailShell,
+  RelatedRow,
+  Section,
+  SummaryBlock,
+  TimelineList,
+} from '../../ui/detail'
+import { EmptyState, ErrorState, LoadingState, StatTile } from '../../ui/primitives'
+import { stageStyle, t } from '../../ui/tokens'
+import { useDatasets } from '../../ui/useDatasets'
+
+export default function CompanyDetail({ route }: any) {
+  const name: string = route.params.name
+  const nav = useNavigation<any>()
+  const { data: ds, loading, refreshing, error, refresh } = useDatasets()
+
+  const co = ds ? companyBundle(ds, name) : null
+  const upcoming = co?.interviews.filter((i) => i.upcoming) || []
+
+  return (
+    <DetailShell
+      kicker="Company"
+      title={name}
+      subtitle={
+        co
+          ? `${co.jobs.length} jobs · ${co.interviews.length} interviews · ${co.people.length} contacts`
+          : undefined
+      }
+      shareText={`${name} — tracked in jobContext`}
+      refreshing={refreshing}
+      onRefresh={refresh}
+    >
+      {loading && !ds ? <LoadingState /> : null}
+      {error && !ds ? <ErrorState message={error} onRetry={refresh} /> : null}
+
+      {co ? (
+        <>
+          <SummaryBlock sentences={companySummary(co)} />
+
+          <View style={{ flexDirection: 'row', gap: 10, marginTop: 18 }}>
+            <StatTile value={co.jobs.length} label="Jobs" />
+            <StatTile value={co.interviews.length} label="Interviews" accent={upcoming.length > 0} />
+            <StatTile value={co.people.length} label="Contacts" />
+          </View>
+
+          {co.jobs.length ? (
+            <Section label="Open jobs" count={co.jobs.length}>
+              {co.jobs.map((j) => (
+                <RelatedRow
+                  key={j.id}
+                  title={j.role}
+                  sub={(stageStyle[(j.status || 'pending').toLowerCase()] || stageStyle.pending).label}
+                  right={Number(j.fitment_score) ? `${Number(j.fitment_score)} FIT` : undefined}
+                  onPress={() => nav.push('JobDetail', { job: j })}
+                />
+              ))}
+            </Section>
+          ) : null}
+
+          {co.interviews.length ? (
+            <Section label="Interviews" count={co.interviews.length}>
+              {co.interviews.map((iv, i) => (
+                <RelatedRow
+                  key={iv.id ?? i}
+                  title={(iv.interview_type || 'interview').replace(/_/g, ' ')}
+                  sub={iv.upcoming ? 'upcoming' : iv.interviewer ? `with ${iv.interviewer}` : 'debriefed'}
+                  right={(iv.interview_date || '').slice(0, 10)}
+                  onPress={() => nav.push('InterviewDetail', { interview: iv })}
+                />
+              ))}
+            </Section>
+          ) : null}
+
+          {co.people.length ? (
+            <Section label="People" count={co.people.length}>
+              {co.people.map((p) => (
+                <RelatedRow
+                  key={p.id}
+                  title={p.name}
+                  sub={p.relationship}
+                  right={(p.outreach_status || '').toUpperCase() || undefined}
+                  onPress={() => nav.push('PersonDetail', { person: p })}
+                />
+              ))}
+            </Section>
+          ) : null}
+
+          {co.events.length ? (
+            <Section label="Timeline" count={co.events.length} initiallyOpen={false}>
+              <TimelineList
+                items={co.events.slice(0, 12).map((e) => ({ title: e.title, sub: e.subtitle, ts: e.ts }))}
+              />
+            </Section>
+          ) : null}
+
+          {!co.jobs.length && !co.interviews.length && !co.people.length ? (
+            <EmptyState
+              message={`Nothing tracked for ${name} yet.`}
+              suggestions={['Share a job posting from this company', 'Add a contact from the desktop']}
+            />
+          ) : null}
+
+          <Section label="Quick actions">
+            <ActionRow
+              actions={[
+                { label: 'Search everything', onPress: () => nav.push('Search', { initialQuery: name }), primary: true },
+                { label: 'Pipeline', onPress: () => nav.navigate('Tabs', { screen: 'Pipeline' }) },
+              ]}
+            />
+          </Section>
+        </>
+      ) : null}
+    </DetailShell>
+  )
+}

--- a/mobile/src/screens/detail/InterviewDetail.tsx
+++ b/mobile/src/screens/detail/InterviewDetail.tsx
@@ -1,0 +1,180 @@
+// Interview detail — overview, self-score, what landed / what didn't,
+// verbatim quotes from the debrief, and the interview arc at this company.
+import { useNavigation } from '@react-navigation/native'
+import { Text, View } from 'react-native'
+import { interviewSummary } from '../../lib/insights'
+import { Interview, companyBundle, normName } from '../../lib/store'
+import { countdownChip, interviewTimeLine } from '../../ui/format'
+import {
+  ActionRow,
+  Bullets,
+  DetailShell,
+  MetaGrid,
+  Meter,
+  RelatedRow,
+  Section,
+  SummaryBlock,
+  TimelineList,
+} from '../../ui/detail'
+import { ErrorState, LoadingState } from '../../ui/primitives'
+import { fonts, t } from '../../ui/tokens'
+import { useDatasets } from '../../ui/useDatasets'
+
+function sameInterview(a: Interview, b: Interview): boolean {
+  if (a.id != null && b.id != null) return a.id === b.id
+  return normName(a.company) === normName(b.company) && a.interview_date === b.interview_date
+}
+
+export default function InterviewDetail({ route }: any) {
+  const seed: Interview = route.params.interview
+  const nav = useNavigation<any>()
+  const { data: ds, loading, refreshing, error, refresh } = useDatasets()
+
+  const iv = ds?.interviews.find((i) => sameInterview(i, seed)) || seed
+  const co = ds && iv.company ? companyBundle(ds, iv.company) : null
+  const type = (iv.interview_type || 'interview').replace(/_/g, ' ')
+  const others = (co?.interviews || []).filter((i) => !sameInterview(i, iv))
+  const arc = co
+    ? [...co.interviews].sort((a, b) => (a.interview_date || '').localeCompare(b.interview_date || ''))
+    : []
+
+  const quotes = (iv.verbatim_quotes || [])
+    .map((q) => (typeof q === 'string' ? { quote: q } : q))
+    .filter((q) => (q.quote || '').trim())
+
+  return (
+    <DetailShell
+      kicker={iv.upcoming ? 'Upcoming interview' : 'Interview debrief'}
+      title={[iv.company, type].filter(Boolean).join(' · ')}
+      subtitle={iv.role}
+      shareText={`${type} at ${iv.company}${iv.interview_date ? ` on ${iv.interview_date.slice(0, 10)}` : ''}`}
+      refreshing={refreshing}
+      onRefresh={refresh}
+    >
+      {iv.upcoming && iv.interview_date ? (
+        <Text style={{ color: t.cyanBright, fontFamily: fonts.mono, fontWeight: '600', fontSize: 12, marginTop: 10 }}>
+          {countdownChip(iv.interview_date)}
+        </Text>
+      ) : null}
+
+      {loading && !ds ? <LoadingState /> : null}
+      {error && !ds ? <ErrorState message={error} onRetry={refresh} /> : null}
+
+      {ds ? <SummaryBlock sentences={interviewSummary(iv, ds)} /> : null}
+
+      <Section label="Overview">
+        <MetaGrid
+          rows={[
+            { label: 'Company', value: iv.company },
+            { label: 'Role', value: iv.role },
+            { label: 'Type', value: type },
+            { label: 'When', value: interviewTimeLine(iv) || (iv.interview_date || '').slice(0, 10) },
+            {
+              label: 'Interviewer',
+              value: iv.interviewer ? `${iv.interviewer}${iv.interviewer_role ? ` · ${iv.interviewer_role}` : ''}` : undefined,
+            },
+          ]}
+        />
+      </Section>
+
+      {iv.self_rating != null ? (
+        <Section label="Score">
+          <View style={card}>
+            <Meter label="Self-rating" value={iv.self_rating} />
+          </View>
+        </Section>
+      ) : null}
+
+      {iv.what_landed?.length ? (
+        <Section label="What landed" count={iv.what_landed.length}>
+          <Bullets items={iv.what_landed} color={t.green} />
+        </Section>
+      ) : null}
+
+      {iv.what_didnt?.length ? (
+        <Section label="What didn't" count={iv.what_didnt.length}>
+          <Bullets items={iv.what_didnt} color={t.amber} />
+        </Section>
+      ) : null}
+
+      {quotes.length ? (
+        <Section label="Verbatim" count={quotes.length} initiallyOpen={false}>
+          {quotes.map((q, i) => (
+            <View key={i} style={[card, { borderLeftWidth: 3, borderLeftColor: t.cyan }]}>
+              <Text style={{ color: t.textBody, fontSize: 13.5, lineHeight: 20, fontStyle: 'italic' }}>
+                “{q.quote}”
+              </Text>
+              {q.speaker ? (
+                <Text style={{ color: t.faint, fontSize: 11.5, marginTop: 6 }}>— {q.speaker}</Text>
+              ) : null}
+            </View>
+          ))}
+        </Section>
+      ) : null}
+
+      {arc.length > 1 ? (
+        <Section label="Interview arc" count={arc.length}>
+          <TimelineList
+            items={arc.map((i) => ({
+              title: (i.interview_type || 'interview').replace(/_/g, ' '),
+              sub: sameInterview(i, iv) ? 'This interview' : i.interviewer ? `with ${i.interviewer}` : undefined,
+              ts: i.interview_date,
+              color: sameInterview(i, iv) ? t.cyanBright : i.upcoming ? t.amber : t.cyan,
+            }))}
+          />
+        </Section>
+      ) : null}
+
+      {others.length || co?.jobs.length || co?.people.length ? (
+        <Section label="Related" initiallyOpen={false}>
+          {others.slice(0, 3).map((i, idx) => (
+            <RelatedRow
+              key={`iv${i.id ?? idx}`}
+              title={(i.interview_type || 'interview').replace(/_/g, ' ')}
+              sub={i.upcoming ? 'upcoming' : 'debriefed'}
+              right={(i.interview_date || '').slice(0, 10)}
+              onPress={() => nav.push('InterviewDetail', { interview: i })}
+            />
+          ))}
+          {(co?.jobs || []).slice(0, 3).map((j) => (
+            <RelatedRow
+              key={`j${j.id}`}
+              title={j.role}
+              sub={j.status}
+              right={Number(j.fitment_score) ? `${Number(j.fitment_score)} FIT` : undefined}
+              onPress={() => nav.push('JobDetail', { job: j })}
+            />
+          ))}
+          {(co?.people || []).slice(0, 3).map((p) => (
+            <RelatedRow
+              key={`p${p.id}`}
+              title={p.name}
+              sub={p.relationship}
+              onPress={() => nav.push('PersonDetail', { person: p })}
+            />
+          ))}
+        </Section>
+      ) : null}
+
+      <Section label="Quick actions">
+        <ActionRow
+          actions={[
+            ...(iv.company
+              ? [{ label: 'View company', onPress: () => nav.push('CompanyDetail', { name: iv.company }), primary: true }]
+              : []),
+            { label: 'All interviews', onPress: () => nav.navigate('Tabs', { screen: 'Interviews' }) },
+          ]}
+        />
+      </Section>
+    </DetailShell>
+  )
+}
+
+const card = {
+  marginTop: 10,
+  borderRadius: 16,
+  borderWidth: 1,
+  borderColor: t.cardBorder,
+  backgroundColor: t.card,
+  padding: 15,
+} as const

--- a/mobile/src/screens/detail/JobDetail.tsx
+++ b/mobile/src/screens/detail/JobDetail.tsx
@@ -1,0 +1,159 @@
+// Job detail — every pipeline card opens here. Surfaces the assessment
+// detail, materials, and company relationships the list card has no room
+// for, plus the company's activity timeline.
+import { useNavigation } from '@react-navigation/native'
+import { Linking, Text, View } from 'react-native'
+import { jobSummary } from '../../lib/insights'
+import { Job, companyBundle, daysSince } from '../../lib/store'
+import {
+  ActionRow,
+  DetailShell,
+  MetaGrid,
+  RelatedRow,
+  Section,
+  SummaryBlock,
+  TimelineList,
+} from '../../ui/detail'
+import { ErrorState, LoadingState, StatusChip } from '../../ui/primitives'
+import { stageStyle, t } from '../../ui/tokens'
+import { useDatasets } from '../../ui/useDatasets'
+
+export default function JobDetail({ route }: any) {
+  const seed: Job = route.params.job
+  const nav = useNavigation<any>()
+  const { data: ds, loading, refreshing, error, refresh } = useDatasets()
+
+  const job = ds?.jobs.find((j) => j.id === seed.id) || seed
+  const stage = stageStyle[(job.status || 'pending').toLowerCase()] || stageStyle.pending
+  const score = Number(job.fitment_score) || 0
+  const co = ds ? companyBundle(ds, job.company) : null
+  const age = daysSince(job.added_date)
+  const sourceUrl = /^https?:\/\//i.test(job.source || '') ? job.source : undefined
+
+  const actions = [
+    ...(sourceUrl
+      ? [{ label: 'Open posting', onPress: () => Linking.openURL(sourceUrl).catch(() => {}), primary: true }]
+      : []),
+    { label: 'View company', onPress: () => nav.push('CompanyDetail', { name: job.company }) },
+  ]
+
+  return (
+    <DetailShell
+      kicker="Job"
+      title={job.role || 'Untitled role'}
+      subtitle={job.company}
+      shareText={`${job.role} at ${job.company}${score ? ` — fit score ${score}` : ''}${sourceUrl ? `\n${sourceUrl}` : ''}`}
+      refreshing={refreshing}
+      onRefresh={refresh}
+    >
+      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10, marginTop: 12 }}>
+        <StatusChip label={stage.label} color={stage.color} bg={stage.bg} />
+        {score > 0 ? <Text style={{ color: t.cyanBright, fontWeight: '700', fontSize: 15 }}>{score} FIT</Text> : null}
+      </View>
+
+      {loading && !ds ? <LoadingState /> : null}
+      {error && !ds ? <ErrorState message={error} onRetry={refresh} /> : null}
+
+      {ds ? <SummaryBlock sentences={jobSummary(job, ds)} /> : null}
+
+      <Section label="Overview">
+        <MetaGrid
+          rows={[
+            { label: 'Company', value: job.company },
+            { label: 'Status', value: stage.label },
+            { label: 'Fit score', value: score || undefined },
+            { label: 'Added', value: (job.added_date || '').slice(0, 10) },
+            { label: 'In pipeline', value: age != null && age >= 0 ? `${age} day${age === 1 ? '' : 's'}` : undefined },
+            { label: 'Source', value: sourceUrl ? undefined : job.source },
+          ]}
+        />
+      </Section>
+
+      {job.assessment_detail || job.assessment_summary ? (
+        <Section label="Assessment">
+          <View style={cardStyle}>
+            <Text style={{ color: t.textBody, fontSize: 13.5, lineHeight: 20 }}>
+              {job.assessment_detail || job.assessment_summary}
+            </Text>
+            {job.decision_notes ? (
+              <Text style={{ color: t.muted, fontSize: 12.5, lineHeight: 18, marginTop: 10 }}>
+                Decision: {job.decision_notes}
+              </Text>
+            ) : null}
+          </View>
+        </Section>
+      ) : null}
+
+      {job.selected_resume || job.recommended_resume || job.last_edited_cover_letter ? (
+        <Section label="Materials" initiallyOpen={false}>
+          <MetaGrid
+            rows={[
+              { label: 'Resume', value: job.selected_resume || job.recommended_resume },
+              { label: 'Tailored', value: job.last_edited_resume },
+              { label: 'Cover letter', value: job.last_edited_cover_letter },
+            ]}
+          />
+          <Text style={{ color: t.faint, fontSize: 11.5, marginTop: 8, lineHeight: 16 }}>
+            Generate and edit materials from the desktop — they sync here.
+          </Text>
+        </Section>
+      ) : null}
+
+      {co && (co.people.length || co.interviews.length || co.jobs.length > 1) ? (
+        <Section label={`At ${job.company}`}>
+          {co.interviews.slice(0, 3).map((iv, i) => (
+            <RelatedRow
+              key={`iv${iv.id ?? i}`}
+              title={`${(iv.interview_type || 'interview').replace(/_/g, ' ')}${iv.upcoming ? ' · upcoming' : ''}`}
+              sub={iv.interviewer ? `with ${iv.interviewer}` : undefined}
+              right={(iv.interview_date || '').slice(0, 10)}
+              onPress={() => nav.push('InterviewDetail', { interview: iv })}
+            />
+          ))}
+          {co.people.slice(0, 3).map((p) => (
+            <RelatedRow
+              key={`p${p.id}`}
+              title={p.name}
+              sub={p.relationship}
+              right={(p.outreach_status || '').toUpperCase()}
+              onPress={() => nav.push('PersonDetail', { person: p })}
+            />
+          ))}
+          {co.jobs
+            .filter((j) => j.id !== job.id)
+            .slice(0, 3)
+            .map((j) => (
+              <RelatedRow
+                key={`j${j.id}`}
+                title={j.role}
+                sub={(stageStyle[(j.status || 'pending').toLowerCase()] || stageStyle.pending).label}
+                right={Number(j.fitment_score) ? `${Number(j.fitment_score)} FIT` : undefined}
+                onPress={() => nav.push('JobDetail', { job: j })}
+              />
+            ))}
+        </Section>
+      ) : null}
+
+      {co && co.events.length ? (
+        <Section label="Timeline" initiallyOpen={false} count={co.events.length}>
+          <TimelineList
+            items={co.events.slice(0, 10).map((e) => ({ title: e.title, sub: e.subtitle, ts: e.ts }))}
+          />
+        </Section>
+      ) : null}
+
+      <Section label="Quick actions">
+        <ActionRow actions={actions} />
+      </Section>
+    </DetailShell>
+  )
+}
+
+const cardStyle = {
+  marginTop: 10,
+  borderRadius: 16,
+  borderWidth: 1,
+  borderColor: t.cardBorder,
+  backgroundColor: t.card,
+  padding: 15,
+} as const

--- a/mobile/src/screens/detail/PersonDetail.tsx
+++ b/mobile/src/screens/detail/PersonDetail.tsx
@@ -1,0 +1,198 @@
+// Person detail — every contact becomes a small CRM page: warmth status,
+// tappable channels, relationship summary, notes, what's live at their
+// company, and one-tap outreach actions.
+import { useNavigation } from '@react-navigation/native'
+import { Linking, Text, View } from 'react-native'
+import { personSummary } from '../../lib/insights'
+import { Person, companyBundle, contactChannels, daysSince } from '../../lib/store'
+import {
+  ActionRow,
+  DetailShell,
+  MetaGrid,
+  RelatedRow,
+  Section,
+  SummaryBlock,
+  TimelineList,
+} from '../../ui/detail'
+import { ErrorState, LoadingState, StatusChip } from '../../ui/primitives'
+import { avatarPalette, t } from '../../ui/tokens'
+import { useDatasets } from '../../ui/useDatasets'
+
+const WARMTH: Record<string, { label: string; color: string; bg: string }> = {
+  responded: { label: 'WARM · REPLIED', color: t.green, bg: 'rgba(111,211,160,.15)' },
+  'follow-up': { label: 'FOLLOW-UP DUE', color: t.amber, bg: 'rgba(224,183,122,.15)' },
+  sent: { label: 'AWAITING REPLY', color: t.amber, bg: 'rgba(224,183,122,.15)' },
+  drafted: { label: 'DRAFTED', color: '#9BB0D0', bg: 'rgba(255,255,255,.06)' },
+  none: { label: 'NOT CONTACTED', color: '#9BB0D0', bg: 'rgba(255,255,255,.06)' },
+}
+
+function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((w) => w[0].toUpperCase())
+    .join('')
+}
+
+export default function PersonDetail({ route }: any) {
+  const seed: Person = route.params.person
+  const nav = useNavigation<any>()
+  const { data: ds, loading, refreshing, error, refresh } = useDatasets()
+
+  const p = ds?.people.find((x) => x.id === seed.id) || seed
+  const co = ds && p.company ? companyBundle(ds, p.company) : null
+  const warmth = WARMTH[(p.outreach_status || 'none').toLowerCase()] || WARMTH.none
+  const { email, phone, linkedin } = contactChannels(p)
+  const open = (url: string) => Linking.openURL(url).catch(() => {})
+  const gap = daysSince(p.last_contacted || p.last_updated)
+
+  const actions = [
+    ...(email
+      ? [
+          {
+            label: 'Draft follow-up',
+            onPress: () =>
+              open(
+                `mailto:${email}?subject=${encodeURIComponent('Following up')}&body=${encodeURIComponent(`Hi ${p.name.split(' ')[0]},\n\n`)}`,
+              ),
+            primary: true,
+          },
+        ]
+      : []),
+    ...(phone ? [{ label: 'Call', onPress: () => open(`tel:${phone.replace(/[^+\d]/g, '')}`) }] : []),
+    ...(email ? [{ label: 'Email', onPress: () => open(`mailto:${email}`) }] : []),
+    ...(linkedin
+      ? [{ label: 'LinkedIn', onPress: () => open(linkedin.startsWith('http') ? linkedin : `https://${linkedin}`) }]
+      : []),
+    ...(p.company ? [{ label: 'View company', onPress: () => nav.push('CompanyDetail', { name: p.company }) }] : []),
+  ]
+
+  return (
+    <DetailShell
+      kicker={p.relationship || 'Contact'}
+      title={p.name}
+      subtitle={[p.relationship, p.company].filter(Boolean).join(' · ')}
+      shareText={`${p.name}${p.company ? ` — ${p.company}` : ''}${linkedin ? `\n${linkedin}` : ''}`}
+      refreshing={refreshing}
+      onRefresh={refresh}
+    >
+      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12, marginTop: 12 }}>
+        <View
+          style={{
+            width: 46,
+            height: 46,
+            borderRadius: 23,
+            backgroundColor: avatarPalette[(p.id || 0) % avatarPalette.length],
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <Text style={{ fontWeight: '700', fontSize: 16, color: t.cyanInk }}>{initials(p.name)}</Text>
+        </View>
+        <View style={{ gap: 5, alignItems: 'flex-start' }}>
+          <StatusChip {...warmth} />
+          {gap != null && gap >= 0 ? (
+            <Text style={{ fontSize: 11, color: gap > 14 ? t.amber : t.faint }}>
+              Last touch {gap === 0 ? 'today' : `${gap} day${gap === 1 ? '' : 's'} ago`}
+            </Text>
+          ) : null}
+        </View>
+      </View>
+
+      {loading && !ds ? <LoadingState /> : null}
+      {error && !ds ? <ErrorState message={error} onRetry={refresh} /> : null}
+
+      {ds ? <SummaryBlock sentences={personSummary(p, ds)} /> : null}
+
+      {email || phone || linkedin ? (
+        <Section label="Contact">
+          {email ? <RelatedRow title={email} sub="Email" onPress={() => open(`mailto:${email}`)} /> : null}
+          {phone ? <RelatedRow title={phone} sub="Phone" onPress={() => open(`tel:${phone.replace(/[^+\d]/g, '')}`)} /> : null}
+          {linkedin ? (
+            <RelatedRow
+              title={linkedin.replace(/^https?:\/\/(www\.)?/, '')}
+              sub="LinkedIn"
+              onPress={() => open(linkedin.startsWith('http') ? linkedin : `https://${linkedin}`)}
+            />
+          ) : null}
+        </Section>
+      ) : null}
+
+      {p.context || p.notes ? (
+        <Section label="Notes">
+          <View style={card}>
+            {p.context ? (
+              <Text style={{ color: t.textBody, fontSize: 13.5, lineHeight: 20 }}>{p.context}</Text>
+            ) : null}
+            {p.notes && p.notes !== p.context ? (
+              <Text
+                style={{ color: t.muted, fontSize: 13, lineHeight: 19, marginTop: p.context ? 10 : 0 }}
+              >
+                {p.notes}
+              </Text>
+            ) : null}
+          </View>
+        </Section>
+      ) : null}
+
+      <Section label="Status">
+        <MetaGrid
+          rows={[
+            { label: 'Outreach', value: p.outreach_status || 'none' },
+            { label: 'Last contact', value: (p.last_contacted || '').slice(0, 10) },
+            { label: 'Updated', value: (p.last_updated || '').slice(0, 10) },
+            { label: 'Tags', value: p.tags?.length ? p.tags.join(', ') : undefined },
+          ]}
+        />
+      </Section>
+
+      {co && (co.jobs.length || co.interviews.length) ? (
+        <Section label={`Live at ${p.company}`}>
+          {co.jobs.slice(0, 4).map((j) => (
+            <RelatedRow
+              key={`j${j.id}`}
+              title={j.role}
+              sub={j.status}
+              right={Number(j.fitment_score) ? `${Number(j.fitment_score)} FIT` : undefined}
+              onPress={() => nav.push('JobDetail', { job: j })}
+            />
+          ))}
+          {co.interviews.slice(0, 3).map((iv, i) => (
+            <RelatedRow
+              key={`iv${iv.id ?? i}`}
+              title={(iv.interview_type || 'interview').replace(/_/g, ' ')}
+              sub={iv.upcoming ? 'upcoming' : 'debriefed'}
+              right={(iv.interview_date || '').slice(0, 10)}
+              onPress={() => nav.push('InterviewDetail', { interview: iv })}
+            />
+          ))}
+        </Section>
+      ) : null}
+
+      {co && co.events.length ? (
+        <Section label="Timeline" initiallyOpen={false} count={co.events.length}>
+          <TimelineList items={co.events.slice(0, 8).map((e) => ({ title: e.title, sub: e.subtitle, ts: e.ts }))} />
+        </Section>
+      ) : null}
+
+      <Section label="Suggested actions">
+        <ActionRow actions={actions} />
+        {!email && !phone && !linkedin ? (
+          <Text style={{ color: t.faint, fontSize: 12, marginTop: 10, lineHeight: 17 }}>
+            No channels on file — add contact info from the desktop to unlock one-tap outreach.
+          </Text>
+        ) : null}
+      </Section>
+    </DetailShell>
+  )
+}
+
+const card = {
+  marginTop: 10,
+  borderRadius: 16,
+  borderWidth: 1,
+  borderColor: t.cardBorder,
+  backgroundColor: t.card,
+  padding: 15,
+} as const

--- a/mobile/src/screens/detail/PostDetail.tsx
+++ b/mobile/src/screens/detail/PostDetail.tsx
@@ -1,0 +1,97 @@
+// Post detail — full content (list cards clamp at 4 lines), metrics with
+// performance-vs-average context, and the update/open/share actions.
+import { useNavigation } from '@react-navigation/native'
+import { Linking, Text, View } from 'react-native'
+import { postSummary } from '../../lib/insights'
+import { Post } from '../../lib/store'
+import { ActionRow, DetailShell, MetaGrid, Meter, Section, SummaryBlock } from '../../ui/detail'
+import { ErrorState, LoadingState, StatTile } from '../../ui/primitives'
+import { fmtK, fonts, t } from '../../ui/tokens'
+import { useDatasets } from '../../ui/useDatasets'
+
+export default function PostDetail({ route }: any) {
+  const seed: Post = route.params.post
+  const nav = useNavigation<any>()
+  const { data: ds, loading, refreshing, error, refresh } = useDatasets()
+
+  const post = ds?.posts.find((p) => p.id === seed.id) || seed
+  const n = ds?.posts.length || 0
+  const avgImp = n ? (ds!.postTotals.impressions || 0) / n : 0
+  const engagement = post.impressions > 0 ? ((post.reactions + post.comments) / post.impressions) * 100 : 0
+  const vsAvg = avgImp > 0 ? Math.min(200, Math.round((post.impressions / avgImp) * 100)) : 0
+
+  return (
+    <DetailShell
+      kicker="LinkedIn post"
+      title={post.title || 'Post'}
+      subtitle={(post.posted_date || '').slice(0, 10)}
+      shareText={post.url || post.text}
+      refreshing={refreshing}
+      onRefresh={refresh}
+    >
+      {loading && !ds ? <LoadingState /> : null}
+      {error && !ds ? <ErrorState message={error} onRetry={refresh} /> : null}
+
+      {ds ? <SummaryBlock sentences={postSummary(post, ds)} /> : null}
+
+      <View style={{ flexDirection: 'row', gap: 10, marginTop: 18 }}>
+        <StatTile value={fmtK(post.impressions)} label="Impressions" />
+        <StatTile value={fmtK(post.reactions)} label="Reactions" />
+        <StatTile value={fmtK(post.comments)} label="Comments" accent />
+      </View>
+
+      {post.impressions > 0 ? (
+        <Section label="Performance">
+          <View style={card}>
+            <Meter label="Engagement %" value={Number(engagement.toFixed(1))} max={Math.max(5, Math.ceil(engagement))} />
+            {vsAvg > 0 ? <Meter label="vs your avg" value={vsAvg} max={200} /> : null}
+            <Text style={{ color: t.faint, fontSize: 11, marginTop: 10, lineHeight: 15 }}>
+              "vs your avg" caps at 2× — 100 means an average post.
+            </Text>
+          </View>
+        </Section>
+      ) : null}
+
+      <Section label="Content">
+        <View style={card}>
+          <Text style={{ color: t.textBright, fontSize: 14, lineHeight: 21 }}>{post.text}</Text>
+          {post.hashtags?.length ? (
+            <Text style={{ marginTop: 12, fontSize: 12, color: t.cyanBright, fontFamily: fonts.mono }}>
+              {post.hashtags.map((h) => (h.startsWith('#') ? h : `#${h}`)).join(' ')}
+            </Text>
+          ) : null}
+        </View>
+      </Section>
+
+      <Section label="Details" initiallyOpen={false}>
+        <MetaGrid
+          rows={[
+            { label: 'Published', value: (post.posted_date || '').slice(0, 10) },
+            { label: 'Source', value: post.source },
+            { label: 'Words', value: post.text ? post.text.trim().split(/\s+/).length : undefined },
+          ]}
+        />
+      </Section>
+
+      <Section label="Quick actions">
+        <ActionRow
+          actions={[
+            ...(post.url
+              ? [{ label: 'Open on LinkedIn', onPress: () => Linking.openURL(post.url!).catch(() => {}), primary: true }]
+              : []),
+            { label: 'Update metrics', onPress: () => nav.navigate('Tabs', { screen: 'Posts' }) },
+          ]}
+        />
+      </Section>
+    </DetailShell>
+  )
+}
+
+const card = {
+  marginTop: 10,
+  borderRadius: 16,
+  borderWidth: 1,
+  borderColor: t.cardBorder,
+  backgroundColor: t.card,
+  padding: 15,
+} as const

--- a/mobile/src/ui/detail.tsx
+++ b/mobile/src/ui/detail.tsx
@@ -1,0 +1,378 @@
+// Universal detail-page kit. Every object card in the app pushes one of
+// these pages onto the root stack; they all share the same skeleton so the
+// app reads as one system: kicker + large title + hero, pinned summary
+// block, collapsible sections, meta grid, timeline, related rows, and a
+// quick-action row. Cards use PressableScale for the spring press-feedback.
+import { useNavigation } from '@react-navigation/native'
+import { ReactNode, useRef, useState } from 'react'
+import {
+  Animated,
+  LayoutAnimation,
+  Platform,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  Share,
+  StyleSheet,
+  Text,
+  UIManager,
+  View,
+  ViewStyle,
+} from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { fonts, t } from './tokens'
+
+if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
+  UIManager.setLayoutAnimationEnabledExperimental(true)
+}
+
+/** Spring scale-down on press — the "card press" animation used everywhere. */
+export function PressableScale({
+  children,
+  onPress,
+  onLongPress,
+  style,
+  disabled,
+}: {
+  children: ReactNode
+  onPress?: () => void
+  onLongPress?: () => void
+  style?: ViewStyle
+  disabled?: boolean
+}) {
+  const scale = useRef(new Animated.Value(1)).current
+  const to = (v: number) =>
+    Animated.spring(scale, { toValue: v, useNativeDriver: true, speed: 40, bounciness: 6 }).start()
+  return (
+    <Pressable
+      onPress={onPress}
+      onLongPress={onLongPress}
+      disabled={disabled}
+      onPressIn={() => to(0.97)}
+      onPressOut={() => to(1)}
+    >
+      <Animated.View style={[style, { transform: [{ scale }] }]}>{children}</Animated.View>
+    </Pressable>
+  )
+}
+
+/** Full-screen shell for a pushed detail page: back chevron, share button,
+ *  mono kicker ("JOB" / "RECRUITER"), large title, optional hero line. */
+export function DetailShell({
+  kicker,
+  title,
+  subtitle,
+  shareText,
+  children,
+  refreshing = false,
+  onRefresh,
+}: {
+  kicker: string
+  title: string
+  subtitle?: string
+  /** When set, the ↗ button opens the native share sheet with this text. */
+  shareText?: string
+  children: ReactNode
+  refreshing?: boolean
+  onRefresh?: () => void
+}) {
+  const nav = useNavigation<any>()
+  const insets = useSafeAreaInsets()
+  return (
+    <View style={styles.root}>
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{ paddingTop: insets.top + 8, paddingHorizontal: 18, paddingBottom: 36 }}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          onRefresh ? <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={t.cyan} /> : undefined
+        }
+      >
+        <View style={styles.navRow}>
+          <Pressable onPress={() => nav.goBack()} hitSlop={12} style={styles.navBtn}>
+            <Text style={styles.navBtnText}>‹</Text>
+          </Pressable>
+          {shareText ? (
+            <Pressable
+              onPress={() => Share.share({ message: shareText }).catch(() => {})}
+              hitSlop={12}
+              style={styles.navBtn}
+            >
+              <Text style={[styles.navBtnText, { fontSize: 17 }]}>↗</Text>
+            </Pressable>
+          ) : null}
+        </View>
+        <Text style={styles.kicker}>{kicker.toUpperCase()}</Text>
+        <Text style={styles.title}>{title}</Text>
+        {subtitle ? <Text style={styles.subtitle}>{subtitle}</Text> : null}
+        {children}
+      </ScrollView>
+    </View>
+  )
+}
+
+/** The pinned executive-summary block. Always expanded, opens every page. */
+export function SummaryBlock({ sentences }: { sentences: string[] }) {
+  if (!sentences.length) return null
+  return (
+    <View style={styles.summary}>
+      <Text style={styles.summaryLabel}>◈ SUMMARY</Text>
+      <Text style={styles.summaryText}>{sentences.join(' ')}</Text>
+    </View>
+  )
+}
+
+/** Collapsible section — everything below the summary folds. */
+export function Section({
+  label,
+  count,
+  initiallyOpen = true,
+  children,
+}: {
+  label: string
+  count?: number
+  initiallyOpen?: boolean
+  children: ReactNode
+}) {
+  const [open, setOpen] = useState(initiallyOpen)
+  const toggle = () => {
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
+    setOpen((o) => !o)
+  }
+  return (
+    <View style={{ marginTop: 22 }}>
+      <Pressable onPress={toggle} style={styles.sectionRow} hitSlop={6}>
+        <Text style={styles.sectionLabel}>
+          {label.toUpperCase()}
+          {count != null ? `  ·  ${count}` : ''}
+        </Text>
+        <Text style={[styles.sectionChevron, open && { transform: [{ rotate: '90deg' }] }]}>›</Text>
+      </Pressable>
+      {open ? children : null}
+    </View>
+  )
+}
+
+/** Label/value rows for object metadata. */
+export function MetaGrid({ rows }: { rows: { label: string; value?: string | number | null }[] }) {
+  const shown = rows.filter((r) => r.value !== undefined && r.value !== null && String(r.value).trim() !== '')
+  if (!shown.length) return null
+  return (
+    <View style={styles.metaCard}>
+      {shown.map((r, i) => (
+        <View key={r.label} style={[styles.metaRow, i > 0 && styles.metaRowBorder]}>
+          <Text style={styles.metaLabel}>{r.label.toUpperCase()}</Text>
+          <Text style={styles.metaValue} numberOfLines={2}>
+            {String(r.value)}
+          </Text>
+        </View>
+      ))}
+    </View>
+  )
+}
+
+export type TimelineItem = { title: string; sub?: string; ts?: string; color?: string }
+
+/** Vertical dotted timeline used for "what happened" on every page. */
+export function TimelineList({ items }: { items: TimelineItem[] }) {
+  if (!items.length) return null
+  return (
+    <View style={{ marginTop: 10 }}>
+      {items.map((it, i) => (
+        <View key={`${it.title}${i}`} style={styles.tlRow}>
+          <View style={styles.tlRail}>
+            <View style={[styles.tlDot, { backgroundColor: it.color || t.cyan }]} />
+            {i < items.length - 1 ? <View style={styles.tlLine} /> : null}
+          </View>
+          <View style={{ flex: 1, paddingBottom: i < items.length - 1 ? 14 : 0 }}>
+            <View style={styles.tlTop}>
+              <Text style={styles.tlTitle}>{it.title}</Text>
+              {it.ts ? <Text style={styles.tlTs}>{it.ts.slice(0, 10)}</Text> : null}
+            </View>
+            {it.sub ? (
+              <Text style={styles.tlSub} numberOfLines={2}>
+                {it.sub}
+              </Text>
+            ) : null}
+          </View>
+        </View>
+      ))}
+    </View>
+  )
+}
+
+/** Compact tappable row for related objects — never a dead end. */
+export function RelatedRow({
+  title,
+  sub,
+  right,
+  onPress,
+}: {
+  title: string
+  sub?: string
+  right?: string
+  onPress?: () => void
+}) {
+  return (
+    <PressableScale onPress={onPress} style={styles.relatedRow}>
+      <View style={{ flex: 1, minWidth: 0 }}>
+        <Text style={styles.relatedTitle} numberOfLines={1}>
+          {title}
+        </Text>
+        {sub ? (
+          <Text style={styles.relatedSub} numberOfLines={1}>
+            {sub}
+          </Text>
+        ) : null}
+      </View>
+      {right ? <Text style={styles.relatedRight}>{right}</Text> : null}
+      {onPress ? <Text style={styles.relatedArrow}>›</Text> : null}
+    </PressableScale>
+  )
+}
+
+/** Wrapping row of quick-action pills that ends every detail page. */
+export function ActionRow({
+  actions,
+}: {
+  actions: { label: string; onPress: () => void; primary?: boolean }[]
+}) {
+  if (!actions.length) return null
+  return (
+    <View style={styles.actionRow}>
+      {actions.map((a) => (
+        <PressableScale
+          key={a.label}
+          onPress={a.onPress}
+          style={[styles.actionBtn, a.primary ? styles.actionPrimary : null] as unknown as ViewStyle}
+        >
+          <Text style={[styles.actionText, a.primary && { color: t.cyanInk }]}>{a.label}</Text>
+        </PressableScale>
+      ))}
+    </View>
+  )
+}
+
+/** Bullet list (strengths / weaknesses / priorities). */
+export function Bullets({ items, color }: { items: string[]; color?: string }) {
+  if (!items.length) return null
+  return (
+    <View style={styles.bullets}>
+      {items.map((b, i) => (
+        <View key={i} style={styles.bulletRow}>
+          <View style={[styles.bulletDot, { backgroundColor: color || t.cyan }]} />
+          <Text style={styles.bulletText}>{b}</Text>
+        </View>
+      ))}
+    </View>
+  )
+}
+
+/** Labeled meter (energy, self-rating, engagement) 0..max. */
+export function Meter({ label, value, max = 10 }: { label: string; value: number; max?: number }) {
+  return (
+    <View style={styles.meterRow}>
+      <Text style={styles.meterLabel}>{label.toUpperCase()}</Text>
+      <View style={styles.meterTrack}>
+        <View style={[styles.meterFill, { width: `${Math.min(100, (value / max) * 100)}%` }]} />
+      </View>
+      <Text style={styles.meterVal}>
+        {value}/{max}
+      </Text>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1, backgroundColor: t.bg },
+  navRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: 14 },
+  navBtn: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: t.chipBg,
+    borderWidth: 1,
+    borderColor: t.cardBorder,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  navBtnText: { color: t.textBright, fontSize: 22, lineHeight: 24, fontWeight: '600' },
+  kicker: { fontSize: 11, fontWeight: '600', letterSpacing: 1.5, color: t.cyanBright, fontFamily: fonts.mono },
+  title: { fontSize: 28, fontWeight: '700', color: t.text, letterSpacing: -0.6, marginTop: 4 },
+  subtitle: { fontSize: 14, color: t.muted, marginTop: 4, lineHeight: 20 },
+  summary: {
+    marginTop: 18,
+    borderRadius: 18,
+    padding: 16,
+    backgroundColor: t.tintFillHi,
+    borderWidth: 1,
+    borderColor: t.tintBorderHi,
+  },
+  summaryLabel: { fontSize: 10.5, fontWeight: '600', letterSpacing: 1.5, color: t.cyanBright, fontFamily: fonts.mono },
+  summaryText: { marginTop: 8, fontSize: 14, color: t.textBright, lineHeight: 21 },
+  sectionRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  sectionLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    letterSpacing: 1.2,
+    color: t.muted2,
+    fontFamily: fonts.mono,
+  },
+  sectionChevron: { color: t.muted2, fontSize: 16, fontWeight: '700' },
+  metaCard: {
+    marginTop: 10,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: t.cardBorder,
+    backgroundColor: t.card,
+    paddingHorizontal: 15,
+  },
+  metaRow: { flexDirection: 'row', alignItems: 'center', gap: 12, paddingVertical: 12 },
+  metaRowBorder: { borderTopWidth: 1, borderTopColor: t.hairline },
+  metaLabel: { width: 96, fontSize: 10.5, color: t.muted2, fontFamily: fonts.mono, letterSpacing: 0.8 },
+  metaValue: { flex: 1, fontSize: 13.5, color: t.textBright, textAlign: 'right' },
+  tlRow: { flexDirection: 'row', gap: 12 },
+  tlRail: { width: 10, alignItems: 'center' },
+  tlDot: { width: 8, height: 8, borderRadius: 4, marginTop: 5 },
+  tlLine: { flex: 1, width: 1.5, backgroundColor: 'rgba(255,255,255,.09)', marginTop: 3 },
+  tlTop: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: 10 },
+  tlTitle: { fontSize: 13.5, fontWeight: '600', color: t.textBright, flex: 1 },
+  tlTs: { fontSize: 10.5, color: t.faint, fontFamily: fonts.mono },
+  tlSub: { fontSize: 12.5, color: t.muted, marginTop: 2, lineHeight: 17 },
+  relatedRow: {
+    marginTop: 8,
+    borderRadius: 14,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    backgroundColor: t.card,
+    borderWidth: 1,
+    borderColor: t.cardBorder,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  relatedTitle: { fontSize: 14, fontWeight: '600', color: t.text },
+  relatedSub: { fontSize: 12, color: t.muted, marginTop: 1 },
+  relatedRight: { fontSize: 11, color: t.cyanBright, fontFamily: fonts.mono, fontWeight: '600' },
+  relatedArrow: { fontSize: 16, color: t.muted2 },
+  actionRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginTop: 10 },
+  actionBtn: {
+    backgroundColor: t.tintFillLo,
+    borderColor: t.tintBorderLo,
+    borderWidth: 1,
+    borderRadius: 11,
+    paddingHorizontal: 15,
+    paddingVertical: 9,
+  },
+  actionPrimary: { backgroundColor: t.cyan, borderColor: t.cyan },
+  actionText: { color: t.cyanBright, fontSize: 13, fontWeight: '600' },
+  bullets: { marginTop: 10, gap: 8 },
+  bulletRow: { flexDirection: 'row', gap: 10, alignItems: 'flex-start' },
+  bulletDot: { width: 6, height: 6, borderRadius: 3, marginTop: 6 },
+  bulletText: { flex: 1, fontSize: 13.5, color: t.textBody, lineHeight: 19 },
+  meterRow: { flexDirection: 'row', alignItems: 'center', gap: 10, marginTop: 10 },
+  meterLabel: { width: 110, fontSize: 9.5, color: t.muted2, fontFamily: fonts.mono, letterSpacing: 1 },
+  meterTrack: { flex: 1, height: 6, borderRadius: 3, backgroundColor: 'rgba(255,255,255,.07)', overflow: 'hidden' },
+  meterFill: { height: '100%', borderRadius: 3, backgroundColor: t.cyan },
+  meterVal: { width: 44, fontSize: 11, fontWeight: '600', color: t.textSecondary, fontFamily: fonts.mono, textAlign: 'right' },
+})

--- a/mobile/src/ui/primitives.tsx
+++ b/mobile/src/ui/primitives.tsx
@@ -172,10 +172,36 @@ export function ErrorState({ message, onRetry }: { message: string; onRetry?: ()
   )
 }
 
-export function EmptyState({ message }: { message: string }) {
+/** Empty states recommend an action instead of announcing absence: an
+ *  upbeat headline, optional "great time to:" suggestions, and a button. */
+export function EmptyState({
+  message,
+  suggestions,
+  actionLabel,
+  onAction,
+}: {
+  message: string
+  suggestions?: string[]
+  actionLabel?: string
+  onAction?: () => void
+}) {
   return (
     <View style={styles.centerBox}>
       <Text style={styles.centerText}>{message}</Text>
+      {suggestions?.length ? (
+        <View style={styles.emptySuggestions}>
+          {suggestions.map((s) => (
+            <Text key={s} style={styles.emptySuggestion}>
+              •  {s}
+            </Text>
+          ))}
+        </View>
+      ) : null}
+      {actionLabel && onAction ? (
+        <Pressable onPress={onAction} style={styles.retry}>
+          <Text style={styles.retryText}>{actionLabel}</Text>
+        </Pressable>
+      ) : null}
     </View>
   )
 }
@@ -202,6 +228,8 @@ const styles = StyleSheet.create({
   statValue: { fontSize: 20, fontWeight: '700' },
   statLabel: { fontSize: 10.5, marginTop: 2 },
   centerBox: { alignItems: 'center', paddingVertical: 48, gap: 10 },
+  emptySuggestions: { gap: 5, alignItems: 'flex-start' },
+  emptySuggestion: { color: t.textSecondary, fontSize: 12.5, lineHeight: 18 },
   centerText: { color: t.muted, fontSize: 13, textAlign: 'center', lineHeight: 19, paddingHorizontal: 24 },
   errorText: { color: t.red, fontSize: 13, textAlign: 'center', lineHeight: 19, paddingHorizontal: 24 },
   retry: {

--- a/mobile/src/ui/useDatasets.ts
+++ b/mobile/src/ui/useDatasets.ts
@@ -1,0 +1,42 @@
+// Fetch lifecycle for the cross-domain dataset bundle (lib/store). Same
+// shape as useDashData but plumbs the force flag through so pull-to-refresh
+// punches past the store's 60s cache while focus-refetches ride it.
+import { useFocusEffect } from '@react-navigation/native'
+import { useCallback, useRef, useState } from 'react'
+import { Datasets, loadDatasets } from '../lib/store'
+
+export function useDatasets() {
+  const [data, setData] = useState<Datasets | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+  const [error, setError] = useState('')
+  const seq = useRef(0)
+
+  const load = useCallback(async (force = false) => {
+    const mySeq = ++seq.current
+    if (force) setRefreshing(true)
+    try {
+      const result = await loadDatasets(force)
+      if (mySeq !== seq.current) return
+      setData(result)
+      setError('')
+    } catch (e: any) {
+      if (mySeq !== seq.current) return
+      setError(e?.message || 'Something went wrong.')
+    } finally {
+      if (mySeq === seq.current) {
+        setLoading(false)
+        setRefreshing(false)
+      }
+    }
+  }, [])
+
+  useFocusEffect(
+    useCallback(() => {
+      load()
+    }, [load]),
+  )
+
+  const refresh = useCallback(() => load(true), [load])
+  return { data, loading, refreshing, error, refresh }
+}


### PR DESCRIPTION
Phase 1 of the mobile UX enhancement spec (depth, navigation, discoverability), plus the same "no dead ends" fix applied to the desktop/web Home dashboard. Targets **main** directly per Frank.

> ⚠️ **Deploy note (changed since the PR was opened):** commit `e09e136` touches `frontend/**`, so this is no longer a mobile-only diff — merging to main **will** trigger `deploy.yml` (tests + Sonar + AKS deploy). The original mobile-only commit (`26f4d25`) would not have.

## Mobile (`mobile/**`, commit `26f4d25`)

**Navigation.** The 6-tab bar now lives inside a root native stack (`@react-navigation/native-stack`, the one new dependency — pure JS, no dev-client rebuild needed). Every card in Pipeline, Interviews, People, Posts, Wellbeing, and Home pushes a dedicated detail page with a slide transition. Inbox/Settings move from hidden tab routes to headered stack routes, unchanged.

**Universal detail pages** (`src/ui/detail.tsx` kit: back/share chrome, pinned summary block, collapsible sections, meta grid, timeline, related rows, action pills, spring-press cards):
- **JobDetail** — assessment detail, materials, funnel stage, source-posting link, company relationships
- **InterviewDetail** — self-rating, what landed / what didn't, verbatim quotes, interview arc at the company
- **PersonDetail** — CRM page: warmth, days-since-touch, tappable email/phone/LinkedIn, notes, live openings at their company, draft-follow-up action
- **CompanyDetail** — companies as first-class objects, joined client-side from jobs + interviews + people + events
- **PostDetail** — full text, engagement vs account average
- **CheckinDetail** — entry vs averages, that week's trend

**Cross-domain layer.** `src/lib/store.ts` fetches all six listing endpoints once (60s cache, partial-failure tolerant) and joins relationships by company name. `src/lib/insights.ts` composes the summary sentences on-device — deterministic heuristics, no LLM round-trip; structured so a server summary endpoint can slot in later.

**Global search** (`Search.tsx`) — one box over jobs, companies, people, interviews, posts, check-ins: word-prefix scoring, grouped results, match highlighting, session-recent searches, idle-state insights. **Timeline** (`Timeline.tsx`) — merged chronological feed with type filters and month headers; every row navigates.

**Polish:** pipeline "All" view groups by funnel stage; empty states recommend actions; spring press feedback on cards.

## Desktop/web Home (`frontend/**`, commit `e09e136`)

The Home dashboard rendered stat tiles, priorities, digest rows, and the Today's Move nudge as static divs. Now:
- **Stat tiles** → Pipeline / Wellbeing / People, with hover affordance
- **Priorities** route by keyword (interview → Interviews, follow-up/message → People, review/apply → Pipeline, post → Posts); unmatched text seeds the chat assistant with the priority (desktop only — web falls back to Pipeline since Chat is desktop-only)
- **Daily digest** rows map the fixed server-side label vocabulary deterministically; the empty-digest card opens Job Hunt
- **Readiness card** links to Wellbeing (or Settings when no ring connected); **Today's move** opens chat seeded with the move (desktop) or the move's subject screen (web)
- All targets keyboard-accessible via a shared `Actionable` wrapper; visual design unchanged

## Testing

- Mobile: `tsc --noEmit` clean; smoke-test via Expo dev client planned before merge (no new native modules). Known cosmetic risk: `LayoutAnimation` on Fabric/Android may snap instead of animate collapsible sections.
- Frontend: eslint clean, `vite build` passes, vitest 4/4.

## Deferred (follow-up branches)

Swipe actions, long-press context menus + haptics, floating AI assistant, daily briefing, drag-and-drop dashboard ordering, interactive charts, smart notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MhvVfvVWmAPcqgcvBWUsYC