### PR TITLE
desktop: fix silent Linux dead-click on file opens; redesign Materials

### DIFF
--- a/frontend/src/screens/Materials.jsx
+++ b/frontend/src/screens/Materials.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import {
   useApi, Screen, SectionHead, StatGrid, Stat, Badge, EmptyState, EYEBROW,
 } from './_shared.jsx'
@@ -25,6 +25,29 @@ const FOLDER_ORDER = [
   'optimized_resumes', 'cover_letters', 'resume_pdfs',
   'cover_letter_pdfs', 'job_assessments', 'interview_prep',
 ]
+
+/* Per-folder accent for the header dot — the grid reads as six equal gray
+   boxes otherwise. */
+const FOLDER_ACCENT = {
+  optimized_resumes: 'var(--cyan-300)',
+  cover_letters: '#C7A9E8',
+  resume_pdfs: 'var(--green-300)',
+  cover_letter_pdfs: 'var(--warn)',
+  job_assessments: '#E39393',
+  interview_prep: '#8AB6C4',
+}
+
+/* File-type chip colors — pdf warm, text cyan, markdown violet, docs/images green. */
+const EXT_COLOR = {
+  pdf: 'var(--warn)',
+  md: '#C7A9E8',
+  markdown: '#C7A9E8',
+  txt: 'var(--cyan-300)',
+  docx: 'var(--green-300)',
+  png: 'var(--green-300)',
+  jpg: 'var(--green-300)',
+  jpeg: 'var(--green-300)',
+}
 
 const PREVIEWABLE = new Set(['pdf', 'txt', 'md', 'png', 'jpg', 'jpeg', 'gif', 'svg'])
 
@@ -102,42 +125,77 @@ function openPreview(file) {
 
 function FileButton({ file }) {
   const ext = extOf(file) || 'file'
+  const extColor = EXT_COLOR[ext] || 'var(--cyan-300)'
   // Desktop: the webview can't open popup previews or downloads — the
   // backend opens the file in its OS-default app instead (view/print/save).
   const isDesktop = useDesktopMode()
+  // idle | busy | error — the native open has no visible in-app response,
+  // so the row itself must confirm the click (or surface the failure;
+  // window.alert doesn't reliably render in the Tauri webview).
+  const [state, setState] = useState('idle')
+  const resetTimer = useRef(null)
+  const open = async () => {
+    if (!isDesktop) {
+      openPreview(file)
+      return
+    }
+    if (state === 'busy') return
+    clearTimeout(resetTimer.current)
+    setState('busy')
+    const ok = await openFileNative(file.href, { notify: false })
+    setState(ok ? 'idle' : 'error')
+    if (!ok) resetTimer.current = setTimeout(() => setState('idle'), 4000)
+  }
   return (
     <button
       type="button"
-      onClick={() => (isDesktop ? openFileNative(file.href) : openPreview(file))}
-      title={`Preview ${file.name}`}
+      onClick={open}
+      title={isDesktop ? `Open ${file.name}` : `Preview ${file.name}`}
       style={{
         appearance: 'none', cursor: 'pointer', textAlign: 'left', width: '100%',
         display: 'flex', alignItems: 'center', gap: 8,
         padding: '7px 9px', borderRadius: 'var(--radius-sm)',
         background: 'transparent', border: '1px solid transparent',
         color: 'var(--text-soft)', fontSize: 'var(--fs-sm)',
+        opacity: state === 'busy' ? 0.6 : 1,
+        transition: 'background .12s ease, border-color .12s ease',
       }}
-      onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--surface-sunken)' }}
-      onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent' }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.background = 'var(--surface-sunken)'
+        e.currentTarget.style.borderColor = 'var(--border-soft)'
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.background = 'transparent'
+        e.currentTarget.style.borderColor = 'transparent'
+      }}
     >
       <span
         style={{
           flexShrink: 0, fontSize: 'var(--fs-2xs)', fontWeight: 'var(--fw-bold)',
           textTransform: 'uppercase', letterSpacing: '0.3px',
           padding: '2px 6px', borderRadius: 4,
-          background: 'var(--surface-chip)', color: 'var(--cyan-300)',
+          background: `color-mix(in srgb, ${extColor} 13%, transparent)`,
+          color: extColor,
         }}
       >
         {ext}
       </span>
-      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+      <span style={{ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
         {file.name}
       </span>
+      {state === 'busy' && (
+        <span style={{ flexShrink: 0, fontSize: 'var(--fs-2xs)', color: 'var(--muted)' }}>Opening…</span>
+      )}
+      {state === 'error' && (
+        <span style={{ flexShrink: 0, fontSize: 'var(--fs-2xs)', color: 'var(--warn)' }}>
+          Couldn&rsquo;t open
+        </span>
+      )}
     </button>
   )
 }
 
-function FolderBox({ label, folder }) {
+function FolderBox({ label, folder, accent }) {
   const files = folder.files || []
   return (
     <Panel pad="0" style={{ display: 'flex', flexDirection: 'column', height: 300, overflow: 'hidden' }}>
@@ -147,15 +205,18 @@ function FolderBox({ label, folder }) {
           padding: '12px 14px', borderBottom: '1px solid var(--border-soft)', flexShrink: 0,
         }}
       >
-        <span style={{ color: 'var(--text-strong)', fontWeight: 'var(--fw-semibold)', fontSize: 'var(--fs-sm)' }}>
-          {label}
+        <span style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
+          <span style={{ width: 7, height: 7, borderRadius: 999, background: accent, flexShrink: 0 }} />
+          <span style={{ color: 'var(--text-strong)', fontWeight: 'var(--fw-semibold)', fontSize: 'var(--fs-sm)' }}>
+            {label}
+          </span>
         </span>
         <Badge tone="muted">{folder.count}</Badge>
       </div>
       <div style={{ flex: 1, overflowY: 'auto', padding: '8px 8px', display: 'grid', gap: 2, alignContent: 'start' }}>
         {files.length > 0
           ? files.map((f) => <FileButton key={f.name} file={f} />)
-          : <div style={{ color: 'var(--muted)', fontSize: 'var(--fs-xs)', padding: '8px 6px' }}>Empty.</div>}
+          : <div style={{ color: 'var(--muted)', fontSize: 'var(--fs-xs)', padding: '8px 6px' }}>Nothing generated here yet.</div>}
       </div>
     </Panel>
   )
@@ -234,7 +295,12 @@ export default function Materials() {
       <div style={{ ...EYEBROW, margin: '4px 2px 12px' }}>Folders {'\u2014'} click a file to preview &amp; print</div>
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: 14 }}>
         {FOLDER_ORDER.filter((k) => folders[k]).map((key) => (
-          <FolderBox key={key} label={FOLDER_LABEL[key] || key} folder={folders[key]} />
+          <FolderBox
+            key={key}
+            label={FOLDER_LABEL[key] || key}
+            folder={folders[key]}
+            accent={FOLDER_ACCENT[key] || 'var(--cyan-300)'}
+          />
         ))}
       </div>
 

--- a/frontend/src/screens/Materials.jsx
+++ b/frontend/src/screens/Materials.jsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import {
   useApi, Screen, SectionHead, StatGrid, Stat, Badge, EmptyState, EYEBROW,
 } from './_shared.jsx'
@@ -9,9 +9,14 @@ import { openFileNative } from '../shell/nativeOpen.js'
 /* Materials — generated resumes, cover letters, PDFs, and prep docs.
    Data: GET /dashboard/materials/data (_materials_payload).
 
-   Folder boxes are uniform-height with an internal scroll so the grid stays
-   even no matter how many files a folder holds. Clicking a file opens a
-   preview window with a Print button (works for PDF / text / images). */
+   Layout: stat strip → "recent" strip (the 6 newest files across every
+   folder — the file you just generated is almost always the one you want)
+   → one global filter over all folders → accent-tinted folder cards with
+   per-row ages → the untracked-resumes audit.
+
+   Clicking a file opens a preview window (hosted) or the OS-default app
+   (desktop — the webview can't do popups/downloads). Failures render
+   inline on the row; window.alert is unreliable in the Tauri webview. */
 
 const FOLDER_LABEL = {
   optimized_resumes: 'Optimized resumes',
@@ -26,8 +31,7 @@ const FOLDER_ORDER = [
   'cover_letter_pdfs', 'job_assessments', 'interview_prep',
 ]
 
-/* Per-folder accent for the header dot — the grid reads as six equal gray
-   boxes otherwise. */
+/* Per-folder accent — the grid reads as six equal gray boxes otherwise. */
 const FOLDER_ACCENT = {
   optimized_resumes: 'var(--cyan-300)',
   cover_letters: '#C7A9E8',
@@ -53,6 +57,16 @@ const PREVIEWABLE = new Set(['pdf', 'txt', 'md', 'png', 'jpg', 'jpeg', 'gif', 's
 
 function extOf(file) {
   return (file.ext || '').replace('.', '').toLowerCase()
+}
+
+function relTime(epochSec) {
+  if (!epochSec) return ''
+  const mins = Math.max(0, Math.round((Date.now() / 1000 - epochSec) / 60))
+  if (mins < 60) return `${mins}m`
+  if (mins < 60 * 24) return `${Math.round(mins / 60)}h`
+  const days = Math.round(mins / 60 / 24)
+  if (days < 30) return `${days}d`
+  return new Date(epochSec * 1000).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
 }
 
 function escapeHtml(s) {
@@ -81,7 +95,7 @@ function openPreview(file) {
   const previewable = PREVIEWABLE.has(extOf(file))
   const content = previewable
     ? `<iframe id="pv" src="${href}" title="${name}"></iframe>`
-    : `<div class="msg">This file type can\u2019t be previewed inline.<br/>
+    : `<div class="msg">This file type can’t be previewed inline.<br/>
          <a class="btn" href="${href}" download>Download ${name}</a></div>`
 
   win.document.write(`<!doctype html><html lang="en"><head><meta charset="utf-8"/>
@@ -123,15 +137,11 @@ function openPreview(file) {
   win.document.close()
 }
 
-function FileButton({ file }) {
-  const ext = extOf(file) || 'file'
-  const extColor = EXT_COLOR[ext] || 'var(--cyan-300)'
-  // Desktop: the webview can't open popup previews or downloads — the
-  // backend opens the file in its OS-default app instead (view/print/save).
+/* Shared open lifecycle: idle | busy | error. The native open has no
+   visible in-app response, so the row/card itself confirms the click and
+   surfaces failures inline. */
+function useOpenFile(file) {
   const isDesktop = useDesktopMode()
-  // idle | busy | error — the native open has no visible in-app response,
-  // so the row itself must confirm the click (or surface the failure;
-  // window.alert doesn't reliably render in the Tauri webview).
   const [state, setState] = useState('idle')
   const resetTimer = useRef(null)
   const open = async () => {
@@ -146,6 +156,43 @@ function FileButton({ file }) {
     setState(ok ? 'idle' : 'error')
     if (!ok) resetTimer.current = setTimeout(() => setState('idle'), 4000)
   }
+  return { open, state, isDesktop }
+}
+
+function ExtChip({ ext }) {
+  const color = EXT_COLOR[ext] || 'var(--cyan-300)'
+  return (
+    <span
+      style={{
+        flexShrink: 0, fontSize: 'var(--fs-2xs)', fontWeight: 'var(--fw-bold)',
+        textTransform: 'uppercase', letterSpacing: '0.3px',
+        padding: '2px 6px', borderRadius: 4,
+        background: `color-mix(in srgb, ${color} 13%, transparent)`,
+        color,
+      }}
+    >
+      {ext}
+    </span>
+  )
+}
+
+function OpenState({ state }) {
+  if (state === 'busy') {
+    return <span style={{ flexShrink: 0, fontSize: 'var(--fs-2xs)', color: 'var(--muted)' }}>Opening…</span>
+  }
+  if (state === 'error') {
+    return (
+      <span style={{ flexShrink: 0, fontSize: 'var(--fs-2xs)', color: 'var(--warn)' }}>
+        Couldn&rsquo;t open
+      </span>
+    )
+  }
+  return null
+}
+
+function FileRow({ file }) {
+  const ext = extOf(file) || 'file'
+  const { open, state, isDesktop } = useOpenFile(file)
   return (
     <button
       type="button"
@@ -169,53 +216,121 @@ function FileButton({ file }) {
         e.currentTarget.style.borderColor = 'transparent'
       }}
     >
-      <span
-        style={{
-          flexShrink: 0, fontSize: 'var(--fs-2xs)', fontWeight: 'var(--fw-bold)',
-          textTransform: 'uppercase', letterSpacing: '0.3px',
-          padding: '2px 6px', borderRadius: 4,
-          background: `color-mix(in srgb, ${extColor} 13%, transparent)`,
-          color: extColor,
-        }}
-      >
-        {ext}
-      </span>
+      <ExtChip ext={ext} />
       <span style={{ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
         {file.name}
       </span>
-      {state === 'busy' && (
-        <span style={{ flexShrink: 0, fontSize: 'var(--fs-2xs)', color: 'var(--muted)' }}>Opening…</span>
-      )}
-      {state === 'error' && (
-        <span style={{ flexShrink: 0, fontSize: 'var(--fs-2xs)', color: 'var(--warn)' }}>
-          Couldn&rsquo;t open
+      <OpenState state={state} />
+      {state === 'idle' && file.mtime ? (
+        <span
+          style={{
+            flexShrink: 0, fontFamily: 'var(--font-mono)', fontSize: 'var(--fs-2xs)',
+            color: 'var(--faint)',
+          }}
+        >
+          {relTime(file.mtime)}
         </span>
-      )}
+      ) : null}
     </button>
   )
 }
 
-function FolderBox({ label, folder, accent }) {
-  const files = folder.files || []
+/* "Recent" strip card — the newest files across every folder, one glance. */
+function RecentCard({ entry }) {
+  const { file, folderKey } = entry
+  const ext = extOf(file) || 'file'
+  const accent = FOLDER_ACCENT[folderKey] || 'var(--cyan-300)'
+  const { open, state, isDesktop } = useOpenFile(file)
+  return (
+    <button
+      type="button"
+      onClick={open}
+      title={isDesktop ? `Open ${file.name}` : `Preview ${file.name}`}
+      style={{
+        appearance: 'none', cursor: 'pointer', textAlign: 'left',
+        flex: '1 1 210px', maxWidth: 320, minWidth: 0,
+        display: 'flex', flexDirection: 'column', gap: 7,
+        padding: '12px 14px', borderRadius: 'var(--radius-md)',
+        background: `linear-gradient(150deg, color-mix(in srgb, ${accent} 9%, transparent), rgba(255,255,255,.03))`,
+        border: `1px solid color-mix(in srgb, ${accent} 22%, transparent)`,
+        color: 'var(--text-soft)',
+        opacity: state === 'busy' ? 0.6 : 1,
+        transition: 'transform .12s ease, border-color .12s ease',
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.transform = 'translateY(-1px)'
+        e.currentTarget.style.borderColor = `color-mix(in srgb, ${accent} 45%, transparent)`
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.transform = 'none'
+        e.currentTarget.style.borderColor = `color-mix(in srgb, ${accent} 22%, transparent)`
+      }}
+    >
+      <span style={{ display: 'flex', alignItems: 'center', gap: 8, width: '100%' }}>
+        <ExtChip ext={ext} />
+        <span style={{ flex: 1 }} />
+        <OpenState state={state} />
+        {state === 'idle' && (
+          <span style={{ fontFamily: 'var(--font-mono)', fontSize: 'var(--fs-2xs)', color: 'var(--faint)' }}>
+            {relTime(file.mtime)}
+          </span>
+        )}
+      </span>
+      <span
+        style={{
+          fontSize: 'var(--fs-sm)', fontWeight: 'var(--fw-semibold)', color: 'var(--text)',
+          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', width: '100%',
+        }}
+      >
+        {file.name}
+      </span>
+      <span style={{ fontSize: 'var(--fs-2xs)', color: accent }}>
+        {FOLDER_LABEL[folderKey] || folderKey}
+      </span>
+    </button>
+  )
+}
+
+function FolderBox({ folderKey, folder, query }) {
+  const label = FOLDER_LABEL[folderKey] || folderKey
+  const accent = FOLDER_ACCENT[folderKey] || 'var(--cyan-300)'
+  const all = folder.files || []
+  const files = query
+    ? all.filter((f) => f.name.toLowerCase().includes(query))
+    : all
+  if (query && files.length === 0) return null
+  const newest = all[0]?.mtime
   return (
     <Panel pad="0" style={{ display: 'flex', flexDirection: 'column', height: 300, overflow: 'hidden' }}>
       <div
         style={{
           display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-          padding: '12px 14px', borderBottom: '1px solid var(--border-soft)', flexShrink: 0,
+          padding: '12px 14px', flexShrink: 0,
+          background: `linear-gradient(150deg, color-mix(in srgb, ${accent} 10%, transparent), transparent 70%)`,
+          borderBottom: `1px solid color-mix(in srgb, ${accent} 18%, var(--border-soft))`,
         }}
       >
-        <span style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
-          <span style={{ width: 7, height: 7, borderRadius: 999, background: accent, flexShrink: 0 }} />
-          <span style={{ color: 'var(--text-strong)', fontWeight: 'var(--fw-semibold)', fontSize: 'var(--fs-sm)' }}>
+        <span style={{ minWidth: 0 }}>
+          <span
+            style={{
+              display: 'block', color: 'var(--text-strong)',
+              fontWeight: 'var(--fw-semibold)', fontSize: 'var(--fs-sm)',
+              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+            }}
+          >
             {label}
           </span>
+          {newest ? (
+            <span style={{ fontSize: 'var(--fs-2xs)', color: 'var(--muted)' }}>
+              updated {relTime(newest)} ago
+            </span>
+          ) : null}
         </span>
-        <Badge tone="muted">{folder.count}</Badge>
+        <Badge tone="muted">{query ? `${files.length}/${folder.count}` : folder.count}</Badge>
       </div>
       <div style={{ flex: 1, overflowY: 'auto', padding: '8px 8px', display: 'grid', gap: 2, alignContent: 'start' }}>
         {files.length > 0
-          ? files.map((f) => <FileButton key={f.name} file={f} />)
+          ? files.map((f) => <FileRow key={f.name} file={f} />)
           : <div style={{ color: 'var(--muted)', fontSize: 'var(--fs-xs)', padding: '8px 6px' }}>Nothing generated here yet.</div>}
       </div>
     </Panel>
@@ -227,12 +342,15 @@ function UntrackedSection({ files }) {
   const filtered = files.filter((f) => !q || f.toLowerCase().includes(q.toLowerCase()))
 
   return (
-    <div style={{ marginTop: 24 }}>
+    <div style={{ marginTop: 28 }}>
       <SectionHead title="Untracked resume files" right={`${filtered.length}`} />
+      <div style={{ fontSize: 'var(--fs-xs)', color: 'var(--muted)', margin: '-4px 0 10px' }}>
+        Resumes with no tracked application — worth linking or archiving.
+      </div>
       <input
         value={q}
         onChange={(e) => setQ(e.target.value)}
-        placeholder={'Filter untracked files\u2026'}
+        placeholder={'Filter untracked files…'}
         style={{
           width: '100%', maxWidth: 440, marginBottom: 12,
           background: 'var(--surface-sunken)', border: '1px solid var(--border)',
@@ -258,7 +376,7 @@ function UntrackedSection({ files }) {
         </div>
       ) : (
         <div style={{ color: 'var(--muted)', fontSize: 'var(--fs-sm)' }}>
-          All clear {'\u2014'} every resume maps to a tracked application.
+          All clear {'—'} every resume maps to a tracked application.
         </div>
       )}
     </div>
@@ -267,9 +385,20 @@ function UntrackedSection({ files }) {
 
 export default function Materials() {
   const { data, loading, error } = useApi('/dashboard/materials/data')
-  const folders = data?.folders || {}
+  const [query, setQuery] = useState('')
+  const folders = useMemo(() => data?.folders || {}, [data])
   const totalFiles = Object.values(folders).reduce((n, f) => n + (f.count || 0), 0)
   const untracked = data?.untracked_resume_files || []
+  const q = query.trim().toLowerCase()
+
+  // Six newest files across all folders — server pre-sorts each folder by
+  // mtime desc, so a merge of the heads is cheap.
+  const recent = useMemo(() => {
+    const entries = FOLDER_ORDER.flatMap((key) =>
+      (folders[key]?.files || []).slice(0, 6).map((file) => ({ file, folderKey: key })),
+    ).filter((e) => e.file.mtime)
+    return entries.sort((a, b) => b.file.mtime - a.file.mtime).slice(0, 6)
+  }, [folders])
 
   return (
     <Screen
@@ -292,17 +421,47 @@ export default function Materials() {
         />
       </StatGrid>
 
-      <div style={{ ...EYEBROW, margin: '4px 2px 12px' }}>Folders {'\u2014'} click a file to preview &amp; print</div>
+      {recent.length > 0 && !q && (
+        <>
+          <div style={{ ...EYEBROW, margin: '4px 2px 10px' }}>Recent {'—'} fresh off the press</div>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, marginBottom: 22 }}>
+            {recent.map((e) => (
+              <RecentCard key={`${e.folderKey}/${e.file.name}`} entry={e} />
+            ))}
+          </div>
+        </>
+      )}
+
+      <div
+        style={{
+          display: 'flex', alignItems: 'baseline', justifyContent: 'space-between',
+          gap: 14, flexWrap: 'wrap', margin: '4px 2px 12px',
+        }}
+      >
+        <div style={EYEBROW}>Folders {'—'} click a file to open &amp; print</div>
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={`Filter ${totalFiles} files…`}
+          style={{
+            flex: '0 1 300px',
+            background: 'var(--surface-sunken)', border: '1px solid var(--border)',
+            borderRadius: 'var(--radius-sm)', padding: '8px 11px',
+            color: 'var(--text)', fontSize: 'var(--fs-sm)',
+          }}
+        />
+      </div>
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: 14 }}>
         {FOLDER_ORDER.filter((k) => folders[k]).map((key) => (
-          <FolderBox
-            key={key}
-            label={FOLDER_LABEL[key] || key}
-            folder={folders[key]}
-            accent={FOLDER_ACCENT[key] || 'var(--cyan-300)'}
-          />
+          <FolderBox key={key} folderKey={key} folder={folders[key]} query={q} />
         ))}
       </div>
+      {q && FOLDER_ORDER.every((k) => {
+        const fs = folders[k]?.files || []
+        return fs.every((f) => !f.name.toLowerCase().includes(q))
+      }) && (
+        <EmptyState label={`No files match “${query.trim()}”.`} />
+      )}
 
       {untracked.length > 0 && <UntrackedSection files={untracked} />}
 

--- a/frontend/src/shell/nativeOpen.js
+++ b/frontend/src/shell/nativeOpen.js
@@ -5,11 +5,18 @@
 // anchor/popup behavior.
 import { apiPost } from '../auth/api.js'
 
-/** Open a workspace-file href (materials/pipeline artifacts) natively. */
-export function openFileNative(href) {
-  return apiPost('/desktop/open-file', { href }).catch(() => {
-    window.alert('Could not open the file.')
-  })
+/** Open a workspace-file href (materials/pipeline artifacts) natively.
+ *  Resolves true/false; pass notify:false to render failures inline —
+ *  window.alert is unreliable in the Tauri webview (notably WebKitGTK),
+ *  which made Linux failures fully silent. */
+export function openFileNative(href, { notify = true } = {}) {
+  return apiPost('/desktop/open-file', { href }).then(
+    () => true,
+    () => {
+      if (notify) window.alert('Could not open the file.')
+      return false
+    },
+  )
 }
 
 /** Open an external http(s) URL in the system browser. */

--- a/tests/test_desktop_mode.py
+++ b/tests/test_desktop_mode.py
@@ -687,10 +687,10 @@ def test_open_file_rejects_traversal_and_foreign_hrefs(desktop_client, desktop_d
 
 
 def test_open_url_http_only(desktop_client, monkeypatch):
-    import webbrowser
+    import transport.http.desktop.os_open as desktop_mod
 
     opened = {}
-    monkeypatch.setattr(webbrowser, "open", lambda t: opened.setdefault("t", t))
+    monkeypatch.setattr(desktop_mod, "_open_with_os", lambda t: opened.setdefault("t", t))
     resp = desktop_client.post("/desktop/open-url", json={"url": "https://www.linkedin.com/posts/x"})
     assert resp.status_code == 200
     assert opened["t"].startswith("https://")
@@ -714,7 +714,7 @@ class TestOpenWithOsArgumentInjection:
         monkeypatch.setattr(desktop_mod.sys, "platform", "linux")
         monkeypatch.setattr(desktop_mod.os, "name", "posix")
         calls = []
-        monkeypatch.setattr(subprocess, "Popen", lambda args: calls.append(args))
+        monkeypatch.setattr(subprocess, "Popen", lambda args, env=None: calls.append(args))
 
         desktop_mod._open_with_os("--dangerous-flag")
 
@@ -728,7 +728,7 @@ class TestOpenWithOsArgumentInjection:
         monkeypatch.setattr(desktop_mod.sys, "platform", "linux")
         monkeypatch.setattr(desktop_mod.os, "name", "posix")
         calls = []
-        monkeypatch.setattr(subprocess, "Popen", lambda args: calls.append(args))
+        monkeypatch.setattr(subprocess, "Popen", lambda args, env=None: calls.append(args))
 
         desktop_mod._open_with_os("/workspace/resumes/resume.pdf")
 
@@ -736,8 +736,8 @@ class TestOpenWithOsArgumentInjection:
 
     def test_url_target_is_never_dash_prefixed(self, monkeypatch):
         """A validated http(s) URL can never start with '-', so the guard
-        must be a no-op for the open-url call site (now handled by
-        webbrowser.open, not _open_with_os)."""
+        must be a no-op for the open-url call site (routed through
+        _open_with_os so URLs get the same scrubbed child env as files)."""
         import subprocess
 
         import transport.http.desktop.os_open as desktop_mod
@@ -745,11 +745,72 @@ class TestOpenWithOsArgumentInjection:
         monkeypatch.setattr(desktop_mod.sys, "platform", "linux")
         monkeypatch.setattr(desktop_mod.os, "name", "posix")
         calls = []
-        monkeypatch.setattr(subprocess, "Popen", lambda args: calls.append(args))
+        monkeypatch.setattr(subprocess, "Popen", lambda args, env=None: calls.append(args))
 
         desktop_mod._open_with_os("https://example.com/job/123")
 
         assert calls == [["xdg-open", "https://example.com/job/123"]]
+
+
+class TestOpenerChildEnv:
+    """The frozen sidecar's LD_LIBRARY_PATH (PyInstaller's private libs)
+    must never leak into xdg-open's children — it crashes the launched
+    viewer against mismatched system libs, so the open 'succeeds' while
+    nothing appears (the Linux desktop dead-click)."""
+
+    def test_pyinstaller_lib_path_is_restored_to_orig(self, monkeypatch):
+        import transport.http.desktop.os_open as desktop_mod
+
+        monkeypatch.setenv("LD_LIBRARY_PATH", "/tmp/_MEIxyz/lib")
+        monkeypatch.setenv("LD_LIBRARY_PATH_ORIG", "/usr/local/lib")
+        env = desktop_mod._child_env()
+        assert env["LD_LIBRARY_PATH"] == "/usr/local/lib"
+
+    def test_pyinstaller_lib_path_is_dropped_without_orig(self, monkeypatch):
+        import transport.http.desktop.os_open as desktop_mod
+
+        monkeypatch.setenv("LD_LIBRARY_PATH", "/tmp/_MEIxyz/lib")
+        monkeypatch.delenv("LD_LIBRARY_PATH_ORIG", raising=False)
+        env = desktop_mod._child_env()
+        assert "LD_LIBRARY_PATH" not in env
+
+    def test_popen_receives_scrubbed_env(self, monkeypatch):
+        import subprocess
+
+        import transport.http.desktop.os_open as desktop_mod
+
+        monkeypatch.setattr(desktop_mod.sys, "platform", "linux")
+        monkeypatch.setattr(desktop_mod.os, "name", "posix")
+        monkeypatch.setenv("LD_LIBRARY_PATH", "/tmp/_MEIxyz/lib")
+        monkeypatch.delenv("LD_LIBRARY_PATH_ORIG", raising=False)
+        seen = {}
+        monkeypatch.setattr(
+            subprocess, "Popen", lambda args, env=None: seen.update(args=args, env=env)
+        )
+
+        desktop_mod._open_with_os("/workspace/resumes/resume.pdf")
+
+        assert seen["env"] is not None
+        assert "LD_LIBRARY_PATH" not in seen["env"]
+
+    def test_missing_opener_becomes_500_detail(self, desktop_client, desktop_data_dir_env, monkeypatch, tmp_path):
+        import transport.http.desktop.os_open as desktop_mod
+        from transport.http.routes.dashboard import materials
+
+        folder = tmp_path / "cls"
+        folder.mkdir()
+        (folder / "r.pdf").write_bytes(b"pdf")
+        monkeypatch.setattr(materials, "_folder_path", lambda key: folder if key == "cover_letters" else None)
+
+        def boom(_t):
+            raise FileNotFoundError("xdg-open")
+
+        monkeypatch.setattr(desktop_mod, "_open_with_os", boom)
+        resp = desktop_client.post(
+            "/desktop/open-file", json={"href": "/dashboard/materials/file/cover_letters/r.pdf"}
+        )
+        assert resp.status_code == 500
+        assert "opener" in resp.json()["detail"]
 
 
 def test_open_file_renders_markdown_to_pdf(desktop_client, desktop_data_dir_env, monkeypatch, tmp_path):

--- a/transport/http/desktop/os_open.py
+++ b/transport/http/desktop/os_open.py
@@ -18,6 +18,26 @@ from pydantic import BaseModel
 router = APIRouter(tags=["desktop"])
 
 
+def _child_env() -> dict:
+    """Environment for OS-opener children, scrubbed of PyInstaller leakage.
+
+    The frozen sidecar exports LD_LIBRARY_PATH pointing at its bundled
+    private libraries. xdg-open — and the viewer it launches — inherits it
+    and can crash on startup against mismatched system libs, so the Popen
+    "succeeds" while nothing ever appears (the Linux desktop dead-click).
+    PyInstaller preserves the pre-freeze value in <VAR>_ORIG: restore that,
+    or drop the variable entirely. In dev the vars are absent — no-op.
+    """
+    env = dict(os.environ)
+    for var in ("LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH"):
+        orig = env.get(f"{var}_ORIG")
+        if orig:
+            env[var] = orig
+        else:
+            env.pop(var, None)
+    return env
+
+
 def _open_with_os(target: str) -> None:
     import subprocess
 
@@ -29,11 +49,11 @@ def _open_with_os(target: str) -> None:
         target = f"./{target}"
 
     if sys.platform == "darwin":
-        subprocess.Popen(["open", target])  # NOSONAR — list form (no shell); target is a resolved workspace path (containment-checked by open_file, basename-sanitized); taint from HTTP request is broken by os.path.basename sanitization in caller
+        subprocess.Popen(["open", target], env=_child_env())  # NOSONAR — list form (no shell); target is a resolved workspace path (containment-checked by open_file, basename-sanitized); taint from HTTP request is broken by os.path.basename sanitization in caller
     elif os.name == "nt":
         os.startfile(target)  # noqa: S606 — target is a resolved workspace path (containment-checked + basename-sanitized); validated upstream
     else:
-        subprocess.Popen(["xdg-open", target])  # NOSONAR — list form (no shell); target is a resolved workspace path (containment-checked by open_file, basename-sanitized); taint from HTTP request is broken by os.path.basename sanitization in caller
+        subprocess.Popen(["xdg-open", target], env=_child_env())  # NOSONAR — list form (no shell); target is a resolved workspace path (containment-checked by open_file, basename-sanitized); taint from HTTP request is broken by os.path.basename sanitization in caller
 
 
 class OpenFileRequest(BaseModel):
@@ -90,11 +110,23 @@ async def open_file(request: OpenFileRequest) -> dict:
             )
         except Exception:  # noqa: BLE001 — fall back to the raw file
             pdf = target
-        _open_with_os(str(pdf))
+        _launch(str(pdf))
         return {"status": "opened", "name": target.name, "rendered": str(pdf) != str(target)}
 
-    _open_with_os(str(target))
+    _launch(str(target))
     return {"status": "opened", "name": target.name}
+
+
+def _launch(target: str) -> None:
+    """_open_with_os with a missing-opener guard surfaced as a real error
+    instead of a 500 traceback — the SPA shows the detail inline."""
+    try:
+        _open_with_os(target)
+    except FileNotFoundError:
+        raise HTTPException(
+            status_code=500,
+            detail="No system opener found (is xdg-open installed?).",
+        ) from None
 
 
 class OpenUrlRequest(BaseModel):
@@ -103,15 +135,18 @@ class OpenUrlRequest(BaseModel):
 
 @router.post("/desktop/open-url")
 async def open_url(request: OpenUrlRequest) -> dict:
-    """Open an http(s) URL in the system browser."""
-    import webbrowser
+    """Open an http(s) URL in the default browser.
+
+    Routed through the same launcher as files (not stdlib webbrowser): on
+    Linux webbrowser.open also spawns xdg-open, inheriting the frozen
+    sidecar's poisoned LD_LIBRARY_PATH — the same silent dead-click the
+    file path had. One launcher, one env scrub.
+    """
     from urllib.parse import urlsplit
 
     url = request.url.strip()
     scheme = urlsplit(url).scheme.lower()
     if scheme not in ("http", "https"):
         raise HTTPException(status_code=422, detail="Only http(s) links can be opened.")
-    # webbrowser.open is the stdlib-recommended way to launch a URL in the
-    # default browser; it does not involve shell execution or file-path sinks.
-    await asyncio.to_thread(webbrowser.open, url)
+    await asyncio.to_thread(_launch, url)
     return {"status": "opened"}

--- a/transport/http/routes/dashboard/materials.py
+++ b/transport/http/routes/dashboard/materials.py
@@ -47,6 +47,9 @@ def _scan_folders() -> dict:
                         "name": f.name,
                         "ext": f.suffix.lower(),
                         "href": f"/dashboard/materials/file/{key}/{quote(f.name, safe='')}",
+                        # Epoch seconds; the SPA renders relative ages and a
+                        # cross-folder "recent" strip from this.
+                        "mtime": int(f.stat().st_mtime),
                     }
                     for f in files
                 ],


### PR DESCRIPTION
Three commits: the Linux dead-click fix, the Materials redesign, and dispatchable desktop releases.

## 1. Fix: clicking files did nothing on the Linux desktop app (`0764b58`)

Two stacked failures, each independently hiding the problem:

1. **Poisoned child environment.** The PyInstaller-frozen sidecar exports `LD_LIBRARY_PATH` pointing at its bundled private libs. `xdg-open` — and the viewer it launches — inherits it and crashes against mismatched system libraries, so the `Popen` "succeeds" while nothing appears. Fixed by scrubbing the child env (restore PyInstaller's saved `*_ORIG` or drop the var). No-op in dev; macOS/Windows never hit this.
2. **Invisible errors.** The fallback was `window.alert`, which WebKitGTK/Tauri doesn't reliably render. Failures now show inline on the file row; a missing opener returns a clear 500 detail.

`/desktop/open-url` had the same latent bug via stdlib `webbrowser` and now uses the same scrubbed launcher. New regression tests cover the env scrub, Popen env pass-through, and missing-opener path.

## 2. Redesign: Materials was six identical gray boxes (`b658913`)

- **"Recent" strip** — the six newest files across every folder as accent-tinted cards
- **Global filter** — one input filters all files live; counts show matched/total, empty folders drop out
- **Living folder cards** — accent-tinted header bands, "updated 2h ago" lines, per-row relative ages
- **Click feedback** — rows/cards confirm with "Opening…", surface failures inline
- Backend: file entries now carry `mtime` (epoch seconds; additive payload change)

## 3. CI: dispatchable desktop releases (`b175943`)

`desktop-release.yml` gains `workflow_dispatch` (`version` + optional `target` SHA). A `meta` job resolves tag-and-commit once for both trigger shapes; `gh release create --target` creates the tag at the pinned commit on dispatch, so releases can be cut from the Actions UI or by agent sessions without tag-push rights. Pass `target` explicitly to pin the tested main SHA (the default ref head may be a badge-bot `[skip ci]` commit). Tag-push behavior unchanged.

## Testing

`pytest tests/test_desktop_mode.py` 61/61 · materials API tests pass · eslint clean · `vite build` passes · vitest 4/4 · workflow YAML validated

## Deploy

Touches `transport/**` + `frontend/**` → merge runs the full `deploy.yml` pipeline. After merge, cut **`desktop-v1.0.0-beta.24`** — and since the dispatch trigger lands with this same merge, that release can be dispatched directly (no tag push needed): Actions → Desktop Release → Run workflow with `version=1.0.0-beta.24`, `target=<merge SHA>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MhvVfvVWmAPcqgcvBWUsYC