### PR TITLE
frontend: portal modals to body — Add Job modal was clipped on short pages

### DIFF
--- a/frontend/src/screens/Posts.jsx
+++ b/frontend/src/screens/Posts.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { createPortal } from 'react-dom'
 import useDesktopMode from '../shell/useDesktopMode.js'
 import { nativeAnchorHandler } from '../shell/nativeOpen.js'
 import { useToolbarSlot } from '../shell/toolbarSlot.jsx'
@@ -49,7 +50,9 @@ function MetricSheet({ post, onClose, onSaved }) {
     color: 'var(--text)', fontSize: 15, fontFamily: 'var(--font-sans)', outline: 'none',
   }
 
-  return (
+  // Portal to <body> — same containing-block trap as pipeline's Modal:
+  // .jc-page animates `transform`, which captures fixed descendants.
+  return createPortal(
     <div
       onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
       style={{ position: 'fixed', inset: 0, zIndex: 90, background: 'rgba(4,7,14,.66)', backdropFilter: 'blur(3px)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 20 }}
@@ -81,7 +84,8 @@ function MetricSheet({ post, onClose, onSaved }) {
           {busy ? 'Saving…' : 'Save metrics'}
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   )
 }
 

--- a/frontend/src/screens/pipeline/shared.jsx
+++ b/frontend/src/screens/pipeline/shared.jsx
@@ -1,3 +1,4 @@
+import { createPortal } from 'react-dom'
 import { Panel } from '../../design-system'
 import { ApiError } from '../../auth/api.js'
 
@@ -19,7 +20,11 @@ export const modalField = {
 export const modalLabel = { display: 'block', fontSize: 'var(--fs-xs)', color: 'var(--muted)', marginBottom: 5 }
 
 export function Modal({ title, onClose, children, maxWidth = 640 }) {
-  return (
+  // Portal to <body>: .jc-page's enter animation animates `transform`,
+  // which makes it the containing block for fixed descendants — a modal
+  // rendered in-tree gets trapped (and clipped) inside the page wrapper,
+  // visibly so when the page content is short (empty pipeline, qa).
+  return createPortal(
     <div
       onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
       style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.7)', zIndex: 900, overflowY: 'auto', padding: '24px 14px' }}
@@ -31,7 +36,8 @@ export function Modal({ title, onClose, children, maxWidth = 640 }) {
         </div>
         {children}
       </Panel>
-    </div>
+    </div>,
+    document.body,
   )
 }
 


### PR DESCRIPTION
Fixes the clipped **Add Job** modal seen on qa's empty Pipeline page (screenshot report).

## Root cause

The modal overlays use `position: fixed`, which should pin them to the viewport — but `.jc-page` (the wrapper around every dashboard screen) runs the `jc-fadeUp` enter animation, which animates `transform`. An animated transform makes that element the **containing block** for fixed-position descendants, so the "viewport" overlay is actually positioned and sized against the page wrapper. On a short page (empty pipeline on qa), the modal clips at the content fold with its buttons unreachable; on a full page the wrapper is tall enough to mask the bug — which is why it survived on production data.

## Fix

Render both in-tree fixed overlays through `createPortal(…, document.body)`:
- `pipeline/shared.jsx` `Modal` (Add Job, template pickers, resume/cover-letter editors — all inherit)
- `Posts.jsx` metrics sheet (same latent trap)

Portaled overlays are immune to any ancestor transform/filter, now and future. No visual changes.

## Testing

eslint clean · `vite build` passes · vitest 4/4. Verify on qa: Pipeline (empty) → Add Job → modal centered over the full viewport, buttons reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MhvVfvVWmAPcqgcvBWUsYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhvVfvVWmAPcqgcvBWUsYC)_