### PR TITLE
latex: optional website field in resume + cover letter headers

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -47,12 +47,13 @@
     "safety_margin_tokens": 500
   },
 
-  "_comment_contact": "Contact info for cover letter PDF sidebar. Lives here (gitignored) so it never appears in source code.",
+  "_comment_contact": "Contact info for cover letter PDF sidebar. Lives here (gitignored) so it never appears in source code. 'website' is scheme-less (e.g. jobcontext.ai, not https://…) and optional — leave it empty and the resume/letter header renders only the LinkedIn + GitHub links.",
   "contact": {
     "name": "YOUR FULL NAME",
     "phone": "555-867-5309",
     "email": "you@example.com",
     "linkedin": "www.linkedin.com/in/yourhandle",
+    "website": "",
     "address": "123 Your Street",
     "city_state": "Your City, ST 00000",
     "location": "Your City, ST"

--- a/tests/test_latex_export.py
+++ b/tests/test_latex_export.py
@@ -43,6 +43,25 @@ def test_latex_user_identity_blank_strings_fall_back_to_placeholder(monkeypatch)
     assert "example" in identity["email"]
     assert identity["linkedin"] == "yourhandle"
     assert identity["github"] == "YourGitHub"
+    # website has NO placeholder: blank must stay blank so the header's
+    # \ifx\website\empty guard suppresses the third link entirely.
+    assert identity["website"] == ""
+
+
+def test_latex_user_identity_website_is_schemeless(monkeypatch):
+    """The header renders \\href{https://\\website}{\\website}, so the stored
+    value must come back scheme-less and without a trailing slash."""
+    monkeypatch.setattr(
+        latex_export.cfg, "get_contact_info",
+        lambda: {"website": "https://jobcontext.ai/"},
+    )
+    assert latex_export._user_identity()["website"] == "jobcontext.ai"
+
+    monkeypatch.setattr(
+        latex_export.cfg, "get_contact_info",
+        lambda: {"website": "jobcontext.ai"},
+    )
+    assert latex_export._user_identity()["website"] == "jobcontext.ai"
 
 
 def test_latex_cover_letter_defaults_to_cover_letter_pdf_folder(monkeypatch, tmp_path):
@@ -361,6 +380,39 @@ def test_inject_identity_overrides_all_contact_macros():
     # Non-identity macros (role) are never touched by identity injection.
     assert r"\def\role{Keep Me}" in out
     assert "PLACEHOLDER" not in out
+
+
+def test_inject_identity_sets_website_when_provided():
+    src = r"\def\website{}"
+    out = latex_export._inject_identity(src, {"website": "jobcontext.ai"})
+    assert r"\def\website{jobcontext.ai}" in out
+
+
+def test_inject_identity_blank_website_keeps_template_macro_empty():
+    """resume.tex ships \\def\\website{} and _header.tex hides the link via
+    \\ifx\\website\\empty — a blank identity value must leave that untouched
+    (never render a bare https:// link)."""
+    src = r"\def\website{}"
+    out = latex_export._inject_identity(src, {"website": ""})
+    assert out == src
+
+
+def test_cover_letter_template_carries_website_def():
+    """The cover-letter template must declare \\def\\website before
+    \\input{_header} so both documents can render the third header link; an
+    empty value must produce a literally-empty def (the guard's empty test)."""
+    rendered = latex_export._TEX_TEMPLATE.format(
+        name="N", phone="P", city="C", email="E", linkedin="L", github="G",
+        website="", role_title="R", date="D", body="B",
+    )
+    assert "\\def\\website{}" in rendered
+    assert rendered.index("\\def\\website{}") < rendered.index("\\input{_header}")
+
+    rendered = latex_export._TEX_TEMPLATE.format(
+        name="N", phone="P", city="C", email="E", linkedin="L", github="G",
+        website="jobcontext.ai", role_title="R", date="D", body="B",
+    )
+    assert "\\def\\website{jobcontext.ai}" in rendered
 
 
 def test_inject_identity_skips_absent_macros():

--- a/tools/latex_export.py
+++ b/tools/latex_export.py
@@ -51,6 +51,7 @@ _TEX_TEMPLATE = r"""\documentclass[letter,11pt]{{article}}
 \def\email{{{email}}}
 \def\linkedin{{{linkedin}}}
 \def\github{{{github}}}
+\def\website{{{website}}}
 \def\role{{{role_title}}}
 
 \input{{_header}}
@@ -143,6 +144,13 @@ def _user_identity() -> dict[str, str]:
     linkedin = linkedin.replace("https://www.linkedin.com/in/", "").replace("www.linkedin.com/in/", "").strip("/")
     github = str(contact.get("github", "") or "")
     github = github.replace("https://www.github.com/", "").replace("www.github.com/", "").replace("https://github.com/", "").strip("/")
+    # Personal site: _header.tex renders \href{https://\website}{\website},
+    # so the value must be scheme-less (a scheme would double-prefix). Unlike
+    # the other fields there is deliberately NO placeholder fallback — the
+    # header's \ifx\website\empty guard hides the third link entirely when
+    # unconfigured, and a fake placeholder URL would render as a real link.
+    website = str(contact.get("website", "") or "")
+    website = re.sub(r"^https?://", "", website.strip()).strip("/")
     return {
         "name":     str(contact.get("name", "") or "") or _AUTHOR_DEFAULTS["name"],
         "phone":    str(contact.get("phone", "") or "") or _AUTHOR_DEFAULTS["phone"],
@@ -150,6 +158,7 @@ def _user_identity() -> dict[str, str]:
         "email":    str(contact.get("email", "") or "") or _AUTHOR_DEFAULTS["email"],
         "linkedin": linkedin or _AUTHOR_DEFAULTS["linkedin"],
         "github":   github or _AUTHOR_DEFAULTS["github"],
+        "website":  website,
     }
 
 
@@ -394,7 +403,7 @@ _RESUME_TEX = "resume.tex"
 #: *fixed* set of literal names — never built from caller input — so the
 #: matchers below are fully static (no request-influenced regex construction).
 _MACRO_NAMES: tuple[str, ...] = (
-    "role", "name", "phone", "city", "email", "linkedin", "github",
+    "role", "name", "phone", "city", "email", "linkedin", "github", "website",
 )
 
 #: Precompiled ``\def\<macro>{...}`` matchers, one per known macro. Built from
@@ -410,7 +419,10 @@ _ROLE_DEF_RE = _MACRO_DEF_PATTERNS["role"]
 #: Header identity macros populated from the active user's contact info so a
 #: compiled resume never carries another user's name/contact. Mirrors the
 #: cover-letter pipeline's _user_identity() field set.
-_IDENTITY_MACROS = ("name", "phone", "city", "email", "linkedin", "github")
+#: \website has no placeholder default: blank means "no third header link"
+#: (resume.tex ships \def\website{} and _header.tex guards on \ifx\website\empty),
+#: and _inject_def's blank-is-no-op behavior preserves exactly that.
+_IDENTITY_MACROS = ("name", "phone", "city", "email", "linkedin", "github", "website")
 
 #: Defensive ceiling on an injected header value (name/role are short by nature).
 _MACRO_VALUE_MAX_LEN = 200


### PR DESCRIPTION
Adds `contact.website` (scheme-less, e.g. `jobcontext.ai`) as a third header link on **both** LaTeX documents — resume and cover letter.

The template side already existed (`resume.tex` ships `\def\website{}`; `_header.tex` renders `\href{https://\website}{\website}` behind an `\ifx\website\empty` guard). This PR wires the Python side:

- **`_user_identity()`** reads `contact.website`, strips any scheme / trailing slash (the header prefixes `https://` itself). Deliberately **no placeholder fallback**, unlike name/email/etc.: blank means "no third link" — a fake placeholder URL would render as a real link on an unconfigured workspace.
- **Resume path**: `website` joins the static macro allowlist (`_MACRO_NAMES` / `_IDENTITY_MACROS`), so `_inject_identity` rewrites `\def\website{…}` on the compile-time copy. `_inject_def`'s blank-is-no-op behavior keeps the template's empty def when unconfigured — fail closed.
- **Cover letter**: `_TEX_TEMPLATE` gains `\def\website{{{website}}}` before `\input{_header}`, filled from the same identity dict.
- **Per-application override** rides the existing `identity=` parameter on both entry points (`identity={"website": …}` or `{"website": ""}` to suppress) — no new signature needed.
- `config.example.json` documents the key, empty by default.

## Testing

New tests: scheme stripping, blank-stays-blank (no placeholder), injection when set, no-op when blank, cover-letter template def ordering. `pytest tests/test_latex_export.py tests/test_generate_coverage.py` → **69/69**.

Note for the desktop workflow: after this reaches your desktop build (or when running from source), set `"website": "jobcontext.ai"` in the contact block and re-export — existing PDFs predate the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MhvVfvVWmAPcqgcvBWUsYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhvVfvVWmAPcqgcvBWUsYC)_