### PR TITLE
release: v1.4.0 — visible provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,32 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+---
+
+## [1.4.0] - 2026-07-24
+
+The visible-provenance release: the truth gate's verdict now reaches the user on every path that produces or edits a document — one formatted line in every confirmation, a pass/fail badge in the dashboard — and the AI edit dialogs, which had been bypassing the gate entirely, are gated and audited. Plus mobile over-the-air updates and screen-to-screen navigation, an actionable Home dashboard, a Materials redesign, and a LaTeX header website field. 1526 passing tests.
+
 ### Features
 
 - **Provenance verdict surfaced to the user** -- the gate ran on every generation and wrote its audit row, but the single-shot dashboard path completed silently. Now `lib/provenance.format_provenance_line()` is the single source of truth for a one-line verdict (`Provenance: ✓ PASS — 6 claims traced to source, 0 unsourced` / `Provenance: ⚠ 2 unsourced — "47%", "$9M"`), consumed by the single-shot confirmation strings, the agent-pipeline header, and the API (`provenance` field on the generate-resume / generate-cover-letter responses). The Pipeline screen shows a dismissible result banner with a green/amber badge after every generation. Observe-and-report: a FAIL is informational — the document still generates with the warning attached.
 - **Truth gate on the AI edit dialogs** -- `/pipeline/edit-resume` and `/pipeline/edit-cover-letter` called the LLM directly and never ran the gate: an inline edit could inject a fabricated metric with no audit row and no warning. Both now run the observe-and-report gate over the edited draft (audit kinds `resume_edit` / `cover_letter_edit`), with sources = everything the model was shown (current document, JD, edit instructions — an explicitly instructed number is in-source by design). The verdict renders in the Edit Resume result view and in the cover-letter review phase, next to Accept & apply / Discard.
 - The `workflows/langgraph` resume graph anchors its revise trigger on the FAIL shape (`Provenance: ⚠ N unsourced`) so neither the PASS line ("0 unsourced") nor a check-skipped line trips a pointless revision.
+- **Mobile OTA updates** -- expo-updates wired into the companion app with EAS Update channels on the preview/production build profiles, so JS changes ship without a store build; EAS project owner pinned to `justlikefrank`.
+- **Mobile navigation** -- detail pages, global search, and a timeline: cards are no longer dead ends.
+- **Actionable Home dashboard** -- every card on the SPA Home screen is a door to its underlying screen.
+- **Materials redesign** -- global filter and the four real workspace folders (the mtime-based "recents" strip proved noisy and was dropped).
+- **LaTeX website field** -- optional website in resume and cover-letter headers.
+
+### Bug fixes
+
+- **Modals trapped in the page wrapper** -- `.jc-page`'s enter animation animates `transform`, making it the containing block for fixed descendants; modals now portal to `<body>` so overlays center on the viewport.
+- **Silent dead-click opening files on desktop Linux** -- file opens from Materials now report failures instead of doing nothing.
+- **PAT/mobile users greeted as "there"** -- the dashboard greeting (and its avatar initial) now uses the API-key identity name instead of a placeholder.
+
+### CI
+
+- Desktop releases can be dispatched by maintainers without tag-push rights (workflow_dispatch path).
 
 ---
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -123,6 +123,6 @@ LABEL org.opencontainers.image.description="AI-powered job search context MCP se
 LABEL org.opencontainers.image.url="https://github.com/JustLikeFrank3/jobContextMCP"
 LABEL org.opencontainers.image.source="https://github.com/JustLikeFrank3/jobContextMCP"
 LABEL org.opencontainers.image.licenses="MIT"
-LABEL org.opencontainers.image.version="1.3.1"
+LABEL org.opencontainers.image.version="1.4.0"
 
 ENTRYPOINT ["scripts/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-1.3.1-blue" alt="Version 1.3.1"/>
+  <img src="https://img.shields.io/badge/version-1.4.0-blue" alt="Version 1.4.0"/>
   <img src="https://img.shields.io/badge/tests-1526%20passing-brightgreen" alt="1526 tests passing"/>
   <a href="https://sonarcloud.io/component_measures?id=JustLikeFrank3_jobContextMCP&metric=coverage"><img src="https://sonarcloud.io/api/project_badges/measure?project=JustLikeFrank3_jobContextMCP&metric=coverage" alt="Coverage"/></a>
   <img src="https://img.shields.io/badge/tools-11%20domains%20%C2%B7%2088%20actions-informational" alt="11 domain tools, 88 actions"/>
@@ -399,6 +399,12 @@ sequenceDiagram
 | `get_fb_outreach_queue(limit?, offset?, sort_by?, include_pending?)` | **v0.9** — prioritized queue of Facebook friends not yet connected on LinkedIn; sorted by recency (freshest relationships first); active job target companies included so the AI can flag anyone who works there |
 | `save_interview_prep(company, content, filename?)` | Save a generated interview prep document to `08-Interview-Prep-Docs/` as a `.md` file; filename defaults to `{COMPANY}_INTERVIEW_PREP.md`; overwrites for iterative improvement |
 | `save_job_assessment(company, content, filename?, source?)` | Save a generated fitment assessment to `07-Job-Assessments/` (or `07-Job-Assessments/<source>/` subfolder); filename defaults to `{Company} - Fitment Assessment.md` |
+
+---
+
+## v1.4 — Visible provenance: the verdict reaches the user, and edits face the gate
+
+v1.3 built the truth gate; v1.4 makes it visible and closes its last gap. Every generation confirmation now ends with a one-line verdict from a single shared formatter (`Provenance: ✓ PASS — 6 claims traced to source, 0 unsourced` / `Provenance: ⚠ 2 unsourced — "47%", "$9M"`), and the dashboard renders it as a green/amber badge — after generating from the pipeline, and inside the AI edit dialogs right where you decide to accept or discard a draft. Those edit dialogs had been calling the LLM without the gate at all; they now run the same observe-and-report check with their own audit kinds (`resume_edit`, `cover_letter_edit`), so an inline edit can no longer smuggle in a fabricated metric silently. The mobile app gains over-the-air JS updates and real navigation (detail pages, global search, timeline), and the Home dashboard's cards all lead somewhere. Full details in the CHANGELOG.
 
 ---
 

--- a/lib/version.py
+++ b/lib/version.py
@@ -4,4 +4,4 @@ The desktop release workflow (.github/workflows/desktop-release.yml) stamps
 __version__ from the desktop-v* tag before freezing, so /healthz, the API
 docs, and the installers all agree. Dev builds keep the -dev suffix.
 """
-__version__ = "1.3.1"
+__version__ = "1.4.0"


### PR DESCRIPTION
Release bookkeeping for v1.4.0:

- `lib/version.py` and Dockerfile image label: 1.3.1 → 1.4.0
- CHANGELOG: `[Unreleased]` → `[1.4.0] - 2026-07-24`, adding everything on qa since v1.3.1 (provenance verdict surfacing + edit-dialog gate, mobile OTA/EAS channels, mobile detail pages/global search/timeline, actionable Home, Materials redesign, LaTeX website field; modal portal fix, Linux dead-click fix, PAT greeting fix; desktop-release dispatch CI)
- README: version badge 1.4.0, v1.4 narrative section above v1.3

After this merges and the qa deploy is green: promote qa → main, then tag `v1.4.0` on the main merge SHA (not a badge-bot `[skip ci]` commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)