### PR TITLE
Merge qa into main — v1.4.0: visible provenance (verdict in every confirmation + gated AI edits)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- **Provenance verdict surfaced to the user** -- the gate ran on every generation and wrote its audit row, but the single-shot dashboard path completed silently. Now `lib/provenance.format_provenance_line()` is the single source of truth for a one-line verdict (`Provenance: ✓ PASS — 6 claims traced to source, 0 unsourced` / `Provenance: ⚠ 2 unsourced — "47%", "$9M"`), consumed by the single-shot confirmation strings, the agent-pipeline header, and the API (`provenance` field on the generate-resume / generate-cover-letter responses). The Pipeline screen shows a dismissible result banner with a green/amber badge after every generation. Observe-and-report: a FAIL is informational — the document still generates with the warning attached.
+- **Truth gate on the AI edit dialogs** -- `/pipeline/edit-resume` and `/pipeline/edit-cover-letter` called the LLM directly and never ran the gate: an inline edit could inject a fabricated metric with no audit row and no warning. Both now run the observe-and-report gate over the edited draft (audit kinds `resume_edit` / `cover_letter_edit`), with sources = everything the model was shown (current document, JD, edit instructions — an explicitly instructed number is in-source by design). The verdict renders in the Edit Resume result view and in the cover-letter review phase, next to Accept & apply / Discard.
+- The `workflows/langgraph` resume graph anchors its revise trigger on the FAIL shape (`Provenance: ⚠ N unsourced`) so neither the PASS line ("0 unsourced") nor a check-skipped line trips a pointless revision.
+
 ---
 
 ## [1.3.1] - 2026-07-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,32 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+---
+
+## [1.4.0] - 2026-07-24
+
+The visible-provenance release: the truth gate's verdict now reaches the user on every path that produces or edits a document — one formatted line in every confirmation, a pass/fail badge in the dashboard — and the AI edit dialogs, which had been bypassing the gate entirely, are gated and audited. Plus mobile over-the-air updates and screen-to-screen navigation, an actionable Home dashboard, a Materials redesign, and a LaTeX header website field. 1526 passing tests.
+
 ### Features
 
 - **Provenance verdict surfaced to the user** -- the gate ran on every generation and wrote its audit row, but the single-shot dashboard path completed silently. Now `lib/provenance.format_provenance_line()` is the single source of truth for a one-line verdict (`Provenance: ✓ PASS — 6 claims traced to source, 0 unsourced` / `Provenance: ⚠ 2 unsourced — "47%", "$9M"`), consumed by the single-shot confirmation strings, the agent-pipeline header, and the API (`provenance` field on the generate-resume / generate-cover-letter responses). The Pipeline screen shows a dismissible result banner with a green/amber badge after every generation. Observe-and-report: a FAIL is informational — the document still generates with the warning attached.
 - **Truth gate on the AI edit dialogs** -- `/pipeline/edit-resume` and `/pipeline/edit-cover-letter` called the LLM directly and never ran the gate: an inline edit could inject a fabricated metric with no audit row and no warning. Both now run the observe-and-report gate over the edited draft (audit kinds `resume_edit` / `cover_letter_edit`), with sources = everything the model was shown (current document, JD, edit instructions — an explicitly instructed number is in-source by design). The verdict renders in the Edit Resume result view and in the cover-letter review phase, next to Accept & apply / Discard.
 - The `workflows/langgraph` resume graph anchors its revise trigger on the FAIL shape (`Provenance: ⚠ N unsourced`) so neither the PASS line ("0 unsourced") nor a check-skipped line trips a pointless revision.
+- **Mobile OTA updates** -- expo-updates wired into the companion app with EAS Update channels on the preview/production build profiles, so JS changes ship without a store build; EAS project owner pinned to `justlikefrank`.
+- **Mobile navigation** -- detail pages, global search, and a timeline: cards are no longer dead ends.
+- **Actionable Home dashboard** -- every card on the SPA Home screen is a door to its underlying screen.
+- **Materials redesign** -- global filter and the four real workspace folders (the mtime-based "recents" strip proved noisy and was dropped).
+- **LaTeX website field** -- optional website in resume and cover-letter headers.
+
+### Bug fixes
+
+- **Modals trapped in the page wrapper** -- `.jc-page`'s enter animation animates `transform`, making it the containing block for fixed descendants; modals now portal to `<body>` so overlays center on the viewport.
+- **Silent dead-click opening files on desktop Linux** -- file opens from Materials now report failures instead of doing nothing.
+- **PAT/mobile users greeted as "there"** -- the dashboard greeting (and its avatar initial) now uses the API-key identity name instead of a placeholder.
+
+### CI
+
+- Desktop releases can be dispatched by maintainers without tag-push rights (workflow_dispatch path).
 
 ---
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -123,6 +123,6 @@ LABEL org.opencontainers.image.description="AI-powered job search context MCP se
 LABEL org.opencontainers.image.url="https://github.com/JustLikeFrank3/jobContextMCP"
 LABEL org.opencontainers.image.source="https://github.com/JustLikeFrank3/jobContextMCP"
 LABEL org.opencontainers.image.licenses="MIT"
-LABEL org.opencontainers.image.version="1.3.1"
+LABEL org.opencontainers.image.version="1.4.0"
 
 ENTRYPOINT ["scripts/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/version-1.3.1-blue" alt="Version 1.3.1"/>
-  <img src="https://img.shields.io/badge/tests-1512%20passing-brightgreen" alt="1512 tests passing"/>
+  <img src="https://img.shields.io/badge/tests-1516%20passing-brightgreen" alt="1516 tests passing"/>
   <a href="https://sonarcloud.io/component_measures?id=JustLikeFrank3_jobContextMCP&metric=coverage"><img src="https://sonarcloud.io/api/project_badges/measure?project=JustLikeFrank3_jobContextMCP&metric=coverage" alt="Coverage"/></a>
   <img src="https://img.shields.io/badge/tools-11%20domains%20%C2%B7%2085%20actions-informational" alt="11 domain tools, 85 actions"/>
   <img src="https://img.shields.io/badge/license-MIT-lightgrey" alt="MIT License"/>
@@ -35,7 +35,7 @@ Available as a **double-clickable desktop app** (macOS · Windows · Linux), a l
 | | |
 |---|---|
 | 11 domain tools (85 actions) | Resume + cover letter generation |
-| 1512 passing tests | Job fitment analysis with persona lenses |
+| 1516 passing tests | Job fitment analysis with persona lenses |
 | SQLite persistence + JSON fallback | Interview prep + debrief logging |
 | Local RAG semantic search | Outreach + relationship tracking |
 | Azure AKS deployment | Microsoft Entra ID authentication |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-1.3.1-blue" alt="Version 1.3.1"/>
+  <img src="https://img.shields.io/badge/version-1.4.0-blue" alt="Version 1.4.0"/>
   <img src="https://img.shields.io/badge/tests-1526%20passing-brightgreen" alt="1526 tests passing"/>
   <a href="https://sonarcloud.io/component_measures?id=JustLikeFrank3_jobContextMCP&metric=coverage"><img src="https://sonarcloud.io/api/project_badges/measure?project=JustLikeFrank3_jobContextMCP&metric=coverage" alt="Coverage"/></a>
   <img src="https://img.shields.io/badge/tools-11%20domains%20%C2%B7%2088%20actions-informational" alt="11 domain tools, 88 actions"/>
@@ -399,6 +399,12 @@ sequenceDiagram
 | `get_fb_outreach_queue(limit?, offset?, sort_by?, include_pending?)` | **v0.9** — prioritized queue of Facebook friends not yet connected on LinkedIn; sorted by recency (freshest relationships first); active job target companies included so the AI can flag anyone who works there |
 | `save_interview_prep(company, content, filename?)` | Save a generated interview prep document to `08-Interview-Prep-Docs/` as a `.md` file; filename defaults to `{COMPANY}_INTERVIEW_PREP.md`; overwrites for iterative improvement |
 | `save_job_assessment(company, content, filename?, source?)` | Save a generated fitment assessment to `07-Job-Assessments/` (or `07-Job-Assessments/<source>/` subfolder); filename defaults to `{Company} - Fitment Assessment.md` |
+
+---
+
+## v1.4 — Visible provenance: the verdict reaches the user, and edits face the gate
+
+v1.3 built the truth gate; v1.4 makes it visible and closes its last gap. Every generation confirmation now ends with a one-line verdict from a single shared formatter (`Provenance: ✓ PASS — 6 claims traced to source, 0 unsourced` / `Provenance: ⚠ 2 unsourced — "47%", "$9M"`), and the dashboard renders it as a green/amber badge — after generating from the pipeline, and inside the AI edit dialogs right where you decide to accept or discard a draft. Those edit dialogs had been calling the LLM without the gate at all; they now run the same observe-and-report check with their own audit kinds (`resume_edit`, `cover_letter_edit`), so an inline edit can no longer smuggle in a fabricated metric silently. The mobile app gains over-the-air JS updates and real navigation (detail pages, global search, timeline), and the Home dashboard's cards all lead somewhere. Full details in the CHANGELOG.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/version-1.3.1-blue" alt="Version 1.3.1"/>
-  <img src="https://img.shields.io/badge/tests-1494%20passing-brightgreen" alt="1494 tests passing"/>
+  <img src="https://img.shields.io/badge/tests-1518%20passing-brightgreen" alt="1518 tests passing"/>
   <a href="https://sonarcloud.io/component_measures?id=JustLikeFrank3_jobContextMCP&metric=coverage"><img src="https://sonarcloud.io/api/project_badges/measure?project=JustLikeFrank3_jobContextMCP&metric=coverage" alt="Coverage"/></a>
-  <img src="https://img.shields.io/badge/tools-11%20domains%20%C2%B7%2085%20actions-informational" alt="11 domain tools, 85 actions"/>
+  <img src="https://img.shields.io/badge/tools-11%20domains%20%C2%B7%2088%20actions-informational" alt="11 domain tools, 88 actions"/>
   <img src="https://img.shields.io/badge/license-MIT-lightgrey" alt="MIT License"/>
   <img src="https://img.shields.io/badge/Works%20with-Oura%20Ring-00B5C8" alt="Works with Oura Ring"/>
 </p>
@@ -34,8 +34,8 @@ Available as a **double-clickable desktop app** (macOS · Windows · Linux), a l
 
 | | |
 |---|---|
-| 11 domain tools (85 actions) | Resume + cover letter generation |
-| 1494 passing tests | Job fitment analysis with persona lenses |
+| 11 domain tools (88 actions) | Resume + cover letter generation |
+| 1518 passing tests | Job fitment analysis with persona lenses |
 | SQLite persistence + JSON fallback | Interview prep + debrief logging |
 | Local RAG semantic search | Outreach + relationship tracking |
 | Azure AKS deployment | Microsoft Entra ID authentication |
@@ -165,7 +165,7 @@ JobContextMCP is now more than a stdio MCP server. The current branch combines:
 | Storage | SQLite with dual-write JSON fallback — all pipeline writes go to both; reads come from SQLite when `USE_SQLITE=1`. Migration script bootstraps from existing JSON. Sync-delete on save keeps SQLite and JSON consistent. `SQLITE_ONLY=1` skips JSON writes for mapped tables (production AKS default). |
 | Deployment | AKS (Azure Kubernetes Service) — single-node cluster with workload identity, Azure Container Registry, Azure Blob Storage workspace seeding via init container (seeds all workspace dirs + DB on pod start), ConfigMap-driven config, provider-agnostic LLM (OpenAI / Azure AI Foundry keyless / Ollama). Sidecar container (`workspace-sync`) pushes PVC workspace files + DB back to Blob every 15 min so data survives pod replacement. One-shot `provision_aks.sh` idempotent provisioner. |
 | Transports | MCP stdio (local/Docker), MCP Streamable HTTP (`protocolVersion: 2025-03-26`) served by FastMCP via AKS or Docker, FastAPI REST/SSE, CLI, Entra-authenticated dashboard routes, LangGraph workflow streaming |
-| Provenance & trust | Deterministic truth gate on every generation path — numeric claims must trace to source material or the pipeline routes back to revision (reviewer approval alone is not enough); per-run audit records (`generation_provenance`), audited master-resume edits (`master_resume_edits`), durable gate metrics on `/metrics` for dashboards |
+| Provenance & trust | Deterministic truth gate on every generation path *and* the AI edit dialogs — numeric claims must trace to source material or the pipeline routes back to revision (reviewer approval alone is not enough); the verdict is surfaced in every confirmation and as a pass/fail badge in the dashboard; per-run audit records (`generation_provenance`), audited master-resume edits (`master_resume_edits`), durable gate metrics on `/metrics` for dashboards |
 | Self-hosting | Disposable local k3d cluster and a documented single-node k3s deployment (proven on a Raspberry Pi 4, 4GB): arm64 image cross-builds, nightly SQLite-safe backups, Prometheus/Grafana/Loki wallboard with a rotating kiosk, and prod-metrics federation over a scoped outbound tunnel |
 
 ---
@@ -683,7 +683,7 @@ brew install python@3.12
 
 # Smoke test: confirm the server imports cleanly and registers all tools
 .venv/bin/python3 -c "import server; print('OK,', len(server.mcp._tool_manager.list_tools()), 'tools')"
-# Expected: OK, 11 tools (85 actions; set JOBCONTEXT_LEGACY_TOOLS=1 for the old per-function surface)
+# Expected: OK, 11 tools (88 actions; set JOBCONTEXT_LEGACY_TOOLS=1 for the old per-function surface)
 ```
 
 > ⚠️ **macOS venv gotcha:** if you accidentally run `python3 -m venv .venv` with the system 3.9 first, the resulting `.venv/bin/python3` symlink points at the system 3.9 binary. A follow-up `python3.12 -m venv .venv` call will NOT replace it — the broken symlink survives. Symptom: `ModuleNotFoundError: No module named 'mcp'` even though `pip list` shows it installed. Fix: `rm -rf .venv` and recreate with the explicit `/opt/homebrew/opt/python@3.12/bin/python3.12 -m venv .venv` command above.

--- a/config.example.json
+++ b/config.example.json
@@ -47,12 +47,13 @@
     "safety_margin_tokens": 500
   },
 
-  "_comment_contact": "Contact info for cover letter PDF sidebar. Lives here (gitignored) so it never appears in source code.",
+  "_comment_contact": "Contact info for cover letter PDF sidebar. Lives here (gitignored) so it never appears in source code. 'website' is scheme-less (e.g. jobcontext.ai, not https://…) and optional — leave it empty and the resume/letter header renders only the LinkedIn + GitHub links.",
   "contact": {
     "name": "YOUR FULL NAME",
     "phone": "555-867-5309",
     "email": "you@example.com",
     "linkedin": "www.linkedin.com/in/yourhandle",
+    "website": "",
     "address": "123 Your Street",
     "city_state": "Your City, ST 00000",
     "location": "Your City, ST"

--- a/frontend/src/screens/Pipeline.jsx
+++ b/frontend/src/screens/Pipeline.jsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useCallback } from 'react'
 import { Panel, Button } from '../design-system'
 import { apiFetch, apiPost } from '../auth/api.js'
-import { Screen, EmptyState, EYEBROW } from './_shared.jsx'
+import { Screen, EmptyState, EYEBROW, Badge } from './_shared.jsx'
+import { parseProvenance, PROVENANCE_TONE, PROVENANCE_BADGE_LABEL } from './pipeline/provenance.js'
 import { useToolbarSlot } from '../shell/toolbarSlot.jsx'
 import { actionError } from './pipeline/shared.jsx'
 import JobCard, { ROW_GRID } from './pipeline/JobCard.jsx'
@@ -61,6 +62,7 @@ export default function Pipeline() {
   const [stageFilter, setStageFilter] = useState('all')
   const [persona, setPersona] = useState('')
   const [addOpen, setAddOpen] = useState(false)
+  const [genResult, setGenResult] = useState(null) // { title, ok, provenance: parseProvenance() | null }
   const [editor, setEditor] = useState(null) // { type: 'edit-resume'|'edit-cl'|'templates', job }
 
   const load = useCallback(async ({ silent } = {}) => {
@@ -94,12 +96,24 @@ export default function Pipeline() {
         await apiPost('/dashboard/pipeline/evaluate', { job_id: job.id })
       } else if (type === 'resume') {
         setBusy(`Generating resume for ${job.company}…`)
+        setGenResult(null)
         const res = await apiPost('/dashboard/pipeline/generate-resume', { job_id: job.id, persona: activePersona })
+        setGenResult({
+          title: `Resume — ${job.company}`,
+          ok: !!res?.ok,
+          provenance: parseProvenance(res?.provenance),
+        })
         if (!res?.ok) window.alert(`Resume generation did not produce files.\n\n${String(res?.content || res?.notes || '').slice(0, 500)}`)
       } else if (type === 'cl-latex' || type === 'cl-html') {
         const pipeline = type === 'cl-latex' ? 'latex' : 'html'
         setBusy(`Generating cover letter (${pipeline.toUpperCase()}) for ${job.company}…`)
+        setGenResult(null)
         const res = await apiPost('/dashboard/pipeline/generate-cover-letter', { job_id: job.id, export_pipeline: pipeline, persona: activePersona })
+        setGenResult({
+          title: `Cover letter — ${job.company}`,
+          ok: !!res?.ok,
+          provenance: parseProvenance(res?.provenance),
+        })
         if (!res?.ok) window.alert(`Cover letter generation did not produce files (likely an API rate limit or provider error).\n\n${String(res?.content || res?.notes || '').slice(0, 500)}`)
       } else if (type === 'apply') {
         setBusy(`Queueing application for ${job.company}…`)
@@ -148,6 +162,40 @@ export default function Pipeline() {
       <div style={{ fontSize: 13.5, color: 'var(--muted)', marginBottom: 14 }}>
         {activeCount} active {'·'} {countBy('applied')} applied
       </div>
+
+      {genResult && (
+        <Panel pad="10px 14px" style={{ marginBottom: 12 }}>
+          <div style={{ display: 'flex', gap: 10, alignItems: 'center', flexWrap: 'wrap' }}>
+            <span style={{ fontSize: 'var(--fs-sm)', fontWeight: 'var(--fw-semibold)', color: 'var(--text)' }}>
+              {genResult.title}
+            </span>
+            {genResult.provenance ? (
+              <>
+                <Badge tone={PROVENANCE_TONE[genResult.provenance.status]}>
+                  {PROVENANCE_BADGE_LABEL[genResult.provenance.status]}
+                </Badge>
+                <span style={{ fontSize: 'var(--fs-xs)', color: 'var(--muted)' }}>
+                  {genResult.provenance.text}
+                </span>
+              </>
+            ) : (
+              <span style={{ fontSize: 'var(--fs-xs)', color: 'var(--faint)' }}>
+                No provenance verdict returned (context-package generation).
+              </span>
+            )}
+            <button
+              onClick={() => setGenResult(null)}
+              aria-label="Dismiss generation result"
+              style={{
+                marginLeft: 'auto', background: 'none', border: 'none', cursor: 'pointer',
+                color: 'var(--faint)', fontSize: 'var(--fs-sm)', lineHeight: 1, padding: 4,
+              }}
+            >
+              {'✕'}
+            </button>
+          </div>
+        </Panel>
+      )}
 
       <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap', marginBottom: 12 }}>
         <Chip active={stageFilter === 'all'} onClick={() => setStageFilter('all')}>All</Chip>

--- a/frontend/src/screens/pipeline/EditCoverLetterModal.jsx
+++ b/frontend/src/screens/pipeline/EditCoverLetterModal.jsx
@@ -4,7 +4,7 @@ import { apiPost } from '../../auth/api.js'
 import useDesktopMode from '../../shell/useDesktopMode.js'
 import { nativeAnchorHandler } from '../../shell/nativeOpen.js'
 import { EYEBROW } from '../_shared.jsx'
-import { Modal, ResultLine, EmptyEditorState, modalField, modalLabel, actionError } from './shared.jsx'
+import { Modal, ResultLine, EmptyEditorState, ProvenanceNote, modalField, modalLabel, actionError } from './shared.jsx'
 
 /* Edit Cover Letter (draft → review → accept/discard) */
 export default function EditCoverLetterModal({ job, coverLetterOptions, isOwner, onClose, onDone }) {
@@ -86,6 +86,7 @@ export default function EditCoverLetterModal({ job, coverLetterOptions, isOwner,
           background: 'var(--surface-sunken)', border: '1px solid var(--border-soft)', borderRadius: 'var(--radius-sm)',
           color: 'var(--text-soft)', fontSize: 'var(--fs-sm)', lineHeight: 1.5,
         }}>{draft.draft_content}</pre>
+        <ProvenanceNote line={draft.provenance} />
         {draft.save_result && <ResultLine>{draft.save_result}</ResultLine>}
         {draft.pdf_result && <ResultLine>{draft.pdf_result}</ResultLine>}
         {draft.pdf_href && (

--- a/frontend/src/screens/pipeline/EditResumeModal.jsx
+++ b/frontend/src/screens/pipeline/EditResumeModal.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Button } from '../../design-system'
 import { apiPost } from '../../auth/api.js'
-import { Modal, ResultLine, EmptyEditorState, modalField, modalLabel, actionError } from './shared.jsx'
+import { Modal, ResultLine, EmptyEditorState, ProvenanceNote, modalField, modalLabel, actionError } from './shared.jsx'
 
 export default function EditResumeModal({ job, resumeOptions, onClose, onDone }) {
   const options = resumeOptions || []
@@ -36,6 +36,7 @@ export default function EditResumeModal({ job, resumeOptions, onClose, onDone })
               <div style={{ fontFamily: 'var(--font-mono)', fontSize: 'var(--fs-sm)', color: 'var(--text-strong)', wordBreak: 'break-all' }}>{result.edited_resume}</div>
             )}
           </div>
+          <ProvenanceNote line={result.provenance} />
           {result.save_result && <ResultLine>{result.save_result}</ResultLine>}
           {result.pdf_result && <ResultLine>{result.pdf_result}</ResultLine>}
           <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 14 }}>

--- a/frontend/src/screens/pipeline/provenance.js
+++ b/frontend/src/screens/pipeline/provenance.js
@@ -1,0 +1,31 @@
+/* Provenance verdict parsing for generation results.
+
+   The backend appends a one-line verdict from the deterministic truth gate
+   (lib/provenance.format_provenance_line) to every generation confirmation
+   and returns it as `provenance` on the generate-resume / generate-cover-letter
+   responses. Three shapes:
+
+     "Provenance: ✓ PASS — 6 claims traced to source, 0 unsourced"
+     "Provenance: ⚠ 2 unsourced — \"47%\", \"$9M\""
+     "Provenance: ⚠ check skipped — <reason>"
+
+   Kept as a pure module so the classification is unit-testable without DOM. */
+
+export function parseProvenance(line) {
+  const text = (line || '').trim()
+  if (!text.startsWith('Provenance:')) return null
+  if (text.startsWith('Provenance: ✓')) return { status: 'pass', text }
+  // Anchor on the FAIL shape — the PASS line also contains the word
+  // "unsourced" ("0 unsourced"), and the skipped line also starts with ⚠.
+  if (/^Provenance: ⚠ \d+ unsourced/u.test(text)) return { status: 'fail', text }
+  return { status: 'skipped', text }
+}
+
+/* Badge tone (design-system _shared.jsx Badge) per verdict status. */
+export const PROVENANCE_TONE = { pass: 'green', fail: 'warn', skipped: 'muted' }
+
+export const PROVENANCE_BADGE_LABEL = {
+  pass: '✓ provenance pass',
+  fail: '⚠ unsourced claims',
+  skipped: 'provenance skipped',
+}

--- a/frontend/src/screens/pipeline/provenance.test.js
+++ b/frontend/src/screens/pipeline/provenance.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { parseProvenance, PROVENANCE_TONE, PROVENANCE_BADGE_LABEL } from './provenance.js'
+
+describe('parseProvenance', () => {
+  it('classifies the PASS line as pass', () => {
+    const out = parseProvenance('Provenance: ✓ PASS — 6 claims traced to source, 0 unsourced')
+    expect(out).toEqual({
+      status: 'pass',
+      text: 'Provenance: ✓ PASS — 6 claims traced to source, 0 unsourced',
+    })
+  })
+
+  it('classifies the FAIL line as fail, not tripped by "0 unsourced" in PASS', () => {
+    const out = parseProvenance('Provenance: ⚠ 2 unsourced — "47%", "$9M"')
+    expect(out.status).toBe('fail')
+    // PASS line contains the word "unsourced" too — must stay pass.
+    expect(parseProvenance('Provenance: ✓ PASS — 0 claims traced to source, 0 unsourced').status).toBe('pass')
+  })
+
+  it('classifies the check-skipped line as skipped, not fail', () => {
+    const out = parseProvenance('Provenance: ⚠ check skipped — db unavailable')
+    expect(out.status).toBe('skipped')
+  })
+
+  it('keeps a violation containing a quote char intact', () => {
+    const out = parseProvenance('Provenance: ⚠ 1 unsourced — "5""')
+    expect(out.status).toBe('fail')
+    expect(out.text).toContain('5"')
+  })
+
+  it('returns null for absent or non-provenance input', () => {
+    expect(parseProvenance(null)).toBeNull()
+    expect(parseProvenance(undefined)).toBeNull()
+    expect(parseProvenance('')).toBeNull()
+    expect(parseProvenance('✓ Resume generated for R @ C')).toBeNull()
+  })
+
+  it('trims surrounding whitespace from the backend line', () => {
+    expect(parseProvenance('  Provenance: ✓ PASS — 1 claims traced to source, 0 unsourced  ').status).toBe('pass')
+  })
+})
+
+describe('badge mappings', () => {
+  it('maps every status to a tone and label', () => {
+    for (const status of ['pass', 'fail', 'skipped']) {
+      expect(PROVENANCE_TONE[status]).toBeTruthy()
+      expect(PROVENANCE_BADGE_LABEL[status]).toBeTruthy()
+    }
+  })
+})

--- a/frontend/src/screens/pipeline/shared.jsx
+++ b/frontend/src/screens/pipeline/shared.jsx
@@ -1,7 +1,22 @@
 import { Panel } from '../../design-system'
 import { ApiError } from '../../auth/api.js'
+import { Badge } from '../_shared.jsx'
+import { parseProvenance, PROVENANCE_TONE, PROVENANCE_BADGE_LABEL } from './provenance.js'
 
 /* Shared primitives for the Pipeline card actions and editor modals. */
+
+/* Renders the backend's one-line provenance verdict as a badge + line.
+   Renders nothing when the response carried no verdict (e.g. older server). */
+export function ProvenanceNote({ line }) {
+  const parsed = parseProvenance(line)
+  if (!parsed) return null
+  return (
+    <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap', margin: '0 0 8px' }}>
+      <Badge tone={PROVENANCE_TONE[parsed.status]}>{PROVENANCE_BADGE_LABEL[parsed.status]}</Badge>
+      <span style={{ fontSize: 'var(--fs-xs)', color: 'var(--muted)' }}>{parsed.text}</span>
+    </div>
+  )
+}
 
 export function actionError(e) {
   if (e instanceof ApiError) {

--- a/lib/provenance.py
+++ b/lib/provenance.py
@@ -106,6 +106,23 @@ def check_claims(draft: str, sources: list[str]) -> list[str]:
     ]
 
 
+def format_provenance_line(claims: list[str], violations: list[str]) -> str:
+    """One-line human-readable verdict for generation confirmations.
+
+    Single source of truth for how the gate's outcome reads — the agent
+    pipeline header and the single-shot confirmation strings must format
+    identically so dashboards and clients can match one shape.
+    """
+    if violations:
+        shown = ", ".join(f'"{v}"' for v in violations[:6])
+        if len(violations) > 6:
+            shown += ", …"
+        return f"Provenance: ⚠ {len(violations)} unsourced — {shown}"
+    return (
+        f"Provenance: ✓ PASS — {len(claims)} claims traced to source, 0 unsourced"
+    )
+
+
 def record_run(
     *,
     kind: str,

--- a/lib/version.py
+++ b/lib/version.py
@@ -4,4 +4,4 @@ The desktop release workflow (.github/workflows/desktop-release.yml) stamps
 __version__ from the desktop-v* tag before freezing, so /healthz, the API
 docs, and the installers all agree. Dev builds keep the -dev suffix.
 """
-__version__ = "1.3.1"
+__version__ = "1.4.0"

--- a/services/resume_service.py
+++ b/services/resume_service.py
@@ -36,6 +36,11 @@ class ResumeResult:
                         save and export paths embedded in the message.
         pdf_exported:   True if a PDF export step ran and produced a file.
         notes:          Any non-fatal warnings collected during orchestration.
+        provenance:     The one-line provenance verdict emitted by the truth
+                        gate (lib.provenance.format_provenance_line), split
+                        out of `content` so clients can render it as its own
+                        element. None when no gate line is present (keyless
+                        context-package path).
     """
     success: bool
     company: str
@@ -44,10 +49,20 @@ class ResumeResult:
     content: str
     pdf_exported: bool = False
     notes: Optional[list[str]] = None
+    provenance: Optional[str] = None
 
     def __post_init__(self):
         if self.notes is None:
             self.notes = []
+
+
+def _extract_provenance_line(content: str) -> Optional[str]:
+    """Pull the gate's one-line verdict out of a confirmation string."""
+    for line in (content or "").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("Provenance:"):
+            return stripped
+    return None
 
 
 class ResumeService:
@@ -162,6 +177,7 @@ class ResumeService:
             content=content,
             pdf_exported=pdf_exported,
             notes=notes,
+            provenance=_extract_provenance_line(content),
         )
 
     @staticmethod

--- a/templates/latex_assets/sections/experience.tex
+++ b/templates/latex_assets/sections/experience.tex
@@ -5,7 +5,7 @@
 \subsection{{\textbf{Senior Software Engineer} \textit{\ \ Contoso Cloud, Remote} \hfill 20XX --- Present}}
 \begin{zitemize}
 \item Led design and delivery of a customer-facing service from architecture through production and on-call; quantify the impact here (latency, scale, revenue, or adoption).
-\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1512 passing tests at 80\%+ line coverage through disciplined TDD.
+\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1516 passing tests at 80\%+ line coverage through disciplined TDD.
 \item Drove a cross-team win — a migration, a shared API pattern others adopted, or an SLA target consistently met.
 \end{zitemize}
 %====================

--- a/templates/latex_assets/sections/experience.tex
+++ b/templates/latex_assets/sections/experience.tex
@@ -5,7 +5,7 @@
 \subsection{{\textbf{Senior Software Engineer} \textit{\ \ Contoso Cloud, Remote} \hfill 20XX --- Present}}
 \begin{zitemize}
 \item Led design and delivery of a customer-facing service from architecture through production and on-call; quantify the impact here (latency, scale, revenue, or adoption).
-\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1516 passing tests at 80\%+ line coverage through disciplined TDD.
+\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1526 passing tests at 80\%+ line coverage through disciplined TDD.
 \item Drove a cross-team win — a migration, a shared API pattern others adopted, or an SLA target consistently met.
 \end{zitemize}
 %====================

--- a/tests/test_dashboard_pipeline.py
+++ b/tests/test_dashboard_pipeline.py
@@ -237,6 +237,48 @@ class TestResumeEditDialog:
         assert (opt_dir / "edited-stripe.txt").read_text(encoding="utf-8") == "FRANK\nNEW BULLET"
         saved = _load_json(config.JOB_QUEUE_FILE, {"jobs": []})["jobs"][0]
         assert saved["last_edited_resume"] == "edited-stripe.txt"
+        # No numeric claims in the edited draft → clean PASS verdict surfaced.
+        assert body["provenance"] == (
+            "Provenance: ✓ PASS — 0 claims traced to source, 0 unsourced"
+        )
+
+    def test_edit_resume_flags_fabricated_claim(self, http_client_noauth, monkeypatch):
+        """Adversarial: the model injects a metric found nowhere in the prompt
+        (current resume, JD, instructions) — the gate names it, but the edit
+        still succeeds (observe-and-report, not blocking)."""
+        opt_dir = config.RESUME_FOLDER / config._cfg.get("optimized_resumes_dir", "01-Current-Optimized")
+        opt_dir.mkdir(parents=True, exist_ok=True)
+        (opt_dir / "base.txt").write_text("FRANK\nOLD BULLET", encoding="utf-8")
+        _seed_jobs([_job(id=13, company="Stripe", role="Staff Engineer")])
+
+        class FakeMessage:
+            content = "FRANK\nSaved the company $5M annually"
+
+        class FakeChoice:
+            message = FakeMessage()
+
+        class FakeResponse:
+            choices = [FakeChoice()]
+            usage = None
+
+        monkeypatch.setattr(pl.config, "get_llm_client", lambda: (object(), "gpt-test"))
+        monkeypatch.setattr(pl, "create_chat_completion", lambda *a, **kw: FakeResponse())
+
+        r = http_client_noauth.post(
+            "/dashboard/pipeline/edit-resume",
+            json={
+                "job_id": 13,
+                "resume_name": "base.txt",
+                "instructions": "Punch up the impact of the first bullet.",
+                "export_pdf": False,
+            },
+        )
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["ok"] is True
+        assert body["provenance"].startswith("Provenance: ⚠ 1 unsourced")
+        assert '"$5M"' in body["provenance"]
 
 
 class TestCoverLetterEditDialog:
@@ -300,6 +342,9 @@ class TestCoverLetterEditDialog:
         assert body["edited_cover_letter"] == "base.edit1.tmp"
         assert body["draft_name"] == "base.edit1.tmp"
         assert body["draft_href"] == "/dashboard/pipeline/cover-letter-draft/base.edit1.tmp"
+        assert body["provenance"] == (
+            "Provenance: ✓ PASS — 0 claims traced to source, 0 unsourced"
+        )
         assert body["export_pipeline"] == "latex"
         assert "09-Cover-Letter-PDFs" in body["pdf_result"]
         assert body["pdf_href"] == "/dashboard/materials/file/cover_letter_pdfs/edited.pdf"

--- a/tests/test_latex_export.py
+++ b/tests/test_latex_export.py
@@ -43,6 +43,25 @@ def test_latex_user_identity_blank_strings_fall_back_to_placeholder(monkeypatch)
     assert "example" in identity["email"]
     assert identity["linkedin"] == "yourhandle"
     assert identity["github"] == "YourGitHub"
+    # website has NO placeholder: blank must stay blank so the header's
+    # \ifx\website\empty guard suppresses the third link entirely.
+    assert identity["website"] == ""
+
+
+def test_latex_user_identity_website_is_schemeless(monkeypatch):
+    """The header renders \\href{https://\\website}{\\website}, so the stored
+    value must come back scheme-less and without a trailing slash."""
+    monkeypatch.setattr(
+        latex_export.cfg, "get_contact_info",
+        lambda: {"website": "https://jobcontext.ai/"},
+    )
+    assert latex_export._user_identity()["website"] == "jobcontext.ai"
+
+    monkeypatch.setattr(
+        latex_export.cfg, "get_contact_info",
+        lambda: {"website": "jobcontext.ai"},
+    )
+    assert latex_export._user_identity()["website"] == "jobcontext.ai"
 
 
 def test_latex_cover_letter_defaults_to_cover_letter_pdf_folder(monkeypatch, tmp_path):
@@ -361,6 +380,39 @@ def test_inject_identity_overrides_all_contact_macros():
     # Non-identity macros (role) are never touched by identity injection.
     assert r"\def\role{Keep Me}" in out
     assert "PLACEHOLDER" not in out
+
+
+def test_inject_identity_sets_website_when_provided():
+    src = r"\def\website{}"
+    out = latex_export._inject_identity(src, {"website": "jobcontext.ai"})
+    assert r"\def\website{jobcontext.ai}" in out
+
+
+def test_inject_identity_blank_website_keeps_template_macro_empty():
+    """resume.tex ships \\def\\website{} and _header.tex hides the link via
+    \\ifx\\website\\empty — a blank identity value must leave that untouched
+    (never render a bare https:// link)."""
+    src = r"\def\website{}"
+    out = latex_export._inject_identity(src, {"website": ""})
+    assert out == src
+
+
+def test_cover_letter_template_carries_website_def():
+    """The cover-letter template must declare \\def\\website before
+    \\input{_header} so both documents can render the third header link; an
+    empty value must produce a literally-empty def (the guard's empty test)."""
+    rendered = latex_export._TEX_TEMPLATE.format(
+        name="N", phone="P", city="C", email="E", linkedin="L", github="G",
+        website="", role_title="R", date="D", body="B",
+    )
+    assert "\\def\\website{}" in rendered
+    assert rendered.index("\\def\\website{}") < rendered.index("\\input{_header}")
+
+    rendered = latex_export._TEX_TEMPLATE.format(
+        name="N", phone="P", city="C", email="E", linkedin="L", github="G",
+        website="jobcontext.ai", role_title="R", date="D", body="B",
+    )
+    assert "\\def\\website{jobcontext.ai}" in rendered
 
 
 def test_inject_identity_skips_absent_macros():

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -81,6 +81,47 @@ class TestCheckClaims:
 
 
 # ===========================================================================
+# format_provenance_line — the one-line verdict shared by every surface
+# ===========================================================================
+
+class TestFormatProvenanceLine:
+    def test_pass_line_counts_claims(self):
+        from lib.provenance import format_provenance_line
+
+        line = format_provenance_line(["34%", "$1.2M", "3x"], [])
+        assert line == "Provenance: ✓ PASS — 3 claims traced to source, 0 unsourced"
+
+    def test_fail_line_names_violations_quoted(self):
+        from lib.provenance import format_provenance_line
+
+        line = format_provenance_line(["47%", "$9M"], ["47%", "$9M"])
+        assert line == 'Provenance: ⚠ 2 unsourced — "47%", "$9M"'
+
+    def test_violation_with_quote_char_stays_one_line(self):
+        from lib.provenance import format_provenance_line
+
+        line = format_provenance_line([], ['5"'])
+        assert "\n" not in line
+        assert '5"' in line
+        assert line.startswith("Provenance: ⚠ 1 unsourced")
+
+    def test_more_than_six_violations_truncate_with_ellipsis(self):
+        from lib.provenance import format_provenance_line
+
+        vs = [f"{i}%" for i in range(1, 9)]
+        line = format_provenance_line(vs, vs)
+        assert line.startswith("Provenance: ⚠ 8 unsourced")
+        assert "…" in line
+        assert "\n" not in line
+
+    def test_pass_line_with_zero_claims(self):
+        from lib.provenance import format_provenance_line
+
+        line = format_provenance_line([], [])
+        assert line == "Provenance: ✓ PASS — 0 claims traced to source, 0 unsourced"
+
+
+# ===========================================================================
 # record_run — persistence (isolated sqlite via explicit path)
 # ===========================================================================
 
@@ -256,9 +297,10 @@ class TestSingleShotGate:
             "resume", "Initech", "SWE", "jd text",
             content="Cut latency 34%.", source_text="latency fell 34% in prod",
         )
-        assert note.startswith("✓ Provenance")
+        assert note == "Provenance: ✓ PASS — 1 claims traced to source, 0 unsourced"
         assert recorded["verdict"] == "passed"
         assert recorded["kind"] == "resume"
+        assert recorded["claims"] == ["34%"]
 
     def test_note_flags_fabrication_and_records_failure(self, monkeypatch):
         from tools import generate as gen
@@ -271,8 +313,8 @@ class TestSingleShotGate:
             "cover_letter", "Initech", "SWE", "jd",
             content="Grew revenue 47% to $9M.", source_text="no numbers here",
         )
-        assert note.startswith("⚠ Provenance: unsourced claims")
-        assert "47%" in note and "$9M" in note
+        assert note.startswith("Provenance: ⚠ 2 unsourced")
+        assert '"47%"' in note and '"$9M"' in note
         assert recorded["verdict"] == "failed"
         assert recorded["violations"] == ["47%", "$9M"]
 
@@ -286,7 +328,7 @@ class TestSingleShotGate:
         # record_run itself swallows, but simulate an unexpected error path
         monkeypatch.setattr("lib.provenance.check_claims", boom)
         note = gen._provenance_note("resume", "", "", "", "x", "y")
-        assert note.startswith("⚠ Provenance check skipped")
+        assert note.startswith("Provenance: ⚠ check skipped")
 
 
 class TestResumeGraphReactsToVerdict:
@@ -299,14 +341,23 @@ class TestResumeGraphReactsToVerdict:
 
     def test_provenance_warning_triggers_revision(self):
         out = self._review(
-            "✓ Resume generated for X @ Y\n  ⚠ Provenance: unsourced claims — verify before sending: 47%"
+            '✓ Resume generated for X @ Y\n  Provenance: ⚠ 1 unsourced — "47%"'
         )
         assert out["needs_revision"] is True
         assert any("Provenance gate" in f for f in out["review_feedback"])
 
     def test_clean_verdict_passes_review(self):
+        # The PASS line contains the word "unsourced" ("0 unsourced") — the
+        # marker must anchor on the FAIL shape and not trip on it.
         out = self._review(
-            "✓ Resume generated for X @ Y\n  ✓ Provenance: all numeric claims trace to source material"
+            "✓ Resume generated for X @ Y\n  Provenance: ✓ PASS — 6 claims traced to source, 0 unsourced"
+        )
+        assert out["needs_revision"] is False
+        assert out["review_feedback"] == []
+
+    def test_skipped_check_does_not_trigger_revision(self):
+        out = self._review(
+            "✓ Resume generated for X @ Y\n  Provenance: ⚠ check skipped — db unavailable"
         )
         assert out["needs_revision"] is False
         assert out["review_feedback"] == []

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -111,6 +111,44 @@ class TestResumeService:
         )
         assert isinstance(result, ResumeResult)
 
+    def test_provenance_line_extracted_into_result(self, isolated_server, monkeypatch):
+        monkeypatch.setattr(
+            "tools.generate.generate_resume",
+            lambda *a, **k: (
+                "✓ Resume generated for R @ C\n"
+                "  ✓ Saved: resume.txt\n"
+                "  Provenance: ✓ PASS — 2 claims traced to source, 0 unsourced"
+            ),
+        )
+        result = ResumeService.generate(
+            company="C", role="R", job_description="jd", kind="resume",
+        )
+        assert result.provenance == (
+            "Provenance: ✓ PASS — 2 claims traced to source, 0 unsourced"
+        )
+
+    def test_provenance_fail_line_extracted_verbatim(self, isolated_server, monkeypatch):
+        monkeypatch.setattr(
+            "tools.generate.generate_resume",
+            lambda *a, **k: (
+                '✓ Resume generated for R @ C\n  Provenance: ⚠ 1 unsourced — "2M"'
+            ),
+        )
+        result = ResumeService.generate(
+            company="C", role="R", job_description="jd", kind="resume",
+        )
+        assert result.provenance == 'Provenance: ⚠ 1 unsourced — "2M"'
+        # Informational, not blocking: the run still reports success.
+        assert result.success is True
+
+    def test_provenance_none_when_no_gate_line(self, isolated_server):
+        # Keyless config returns the context package, which carries no gate line.
+        result = ResumeService.generate(
+            company="Stripe", role="Staff Engineer", job_description="JD",
+            kind="resume",
+        )
+        assert result.provenance is None
+
     def test_starting_event_payload_includes_company_and_role(self, isolated_server):
         events, cb = _capture()
         ResumeService.generate(

--- a/tools/generate.py
+++ b/tools/generate.py
@@ -1177,8 +1177,14 @@ def _provenance_note(
     is fabricated by definition.
     """
     try:
-        from lib.provenance import check_claims, extract_claims, record_run
+        from lib.provenance import (
+            check_claims,
+            extract_claims,
+            format_provenance_line,
+            record_run,
+        )
 
+        claims = extract_claims(content)
         violations = check_claims(content, [source_text])
         record_run(
             kind=kind,
@@ -1186,19 +1192,14 @@ def _provenance_note(
             role=role,
             job_description=job_description,
             chunk_texts=[],
-            claims=extract_claims(content),
+            claims=claims,
             violations=violations,
             verdict="failed" if violations else "passed",
             revisions=0,
         )
-        if violations:
-            return (
-                "⚠ Provenance: unsourced claims — verify before sending: "
-                + ", ".join(violations[:6])
-            )
-        return "✓ Provenance: all numeric claims trace to source material"
+        return format_provenance_line(claims, violations)
     except Exception as exc:  # noqa: BLE001 — the gate must never break generation
-        return f"⚠ Provenance check skipped: {exc}"
+        return f"Provenance: ⚠ check skipped — {exc}"
 
 
 def generate_resume(

--- a/tools/langgraph_pipeline.py
+++ b/tools/langgraph_pipeline.py
@@ -479,12 +479,11 @@ def generate_resume_agent(company: str, role: str, job_description: str) -> str:
     revisions = final_state["revision_count"]
     review = final_state["review_notes"]
     review_summary = review[:80] + "..." if len(review) > 80 else review
+    from lib.provenance import extract_claims, format_provenance_line
+
     violations = final_state.get("provenance_violations") or []
-    provenance_line = (
-        "  Provenance: PASSED — every numeric claim traces to source material"
-        if not violations
-        else "  Provenance: FAILED — unsourced claims survived revision: "
-        + ", ".join(violations[:5])
+    provenance_line = "  " + format_provenance_line(
+        extract_claims(final_state["draft"]), violations
     )
 
     header = "\n".join([

--- a/tools/latex_export.py
+++ b/tools/latex_export.py
@@ -51,6 +51,7 @@ _TEX_TEMPLATE = r"""\documentclass[letter,11pt]{{article}}
 \def\email{{{email}}}
 \def\linkedin{{{linkedin}}}
 \def\github{{{github}}}
+\def\website{{{website}}}
 \def\role{{{role_title}}}
 
 \input{{_header}}
@@ -143,6 +144,13 @@ def _user_identity() -> dict[str, str]:
     linkedin = linkedin.replace("https://www.linkedin.com/in/", "").replace("www.linkedin.com/in/", "").strip("/")
     github = str(contact.get("github", "") or "")
     github = github.replace("https://www.github.com/", "").replace("www.github.com/", "").replace("https://github.com/", "").strip("/")
+    # Personal site: _header.tex renders \href{https://\website}{\website},
+    # so the value must be scheme-less (a scheme would double-prefix). Unlike
+    # the other fields there is deliberately NO placeholder fallback — the
+    # header's \ifx\website\empty guard hides the third link entirely when
+    # unconfigured, and a fake placeholder URL would render as a real link.
+    website = str(contact.get("website", "") or "")
+    website = re.sub(r"^https?://", "", website.strip()).strip("/")
     return {
         "name":     str(contact.get("name", "") or "") or _AUTHOR_DEFAULTS["name"],
         "phone":    str(contact.get("phone", "") or "") or _AUTHOR_DEFAULTS["phone"],
@@ -150,6 +158,7 @@ def _user_identity() -> dict[str, str]:
         "email":    str(contact.get("email", "") or "") or _AUTHOR_DEFAULTS["email"],
         "linkedin": linkedin or _AUTHOR_DEFAULTS["linkedin"],
         "github":   github or _AUTHOR_DEFAULTS["github"],
+        "website":  website,
     }
 
 
@@ -394,7 +403,7 @@ _RESUME_TEX = "resume.tex"
 #: *fixed* set of literal names — never built from caller input — so the
 #: matchers below are fully static (no request-influenced regex construction).
 _MACRO_NAMES: tuple[str, ...] = (
-    "role", "name", "phone", "city", "email", "linkedin", "github",
+    "role", "name", "phone", "city", "email", "linkedin", "github", "website",
 )
 
 #: Precompiled ``\def\<macro>{...}`` matchers, one per known macro. Built from
@@ -410,7 +419,10 @@ _ROLE_DEF_RE = _MACRO_DEF_PATTERNS["role"]
 #: Header identity macros populated from the active user's contact info so a
 #: compiled resume never carries another user's name/contact. Mirrors the
 #: cover-letter pipeline's _user_identity() field set.
-_IDENTITY_MACROS = ("name", "phone", "city", "email", "linkedin", "github")
+#: \website has no placeholder default: blank means "no third header link"
+#: (resume.tex ships \def\website{} and _header.tex guards on \ifx\website\empty),
+#: and _inject_def's blank-is-no-op behavior preserves exactly that.
+_IDENTITY_MACROS = ("name", "phone", "city", "email", "linkedin", "github", "website")
 
 #: Defensive ceiling on an injected header value (name/role are short by nature).
 _MACRO_VALUE_MAX_LEN = 200

--- a/transport/http/routes/dashboard/pipeline.py
+++ b/transport/http/routes/dashboard/pipeline.py
@@ -167,6 +167,7 @@ async def pipeline_generate_resume(req: _JobActionRequest) -> JSONResponse:
         "ok": result.success,
         "content": result.content,
         "notes": result.notes,
+        "provenance": result.provenance,
         "selected_resume": selected,
     })
 
@@ -203,6 +204,7 @@ async def pipeline_generate_cover_letter(req: _JobActionRequest) -> JSONResponse
         "ok": result.success,
         "content": result.content,
         "notes": result.notes,
+        "provenance": result.provenance,
         "selected_resume": selected,
     })
 

--- a/transport/http/routes/dashboard/pipeline.py
+++ b/transport/http/routes/dashboard/pipeline.py
@@ -17,7 +17,11 @@ from lib.openai_calls import create_chat_completion
 from services import JobAnalysisService, ResumeService
 from services.persona_service import PersonaService, DEFAULT_PERSONA
 from tools.export import export_cover_letter_pdf, export_resume_pdf
-from tools.generate import _extract_cover_letter_body, _sanitize_cover_letter_output
+from tools.generate import (
+    _extract_cover_letter_body,
+    _provenance_note,
+    _sanitize_cover_letter_output,
+)
 from tools.job_hunt import log_application_event, update_application
 from tools.latex_export import generate_cover_letter_latex
 from tools.resume import save_cover_letter_txt, save_resume_txt
@@ -297,6 +301,19 @@ async def pipeline_edit_resume(req: _ResumeEditRequest) -> JSONResponse:
 
     _update_job(req.job_id, lambda j: j.update({"last_edited_resume": output_name}))
 
+    # Truth gate over the edited draft (observe-and-report, never blocks).
+    # Sources = everything the model was shown (current resume, JD, edit
+    # instructions): a numeric claim absent from all of it was fabricated by
+    # the edit. An explicitly instructed number is in-source by design.
+    prov_note = _provenance_note(
+        "resume_edit",
+        job.get("company", ""),
+        job.get("role", ""),
+        job.get("jd", ""),
+        edited,
+        "\n".join(str(m.get("content", "")) for m in messages),
+    )
+
     return JSONResponse({
         "ok": True,
         "job_id": req.job_id,
@@ -304,6 +321,7 @@ async def pipeline_edit_resume(req: _ResumeEditRequest) -> JSONResponse:
         "edited_resume": output_name,
         "save_result": save_result,
         "pdf_result": pdf_result,
+        "provenance": prov_note,
         "usage": {
             "prompt_tokens": getattr(response.usage, "prompt_tokens", None) if response.usage else None,
             "completion_tokens": getattr(response.usage, "completion_tokens", None) if response.usage else None,
@@ -427,11 +445,22 @@ async def pipeline_edit_cover_letter(req: _CoverLetterEditRequest) -> JSONRespon
 
     _update_job(req.job_id, lambda j: j.update({"last_edited_cover_letter": source.name}))
 
+    # Same observe-and-report truth gate as edit-resume, over the CL draft.
+    prov_note = _provenance_note(
+        "cover_letter_edit",
+        job.get("company", ""),
+        job.get("role", ""),
+        job.get("jd", ""),
+        edited,
+        "\n".join(str(m.get("content", "")) for m in messages),
+    )
+
     return JSONResponse({
         "ok": True,
         "job_id": req.job_id,
         "source_cover_letter": source.name,
         "edited_cover_letter": draft_path.name,
+        "provenance": prov_note,
         "draft_name": draft_path.name,
         "draft_href": _draft_href(draft_path),
         "draft_content": edited,

--- a/workflows/langgraph/resume_graph.py
+++ b/workflows/langgraph/resume_graph.py
@@ -30,6 +30,7 @@ falls back to deterministic disk/text operations when no key is present.
 
 from __future__ import annotations
 
+import re
 from typing import TypedDict
 
 from langgraph.graph import StateGraph, END
@@ -120,9 +121,11 @@ def _node_review(state: ResumeGraphState) -> dict:
         feedback.append("LLM call returned an error marker.")
     # The provenance gate runs inside tools.generate (this graph's draft node
     # delegates to it); an unsourced-claims verdict rides back in the
-    # confirmation string. Treat it as a review failure so the revise loop
-    # gets one shot at a clean regeneration.
-    if "⚠ Provenance: unsourced claims" in draft:
+    # confirmation string (lib.provenance.format_provenance_line). Treat it
+    # as a review failure so the revise loop gets one shot at a clean
+    # regeneration. The pattern must not match the PASS line ("0 unsourced")
+    # or the check-skipped line, so it anchors on the FAIL shape "⚠ N unsourced".
+    if re.search(r"Provenance: ⚠ \d+ unsourced", draft):
         feedback.append(
             "Provenance gate found unsourced numeric claims — regenerate "
             "using only facts from the master resume."


### PR DESCRIPTION
Promotes qa → main for the v1.4.0 release. qa deploy is green (run 30129486875: tests, Sonar, AKS qa rollout).

Contents since v1.3.1:

- **Provenance verdict surfaced everywhere** (PR #145): shared `format_provenance_line()` in every generation confirmation, `provenance` field on the generate/edit APIs, green/amber badge on the Pipeline screen and in both AI edit dialogs at the accept/discard decision point.
- **AI edit dialogs now face the truth gate** (PR #145): `/pipeline/edit-resume` and `/pipeline/edit-cover-letter` previously called the LLM with no gate, no audit row, no warning — now observe-and-report gated with audit kinds `resume_edit` / `cover_letter_edit`.
- Mobile: expo-updates OTA + EAS Update channels, detail pages / global search / timeline (PR #144 line).
- Frontend: actionable Home cards, Materials redesign, modals portaled to `<body>`, LaTeX website header field.
- Fixes: Linux dead-click file opens, PAT-user greeting.
- Release bookkeeping (PR #146): version 1.4.0 in `lib/version.py` + image label, CHANGELOG `[1.4.0]`, README v1.4 narrative + corrected badges (88 actions, 1526 tests).

After merge: tag `v1.4.0` on the merge SHA (not a badge-bot `[skip ci]` commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)