### PR TITLE
Merge qa into main — cover-letter accept regenerates the canonical PDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug fixes
+
+- **Accepting a cover-letter edit now regenerates the canonical PDF** -- accept-cover-letter-edit rewrote the .txt (with a .bak backup) but never re-exported, leaving the document's PDF stale; the only fresh PDF was the review-phase preview of the .tmp draft. Accept now re-exports from the accepted text using the job's saved template/style (HTML or owner-only LaTeX, gated before any mutation), surfaces the result + a link in the done view, and reports export failures as warnings without failing the accept. The resume edit dialog was not affected (its one-shot flow already exported the edited copy).
+
 ### Features
 
 - **Follow-up queue sanity** -- the People follow-up queue was "status ∈ {drafted, sent, follow-up}, forever": a ghosted recruiter stayed a suggested follow-up for months. The queue now (1) times out threads untouched for `followup_timeout_days` (default 21) into a collapsed "Gone cold" bucket instead of the to-do list, (2) excludes closed-thread tags (`unresponsive`, `closed-loop`, `do-not-contact`, `dormant`, `archived`), and (3) supports per-contact dismissal (✕ on the card; `POST /dashboard/people/dismiss-followup`, restorable). Dismissals live in a per-user overlay (`lib/dismissals.py`, `dismissals.json`) because the queue is a derived view with no row to delete.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/version-1.4.0-blue" alt="Version 1.4.0"/>
-  <img src="https://img.shields.io/badge/tests-1545%20passing-brightgreen" alt="1545 tests passing"/>
+  <img src="https://img.shields.io/badge/tests-1549%20passing-brightgreen" alt="1549 tests passing"/>
   <a href="https://sonarcloud.io/component_measures?id=JustLikeFrank3_jobContextMCP&metric=coverage"><img src="https://sonarcloud.io/api/project_badges/measure?project=JustLikeFrank3_jobContextMCP&metric=coverage" alt="Coverage"/></a>
   <img src="https://img.shields.io/badge/tools-11%20domains%20%C2%B7%2088%20actions-informational" alt="11 domain tools, 88 actions"/>
   <img src="https://img.shields.io/badge/license-MIT-lightgrey" alt="MIT License"/>
@@ -35,7 +35,7 @@ Available as a **double-clickable desktop app** (macOS · Windows · Linux), a l
 | | |
 |---|---|
 | 11 domain tools (88 actions) | Resume + cover letter generation |
-| 1545 passing tests | Job fitment analysis with persona lenses |
+| 1549 passing tests | Job fitment analysis with persona lenses |
 | SQLite persistence + JSON fallback | Interview prep + debrief logging |
 | Local RAG semantic search | Outreach + relationship tracking |
 | Azure AKS deployment | Microsoft Entra ID authentication |

--- a/frontend/src/screens/pipeline/EditCoverLetterModal.jsx
+++ b/frontend/src/screens/pipeline/EditCoverLetterModal.jsx
@@ -43,6 +43,9 @@ export default function EditCoverLetterModal({ job, coverLetterOptions, isOwner,
     try {
       const res = await apiPost('/dashboard/pipeline/accept-cover-letter-edit', {
         cover_letter_name: clName, draft_name: draft.draft_name,
+        // The accepted text replaces the .txt, so the canonical PDF is
+        // regenerated server-side with this job's template/style.
+        job_id: job.id, export_pdf: exportPdf, export_pipeline: pipeline,
       })
       setAccepted(res); setPhase('done')
     } catch (e) { setErr(actionError(e)) } finally { setSubmitting(false) }
@@ -69,9 +72,15 @@ export default function EditCoverLetterModal({ job, coverLetterOptions, isOwner,
             The draft was applied to {clName}. A .bak backup of the previous version was saved.
           </div>
         </div>
-        {accepted?.href && (
-          <a href={accepted.href} target="_blank" rel="noreferrer" onClick={nativeAnchorHandler(isDesktop, accepted.href, 'file')} style={{ color: 'var(--cyan-300)', fontSize: 'var(--fs-sm)', textDecoration: 'none' }}>Open the updated file {'↗'}</a>
-        )}
+        {accepted?.pdf_result && <ResultLine>{accepted.pdf_result}</ResultLine>}
+        <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap' }}>
+          {accepted?.href && (
+            <a href={accepted.href} target="_blank" rel="noreferrer" onClick={nativeAnchorHandler(isDesktop, accepted.href, 'file')} style={{ color: 'var(--cyan-300)', fontSize: 'var(--fs-sm)', textDecoration: 'none' }}>Open the updated file {'↗'}</a>
+          )}
+          {accepted?.pdf_href && (
+            <a href={accepted.pdf_href} target="_blank" rel="noreferrer" onClick={nativeAnchorHandler(isDesktop, accepted.pdf_href, 'file')} style={{ color: 'var(--cyan-300)', fontSize: 'var(--fs-sm)', textDecoration: 'none' }}>Open the regenerated PDF {'↗'}</a>
+          )}
+        </div>
         <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 14 }}>
           <Button size="sm" onClick={onDone}>Done</Button>
         </div>

--- a/templates/latex_assets/sections/experience.tex
+++ b/templates/latex_assets/sections/experience.tex
@@ -5,7 +5,7 @@
 \subsection{{\textbf{Senior Software Engineer} \textit{\ \ Contoso Cloud, Remote} \hfill 20XX --- Present}}
 \begin{zitemize}
 \item Led design and delivery of a customer-facing service from architecture through production and on-call; quantify the impact here (latency, scale, revenue, or adoption).
-\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1545 passing tests at 80\%+ line coverage through disciplined TDD.
+\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1549 passing tests at 80\%+ line coverage through disciplined TDD.
 \item Drove a cross-team win — a migration, a shared API pattern others adopted, or an SLA target consistently met.
 \end{zitemize}
 %====================

--- a/tests/test_dashboard_pipeline.py
+++ b/tests/test_dashboard_pipeline.py
@@ -421,6 +421,105 @@ class TestCoverLetterEditDialog:
         assert not (cl_dir / "base.edit1.tmp").exists()
         assert not (cl_dir / "base.edit2.tmp").exists()
 
+    def test_accept_regenerates_canonical_pdf_with_job_template(self, http_client_noauth, monkeypatch):
+        """Accepting a draft rewrites the .txt — the canonical PDF must be
+        re-exported from the accepted text (the review-phase PDF was a preview
+        of the .tmp draft, not this document)."""
+        cl_dir = config.RESUME_FOLDER / config._cfg.get("cover_letters_dir", "02-Cover-Letters")
+        cl_dir.mkdir(parents=True, exist_ok=True)
+        (cl_dir / "base.txt").write_text("original", encoding="utf-8")
+        (cl_dir / "base.edit1.tmp").write_text("accepted body", encoding="utf-8")
+        _seed_jobs([_job(id=21, company="Equifax", role="Lead AI Engineer",
+                         cl_template="modern", cl_style="forest")])
+
+        captured = {}
+
+        def fake_export(filename, **kw):
+            captured["filename"] = filename
+            captured.update(kw)
+            return "✓ PDF exported: 09-Cover-Letter-PDFs/base.pdf"
+
+        monkeypatch.setattr(pl, "export_cover_letter_pdf", fake_export)
+
+        r = http_client_noauth.post(
+            "/dashboard/pipeline/accept-cover-letter-edit",
+            json={"cover_letter_name": "base.txt", "draft_name": "base.edit1.tmp",
+                  "job_id": 21, "export_pdf": True, "export_pipeline": "html"},
+        )
+
+        assert r.status_code == 200
+        body = r.json()
+        assert (cl_dir / "base.txt").read_text(encoding="utf-8") == "accepted body"
+        # Export ran against the CANONICAL file with the job's saved selection.
+        assert captured["filename"] == "base.txt"
+        assert captured["template"] == "modern"
+        assert captured["style"] == "forest"
+        assert captured["footer_tag"] == "LEAD AI ENGINEER"
+        assert body["pdf_result"].startswith("✓ PDF exported")
+        assert body["pdf_href"] == "/dashboard/materials/file/cover_letter_pdfs/base.pdf"
+
+    def test_accept_skips_export_when_disabled(self, http_client_noauth, monkeypatch):
+        cl_dir = config.RESUME_FOLDER / config._cfg.get("cover_letters_dir", "02-Cover-Letters")
+        cl_dir.mkdir(parents=True, exist_ok=True)
+        (cl_dir / "base.txt").write_text("original", encoding="utf-8")
+        (cl_dir / "base.edit1.tmp").write_text("draft", encoding="utf-8")
+
+        def boom(*a, **kw):
+            raise AssertionError("export must not run when export_pdf is false")
+
+        monkeypatch.setattr(pl, "export_cover_letter_pdf", boom)
+
+        r = http_client_noauth.post(
+            "/dashboard/pipeline/accept-cover-letter-edit",
+            json={"cover_letter_name": "base.txt", "draft_name": "base.edit1.tmp",
+                  "export_pdf": False},
+        )
+
+        assert r.status_code == 200
+        assert r.json()["pdf_result"] == ""
+        assert r.json()["pdf_href"] == ""
+
+    def test_accept_export_failure_does_not_fail_the_accept(self, http_client_noauth, monkeypatch):
+        cl_dir = config.RESUME_FOLDER / config._cfg.get("cover_letters_dir", "02-Cover-Letters")
+        cl_dir.mkdir(parents=True, exist_ok=True)
+        (cl_dir / "base.txt").write_text("original", encoding="utf-8")
+        (cl_dir / "base.edit1.tmp").write_text("accepted", encoding="utf-8")
+
+        def broken(*a, **kw):
+            raise RuntimeError("weasyprint on fire")
+
+        monkeypatch.setattr(pl, "export_cover_letter_pdf", broken)
+
+        r = http_client_noauth.post(
+            "/dashboard/pipeline/accept-cover-letter-edit",
+            json={"cover_letter_name": "base.txt", "draft_name": "base.edit1.tmp"},
+        )
+
+        assert r.status_code == 200
+        # Text applied even though the export failed — surfaced, not fatal.
+        assert (cl_dir / "base.txt").read_text(encoding="utf-8") == "accepted"
+        assert r.json()["pdf_result"].startswith("⚠ PDF export failed")
+
+    def test_accept_latex_is_owner_gated_before_mutation(self, http_client_noauth, monkeypatch):
+        cl_dir = config.RESUME_FOLDER / config._cfg.get("cover_letters_dir", "02-Cover-Letters")
+        cl_dir.mkdir(parents=True, exist_ok=True)
+        (cl_dir / "base.txt").write_text("original", encoding="utf-8")
+        (cl_dir / "base.edit1.tmp").write_text("draft", encoding="utf-8")
+
+        monkeypatch.setattr("lib.config.OWNER_OID", "owner-123")
+        monkeypatch.setattr("lib.user_context.get_current_user_oid", lambda: "someone-else")
+
+        r = http_client_noauth.post(
+            "/dashboard/pipeline/accept-cover-letter-edit",
+            json={"cover_letter_name": "base.txt", "draft_name": "base.edit1.tmp",
+                  "export_pipeline": "latex"},
+        )
+
+        assert r.status_code == 403
+        # Gate fires BEFORE any mutation: original intact, draft still there.
+        assert (cl_dir / "base.txt").read_text(encoding="utf-8") == "original"
+        assert (cl_dir / "base.edit1.tmp").exists()
+
     def test_cancel_cover_letter_edit_removes_drafts_without_touching_original(self, http_client_noauth):
         cl_dir = config.RESUME_FOLDER / config._cfg.get("cover_letters_dir", "02-Cover-Letters")
         cl_dir.mkdir(parents=True, exist_ok=True)

--- a/transport/http/routes/dashboard/pipeline.py
+++ b/transport/http/routes/dashboard/pipeline.py
@@ -484,6 +484,13 @@ async def pipeline_edit_cover_letter(req: _CoverLetterEditRequest) -> JSONRespon
     },
 )
 async def pipeline_accept_cover_letter_edit(req: _CoverLetterAcceptRequest) -> JSONResponse:
+    # Owner gate mirrors the edit/generate routes — check before any mutation.
+    if req.export_pdf and req.export_pipeline == "latex":
+        from lib.user_context import get_current_user_oid
+        from lib.config import OWNER_OID as _OWNER_OID
+        if not (bool(_OWNER_OID) and get_current_user_oid() == _OWNER_OID):
+            raise HTTPException(status_code=403, detail="LaTeX export is not available for beta accounts.")
+
     source = _resolve_cover_letter(req.cover_letter_name)
     draft = _resolve_cover_letter_draft(req.draft_name)
     if draft not in _list_cover_letter_drafts(source.name):
@@ -491,13 +498,53 @@ async def pipeline_accept_cover_letter_edit(req: _CoverLetterAcceptRequest) -> J
 
     backup = _safe_child_path(source.parent, f"{source.name}.bak", detail="Invalid cover-letter backup path")
     backup.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")  # NOSONAR
-    source.write_text(draft.read_text(encoding="utf-8"), encoding="utf-8")  # NOSONAR
+    accepted_text = draft.read_text(encoding="utf-8")
+    source.write_text(accepted_text, encoding="utf-8")  # NOSONAR
     deleted = _delete_cover_letter_drafts(source.name)
+
+    # The .txt just changed, so the canonical PDF is stale — regenerate it.
+    # The review-phase PDF was rendered from the .tmp draft (a preview file),
+    # not this document. Export failure must not fail the accept: the text is
+    # already applied; surface the warning instead.
+    pdf_result = ""
+    pdf_href = ""
+    if req.export_pdf:
+        job = {}
+        if req.job_id is not None:
+            try:
+                job = _find_job(req.job_id)
+            except HTTPException:
+                job = {}  # job removed since the edit — export with defaults
+        role = job.get("role", "") or "Software Engineer"
+        try:
+            if req.export_pipeline == "latex":
+                body = _extract_cover_letter_body(accepted_text) or accepted_text
+                pdf_path = generate_cover_letter_latex(
+                    body=body,
+                    company=job.get("company", ""),
+                    role=role,
+                    role_title=role,
+                )
+                pdf_result = f"✓ PDF exported: {pdf_path}"
+                pdf_href = _material_href_for_pdf(pdf_path)
+            else:
+                pdf_result = export_cover_letter_pdf(
+                    source.name,
+                    footer_tag=role.upper(),
+                    template=job.get("cl_template") or "",
+                    style=job.get("cl_style") or "navy",
+                )
+                pdf_href = _material_href_for_pdf(_pdf_path_from_export_result(pdf_result))
+        except Exception as exc:  # noqa: BLE001 — text is applied; report, don't fail
+            pdf_result = f"⚠ PDF export failed: {exc}"
+
     return JSONResponse({
         "ok": True,
         "cover_letter_name": source.name,
         "backup_name": backup.name,
         "deleted_drafts": deleted,
+        "pdf_result": pdf_result,
+        "pdf_href": pdf_href,
         "href": f"/dashboard/materials/file/cover_letters/{quote(source.name, safe='')}",
     })
 

--- a/transport/http/routes/dashboard/pipeline_helpers.py
+++ b/transport/http/routes/dashboard/pipeline_helpers.py
@@ -57,6 +57,12 @@ class _CoverLetterEditRequest(BaseModel):
 class _CoverLetterAcceptRequest(BaseModel):
     cover_letter_name: str = Field(..., min_length=1)
     draft_name: str = Field(..., min_length=1)
+    # Applying a draft rewrites the .txt — the canonical PDF must follow.
+    # job_id supplies the saved template/style + role footer; export_pipeline
+    # mirrors the edit dialog's selection (latex stays owner-only).
+    job_id: int | None = None
+    export_pdf: bool = True
+    export_pipeline: str = "html"
 
 
 class _CoverLetterCancelRequest(BaseModel):


### PR DESCRIPTION
Promotes qa → main. qa deploy green (run 30133984951).

Contents: PR #150 — accepting a cover-letter edit now re-exports the canonical PDF from the accepted text (job's saved template/style, HTML or owner-gated LaTeX checked pre-mutation); export failures surface as warnings without failing the accept; done view links the regenerated PDF. Resume edit path audited and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)