### PR TITLE
feat(provenance): every violation visible and actionable at generation time

### DIFF
--- a/frontend/src/screens/Pipeline.jsx
+++ b/frontend/src/screens/Pipeline.jsx
@@ -9,6 +9,7 @@ import JobCard, { ROW_GRID } from './pipeline/JobCard.jsx'
 import AddJobModal from './pipeline/AddJobModal.jsx'
 import EditResumeModal from './pipeline/EditResumeModal.jsx'
 import EditCoverLetterModal from './pipeline/EditCoverLetterModal.jsx'
+import ProvenanceViolationsModal from './pipeline/ProvenanceViolationsModal.jsx'
 import TemplateModal from './pipeline/TemplateModal.jsx'
 
 /* Pipeline — the share-sheet intake queue: assess, generate, decide, apply.
@@ -62,8 +63,9 @@ export default function Pipeline() {
   const [stageFilter, setStageFilter] = useState('all')
   const [persona, setPersona] = useState('')
   const [addOpen, setAddOpen] = useState(false)
-  const [genResult, setGenResult] = useState(null) // { title, ok, provenance: parseProvenance() | null }
-  const [editor, setEditor] = useState(null) // { type: 'edit-resume'|'edit-cl'|'templates', job }
+  const [genResult, setGenResult] = useState(null) // { title, ok, provenance, genKind: 'resume'|'cl', job }
+  const [editor, setEditor] = useState(null) // { type: 'edit-resume'|'edit-cl'|'templates', job, initialInstructions? }
+  const [violModal, setViolModal] = useState(null) // { job, genKind } — provenance violations detail
 
   const load = useCallback(async ({ silent } = {}) => {
     if (!silent) setState((s) => ({ ...s, loading: !s.data, error: null }))
@@ -98,22 +100,20 @@ export default function Pipeline() {
         setBusy(`Generating resume for ${job.company}…`)
         setGenResult(null)
         const res = await apiPost('/dashboard/pipeline/generate-resume', { job_id: job.id, persona: activePersona })
-        setGenResult({
-          title: `Resume — ${job.company}`,
-          ok: !!res?.ok,
-          provenance: parseProvenance(res?.provenance),
-        })
+        const provenance = parseProvenance(res?.provenance)
+        setGenResult({ title: `Resume — ${job.company}`, ok: !!res?.ok, provenance, genKind: 'resume', job })
+        // Violations demand attention at generation time, not on the wallboard
+        // after the fact — auto-open the full list.
+        if (provenance?.status === 'fail') setViolModal({ job, genKind: 'resume' })
         if (!res?.ok) window.alert(`Resume generation did not produce files.\n\n${String(res?.content || res?.notes || '').slice(0, 500)}`)
       } else if (type === 'cl-latex' || type === 'cl-html') {
         const pipeline = type === 'cl-latex' ? 'latex' : 'html'
         setBusy(`Generating cover letter (${pipeline.toUpperCase()}) for ${job.company}…`)
         setGenResult(null)
         const res = await apiPost('/dashboard/pipeline/generate-cover-letter', { job_id: job.id, export_pipeline: pipeline, persona: activePersona })
-        setGenResult({
-          title: `Cover letter — ${job.company}`,
-          ok: !!res?.ok,
-          provenance: parseProvenance(res?.provenance),
-        })
+        const provenance = parseProvenance(res?.provenance)
+        setGenResult({ title: `Cover letter — ${job.company}`, ok: !!res?.ok, provenance, genKind: 'cl', job })
+        if (provenance?.status === 'fail') setViolModal({ job, genKind: 'cl' })
         if (!res?.ok) window.alert(`Cover letter generation did not produce files (likely an API rate limit or provider error).\n\n${String(res?.content || res?.notes || '').slice(0, 500)}`)
       } else if (type === 'apply') {
         setBusy(`Queueing application for ${job.company}…`)
@@ -177,6 +177,12 @@ export default function Pipeline() {
                 <span style={{ fontSize: 'var(--fs-xs)', color: 'var(--muted)' }}>
                   {genResult.provenance.text}
                 </span>
+                {genResult.provenance.status === 'fail' && (
+                  <Button size="sm" variant="ghost"
+                    onClick={() => setViolModal({ job: genResult.job, genKind: genResult.genKind })}>
+                    View violations
+                  </Button>
+                )}
               </>
             ) : (
               <span style={{ fontSize: 'var(--fs-xs)', color: 'var(--faint)' }}>
@@ -282,10 +288,29 @@ export default function Pipeline() {
         />
       )}
 
+      {violModal && (
+        <ProvenanceViolationsModal
+          job={violModal.job}
+          onClose={() => setViolModal(null)}
+          onFix={(instructions) => {
+            // Hand off to the AI-edit flow for whichever document was just
+            // generated; use the freshest job row so the edit modal suggests
+            // the newly generated file.
+            const fresh = jobs.find((j) => j.id === violModal.job.id) || violModal.job
+            setViolModal(null)
+            setEditor({
+              type: violModal.genKind === 'cl' ? 'edit-cl' : 'edit-resume',
+              job: fresh,
+              initialInstructions: instructions,
+            })
+          }}
+        />
+      )}
       {editor?.type === 'edit-resume' && (
         <EditResumeModal
           job={editor.job}
           resumeOptions={data?.optimized_resume_options}
+          initialInstructions={editor.initialInstructions}
           onClose={() => setEditor(null)}
           onDone={() => { setEditor(null); load({ silent: true }) }}
         />
@@ -295,6 +320,7 @@ export default function Pipeline() {
           job={editor.job}
           coverLetterOptions={data?.cover_letter_options}
           isOwner={!!data?.is_owner}
+          initialInstructions={editor.initialInstructions}
           onClose={() => setEditor(null)}
           onDone={() => { setEditor(null); load({ silent: true }) }}
         />

--- a/frontend/src/screens/pipeline/EditCoverLetterModal.jsx
+++ b/frontend/src/screens/pipeline/EditCoverLetterModal.jsx
@@ -7,11 +7,11 @@ import { EYEBROW } from '../_shared.jsx'
 import { Modal, ResultLine, EmptyEditorState, ProvenanceNote, modalField, modalLabel, actionError } from './shared.jsx'
 
 /* Edit Cover Letter (draft → review → accept/discard) */
-export default function EditCoverLetterModal({ job, coverLetterOptions, isOwner, onClose, onDone }) {
+export default function EditCoverLetterModal({ job, coverLetterOptions, isOwner, initialInstructions, onClose, onDone }) {
   const isDesktop = useDesktopMode()
   const options = coverLetterOptions || []
   const [clName, setClName] = useState(job.suggested_edit_cover_letter || options[0] || '')
-  const [instructions, setInstructions] = useState('')
+  const [instructions, setInstructions] = useState(initialInstructions || '')
   const [pipeline, setPipeline] = useState(isOwner ? 'latex' : 'html')
   const [exportPdf, setExportPdf] = useState(true)
   const [submitting, setSubmitting] = useState(false)

--- a/frontend/src/screens/pipeline/EditResumeModal.jsx
+++ b/frontend/src/screens/pipeline/EditResumeModal.jsx
@@ -3,10 +3,10 @@ import { Button } from '../../design-system'
 import { apiPost } from '../../auth/api.js'
 import { Modal, ResultLine, EmptyEditorState, ProvenanceNote, modalField, modalLabel, actionError } from './shared.jsx'
 
-export default function EditResumeModal({ job, resumeOptions, onClose, onDone }) {
+export default function EditResumeModal({ job, resumeOptions, initialInstructions, onClose, onDone }) {
   const options = resumeOptions || []
   const [resumeName, setResumeName] = useState(job.suggested_edit_resume || options[0] || '')
-  const [instructions, setInstructions] = useState('')
+  const [instructions, setInstructions] = useState(initialInstructions || '')
   const [exportPdf, setExportPdf] = useState(true)
   const [submitting, setSubmitting] = useState(false)
   const [err, setErr] = useState('')

--- a/frontend/src/screens/pipeline/ProvenanceViolationsModal.jsx
+++ b/frontend/src/screens/pipeline/ProvenanceViolationsModal.jsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from 'react'
+import { Button } from '../../design-system'
+import { Badge } from '../_shared.jsx'
+import { apiFetch } from '../../auth/api.js'
+import { Modal, actionError } from './shared.jsx'
+import { buildFixInstruction } from './provenance.js'
+
+/* Every violation from the last truth-gate run, listed in full and
+   actionable. The generation responses carry only the one-line verdict
+   (capped at 6 claims) — this modal reads the complete audit row via
+   GET /dashboard/pipeline/provenance/latest and hands picked claims to
+   the AI-edit flow (onFix), whose pipeline re-runs the gate.
+
+   Auto-opened by the Pipeline screen when a generation fails the gate;
+   re-openable from the result banner. */
+export default function ProvenanceViolationsModal({ job, onClose, onFix }) {
+  const [state, setState] = useState({ run: null, loading: true, error: '' })
+
+  useEffect(() => {
+    let alive = true
+    const qs = new URLSearchParams({ company: job.company || '', role: job.role || '' })
+    apiFetch(`/dashboard/pipeline/provenance/latest?${qs}`)
+      .then((run) => { if (alive) setState({ run, loading: false, error: '' }) })
+      .catch((e) => { if (alive) setState({ run: null, loading: false, error: actionError(e) }) })
+    return () => { alive = false }
+  }, [job.company, job.role])
+
+  const run = state.run?.found ? state.run : null
+  const violations = run?.violations || []
+
+  return (
+    <Modal title={`Provenance — ${job.company}`} onClose={onClose}>
+      {state.loading ? (
+        <div style={{ color: 'var(--muted)', fontSize: 'var(--fs-sm)' }}>Loading gate record…</div>
+      ) : state.error ? (
+        <div style={{ color: 'var(--muted)', fontSize: 'var(--fs-sm)' }}>{state.error}</div>
+      ) : !run ? (
+        <div style={{ color: 'var(--muted)', fontSize: 'var(--fs-sm)' }}>
+          No provenance record found for this job.
+        </div>
+      ) : (
+        <>
+          <div style={{ display: 'flex', gap: 10, alignItems: 'center', flexWrap: 'wrap', marginBottom: 12 }}>
+            <Badge tone={violations.length ? 'warn' : 'green'}>
+              {violations.length ? `⚠ ${violations.length} unsourced` : '✓ pass'}
+            </Badge>
+            <span style={{ fontSize: 'var(--fs-xs)', color: 'var(--muted)' }}>
+              {run.kind} {'·'} {run.claims.length} claims checked {'·'} {new Date(run.ts).toLocaleString()}
+            </span>
+          </div>
+          {violations.length === 0 ? (
+            <div style={{ color: 'var(--muted)', fontSize: 'var(--fs-sm)' }}>
+              Every claim traced to source material.
+            </div>
+          ) : (
+            <>
+              <div style={{ fontSize: 'var(--fs-xs)', color: 'var(--muted)', marginBottom: 8 }}>
+                These claims appear in the generated document but not in any source
+                material shown to the model. Fix rephrases or removes them via the AI
+                editor — which re-runs the gate.
+              </div>
+              <ol style={{ margin: '0 0 14px', paddingLeft: 22, display: 'grid', gap: 6 }}>
+                {violations.map((v) => (
+                  <li key={v} style={{ fontSize: 'var(--fs-sm)', color: 'var(--text)' }}>
+                    <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+                      <code style={{
+                        fontFamily: 'var(--font-mono)', background: 'var(--surface-sunken)',
+                        border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)',
+                        padding: '2px 7px', wordBreak: 'break-word',
+                      }}>{v}</code>
+                      <Button size="sm" variant="ghost" onClick={() => onFix(buildFixInstruction([v]))}>
+                        Fix
+                      </Button>
+                    </div>
+                  </li>
+                ))}
+              </ol>
+              <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+                <Button size="sm" variant="ghost" onClick={onClose}>Dismiss</Button>
+                <Button size="sm" onClick={() => onFix(buildFixInstruction(violations))}>
+                  Fix all {violations.length} with AI
+                </Button>
+              </div>
+            </>
+          )}
+        </>
+      )}
+    </Modal>
+  )
+}

--- a/frontend/src/screens/pipeline/provenance.js
+++ b/frontend/src/screens/pipeline/provenance.js
@@ -29,3 +29,19 @@ export const PROVENANCE_BADGE_LABEL = {
   fail: '⚠ unsourced claims',
   skipped: 'provenance skipped',
 }
+
+/* Edit-flow instruction for fixing unsourced claims. Feeds the existing
+   AI-edit modals (edit-resume / edit-cover-letter), whose pipeline re-runs
+   the truth gate — so "Fix with AI" closes the loop with a fresh verdict.
+   Pure so the exact contract with the edit prompt is unit-testable. */
+export function buildFixInstruction(violations) {
+  const vs = (violations || []).filter(Boolean)
+  if (vs.length === 0) return ''
+  const list = vs.map((v) => `"${v}"`).join(', ')
+  const noun = vs.length === 1 ? 'claim' : 'claims'
+  return (
+    `The provenance gate flagged ${vs.length} unsourced ${noun}: ${list}. ` +
+    'For each flagged claim, either rephrase it using only facts present in my source material, ' +
+    'or remove it entirely. Do not invent or substitute any numbers, metrics, or named facts.'
+  )
+}

--- a/frontend/src/screens/pipeline/provenance.test.js
+++ b/frontend/src/screens/pipeline/provenance.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { parseProvenance, PROVENANCE_TONE, PROVENANCE_BADGE_LABEL } from './provenance.js'
+import { parseProvenance, PROVENANCE_TONE, PROVENANCE_BADGE_LABEL, buildFixInstruction } from './provenance.js'
 
 describe('parseProvenance', () => {
   it('classifies the PASS line as pass', () => {
@@ -46,5 +46,30 @@ describe('badge mappings', () => {
       expect(PROVENANCE_TONE[status]).toBeTruthy()
       expect(PROVENANCE_BADGE_LABEL[status]).toBeTruthy()
     }
+  })
+})
+
+describe('buildFixInstruction', () => {
+  it('empty input yields empty string', () => {
+    expect(buildFixInstruction([])).toBe('')
+    expect(buildFixInstruction(null)).toBe('')
+  })
+
+  it('single violation reads as one claim, quoted', () => {
+    const out = buildFixInstruction(['47%'])
+    expect(out).toContain('1 unsourced claim:')
+    expect(out).toContain('"47%"')
+    expect(out).toContain('remove it entirely')
+  })
+
+  it('lists every violation — no cap', () => {
+    const vs = Array.from({ length: 9 }, (_, i) => `${i + 1}%`)
+    const out = buildFixInstruction(vs)
+    expect(out).toContain('9 unsourced claims:')
+    for (const v of vs) expect(out).toContain(`"${v}"`)
+  })
+
+  it('forbids inventing replacements', () => {
+    expect(buildFixInstruction(['$9M'])).toMatch(/Do not invent/)
   })
 })

--- a/lib/provenance.py
+++ b/lib/provenance.py
@@ -175,6 +175,43 @@ def record_run(
         pass
 
 
+def latest_run(
+    *, company: str = "", role: str = "", db_path=None
+) -> dict | None:
+    """Most recent generation_provenance row (partition-scoped DB).
+
+    Filters by company/role when given so a concurrent generation for a
+    different job can't be mistaken for this one. Returns the row with
+    claims/violations decoded, or None when nothing matches — the caller
+    (the dashboard's violations modal) treats None as "no gate record".
+    """
+    from lib.db import get_connection
+
+    where, params = [], []
+    if company:
+        where.append("company = ?")
+        params.append(company)
+    if role:
+        where.append("role = ?")
+        params.append(role)
+    sql = (
+        "SELECT id, ts, kind, company, role, claims, violations, verdict, "
+        "revisions FROM generation_provenance"
+        + (" WHERE " + " AND ".join(where) if where else "")
+        + " ORDER BY id DESC LIMIT 1"
+    )
+    with get_connection(path=db_path) as conn:
+        row = conn.execute(sql, params).fetchone()
+    if row is None:
+        return None
+    keys = ("id", "ts", "kind", "company", "role", "claims", "violations",
+            "verdict", "revisions")
+    out = dict(zip(keys, row))
+    out["claims"] = json.loads(out["claims"] or "[]")
+    out["violations"] = json.loads(out["violations"] or "[]")
+    return out
+
+
 def render_durable_metrics(db_path=None) -> str:
     """Prometheus gauge lines computed from the generation_provenance table.
 

--- a/tests/test_dashboard_pipeline.py
+++ b/tests/test_dashboard_pipeline.py
@@ -772,3 +772,47 @@ class TestPipelineHelpers:
     def test_first_sentence_truncates(self):
         out = pl._first_sentence("x" * 500, max_len=32)
         assert len(out) <= 32
+
+
+# GET /dashboard/pipeline/provenance/latest — full violation detail for the
+# violations modal (the generation responses cap the line at 6 claims).
+
+class TestProvenanceLatest:
+    def test_no_record_reports_found_false(self, http_client_noauth):
+        r = http_client_noauth.get("/dashboard/pipeline/provenance/latest")
+        assert r.status_code == 200
+        assert r.json() == {"found": False}
+
+    def test_returns_every_violation_uncapped(self, http_client_noauth):
+        from lib.provenance import record_run
+
+        violations = [f"{n}%" for n in range(1, 9)]  # 8 > the 6-line cap
+        record_run(
+            kind="resume", company="Initech", role="SWE",
+            job_description="jd", chunk_texts=["src"],
+            claims=violations + ["10x"], violations=violations,
+            verdict="failed", revisions=0,
+        )
+        r = http_client_noauth.get(
+            "/dashboard/pipeline/provenance/latest",
+            params={"company": "Initech", "role": "SWE"},
+        )
+        body = r.json()
+        assert body["found"] is True
+        assert body["violations"] == violations
+        assert body["verdict"] == "failed"
+        assert body["kind"] == "resume"
+        assert len(body["claims"]) == 9
+
+    def test_company_filter_misses_other_jobs(self, http_client_noauth):
+        from lib.provenance import record_run
+
+        record_run(
+            kind="resume", company="Hooli", role="PM", job_description="",
+            chunk_texts=[], claims=[], violations=[], verdict="passed",
+            revisions=0,
+        )
+        r = http_client_noauth.get(
+            "/dashboard/pipeline/provenance/latest", params={"company": "Initech"}
+        )
+        assert r.json() == {"found": False}

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -11,7 +11,7 @@ import json
 
 import pytest
 
-from lib.provenance import check_claims, extract_claims, record_run
+from lib.provenance import check_claims, extract_claims, latest_run, record_run
 
 
 # ===========================================================================
@@ -160,6 +160,48 @@ class TestRecordRun:
             chunk_texts=[], claims=[], violations=[], verdict="failed",
             revisions=0, db_path=tmp_path,
         )  # must not raise
+
+
+# ===========================================================================
+# latest_run — read side for the dashboard violations modal
+# ===========================================================================
+
+class TestLatestRun:
+    def _seed(self, db, **over):
+        base = dict(
+            kind="resume", company="Initech", role="SWE",
+            job_description="jd", chunk_texts=[], claims=["34%", "12%"],
+            violations=[], verdict="passed", revisions=0, db_path=db,
+        )
+        base.update(over)
+        record_run(**base)
+
+    def test_empty_db_returns_none(self, tmp_path):
+        db = tmp_path / "prov.db"
+        # create the schema without inserting
+        from lib.db import get_connection
+        with get_connection(path=db):
+            pass
+        assert latest_run(db_path=db) is None
+
+    def test_newest_row_wins_and_json_fields_decode(self, tmp_path):
+        db = tmp_path / "prov.db"
+        self._seed(db)
+        self._seed(db, violations=["47%", "$9M"], verdict="failed")
+        run = latest_run(db_path=db)
+        assert run["verdict"] == "failed"
+        assert run["violations"] == ["47%", "$9M"]
+        assert run["claims"] == ["34%", "12%"]
+        assert run["kind"] == "resume"
+
+    def test_company_role_filter_skips_other_jobs(self, tmp_path):
+        db = tmp_path / "prov.db"
+        self._seed(db, company="Initech", violations=["1%"], verdict="failed")
+        self._seed(db, company="Hooli", role="PM", verdict="passed")
+        run = latest_run(company="Initech", role="SWE", db_path=db)
+        assert run["company"] == "Initech"
+        assert run["violations"] == ["1%"]
+        assert latest_run(company="Nowhere", db_path=db) is None
 
 
 # ===========================================================================

--- a/transport/http/routes/dashboard/pipeline.py
+++ b/transport/http/routes/dashboard/pipeline.py
@@ -124,6 +124,19 @@ async def pipeline_data() -> JSONResponse:
     return JSONResponse(_pipeline_payload())
 
 
+@router.get("/pipeline/provenance/latest")
+async def pipeline_provenance_latest(company: str = "", role: str = "") -> JSONResponse:
+    """Full detail of the most recent truth-gate run — the generation
+    responses only carry the one-line verdict (capped at 6 violations), so
+    the violations modal reads the complete list from the audit row."""
+    from lib.provenance import latest_run
+
+    run = latest_run(company=company, role=role)
+    if run is None:
+        return JSONResponse({"found": False})
+    return JSONResponse({"found": True, **run})
+
+
 @router.post("/pipeline/evaluate", responses={404: {"description": "Job id not found"}})
 async def pipeline_evaluate(req: _JobActionRequest) -> JSONResponse:
     job = _find_job(req.job_id)


### PR DESCRIPTION
## Summary
One resume generation through Ollama produced 4 violations — and the UI showed a one-line verdict capped at 6 claims, none actionable. Now, when a generation fails the truth gate, a modal auto-opens with **every** violation listed:

- Each violation has a **Fix** button; **Fix all N** covers the batch. Both hand a structured instruction (`buildFixInstruction`, unit-tested) to the existing AI-edit flow — whose pipeline re-runs the gate, so the fix loop ends in a fresh verdict.
- The result banner gains **View violations** to reopen the modal any time.
- Data comes from the audit row the gate already persists: new `lib/provenance.latest_run()` + `GET /dashboard/pipeline/provenance/latest` (company/role-filtered so concurrent generations for other jobs can't cross-contaminate).

## Tests
- `latest_run`: empty DB, newest-row-wins + JSON decode, company/role filter
- Route: `found:false`, uncapped 8-violation list, company filter miss
- `buildFixInstruction`: vitest (empty, singular/plural, no cap, no-invention clause)
- Full backend suite: **1555 passed, 17 skipped**; frontend build + vitest green

🤖 Generated with [Claude Code](https://claude.com/claude-code)