### PR TITLE
feat(wallboard): flight-sim GPU on the kiosk — Windows-boot exporter

### DIFF
--- a/k8s/monitoring/pi/grafana-pi.yaml
+++ b/k8s/monitoring/pi/grafana-pi.yaml
@@ -106,7 +106,9 @@ data:
          "targets": [{"expr": "sum by(verdict)(provenance_runs_total{job=\"ollama-workstation\"})", "legendFormat": "{{verdict}}"}]},
         {"type": "timeseries", "title": "GPU utilization", "gridPos": {"x":0,"y":18,"w":8,"h":9},
          "datasource": {"uid":"prometheus"},
-         "targets": [{"expr": "max(gpu_utilization_percent{job=\"ollama-workstation\"})", "legendFormat": "GPU util"}],
+         "targets": [
+           {"expr": "max(gpu_utilization_percent{job=\"ollama-workstation\"})", "legendFormat": "workstation"},
+           {"expr": "max(gpu_utilization_percent{job=\"gpu-windows\"})", "legendFormat": "flight-sim rig"}],
          "fieldConfig": {"defaults": {"unit": "percent", "min": 0, "max": 100}}},
         {"type": "stat", "title": "Gate pass rate", "gridPos": {"x":16,"y":18,"w":4,"h":9},
          "datasource": {"uid":"prometheus"},
@@ -123,9 +125,10 @@ data:
         {"type": "timeseries", "title": "VRAM", "gridPos": {"x":8,"y":18,"w":8,"h":9},
          "datasource": {"uid":"prometheus"},
          "targets": [
-           {"expr": "max(gpu_memory_used_bytes{job=\"ollama-workstation\"})", "legendFormat": "used"},
-           {"expr": "max(gpu_memory_total_bytes{job=\"ollama-workstation\"})", "legendFormat": "total"},
-           {"expr": "sum(ollama_model_size_vram_bytes{job=\"ollama-workstation\"})", "legendFormat": "ollama model"}],
+           {"expr": "max(gpu_memory_used_bytes{job=\"ollama-workstation\"})", "legendFormat": "workstation used"},
+           {"expr": "max(gpu_memory_total_bytes{job=\"ollama-workstation\"})", "legendFormat": "workstation total"},
+           {"expr": "sum(ollama_model_size_vram_bytes{job=\"ollama-workstation\"})", "legendFormat": "ollama model"},
+           {"expr": "max(gpu_memory_used_bytes{job=\"gpu-windows\"})", "legendFormat": "flight-sim rig used"}],
          "fieldConfig": {"defaults": {"unit": "bytes"}}}
       ]
     }

--- a/k8s/monitoring/pi/prometheus-pi.yaml
+++ b/k8s/monitoring/pi/prometheus-pi.yaml
@@ -93,6 +93,16 @@ data:
       - job_name: ollama-workstation
         static_configs:
           - targets: ["192.168.101.1:9105"]
+      # Same physical box, other boot: the workstation dual-boots Windows
+      # for gaming, where scripts/gpu-exporter.ps1 serves the same GPU on
+      # :9106. Only one OS runs at a time, so exactly one of these two jobs
+      # is up at any moment — the kiosk GPU panels plot both series
+      # ("workstation" vs "flight-sim rig"). Target is the wired NIC's
+      # DHCP-by-MAC lease, identical under either OS; the direct-link IP
+      # (101.1) is Linux-only config, so it can't be used here.
+      - job_name: gpu-windows
+        static_configs:
+          - targets: ["192.168.68.50:9106"]
       - job_name: cadvisor
         kubernetes_sd_configs:
           - role: node

--- a/scripts/gpu-exporter.ps1
+++ b/scripts/gpu-exporter.ps1
@@ -1,0 +1,50 @@
+# gpu-exporter.ps1 — serve nvidia-smi as Prometheus metrics on :9106 (Windows).
+#
+# Counterpart of scripts/ollama-exporter.py for the gaming rig: the Pi
+# wallboard's Prometheus scrapes it as job `gpu-windows` so the kiosk's GPU
+# panels show this machine's load alongside the Linux workstation's.
+#
+# Raw TcpListener rather than HttpListener on purpose — HttpListener needs a
+# urlacl reservation for non-localhost prefixes; a hand-rolled HTTP/1.1
+# response needs nothing. Install (elevated PowerShell; writes this file to
+# C:\ProgramData\jobcontext\, adds a firewall allow on 9106, registers a
+# logon scheduled task): see the block in scripts/gpu-exporter-install.txt.
+
+$ErrorActionPreference = 'SilentlyContinue'
+$listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Any, 9106)
+$listener.Start()
+
+while ($true) {
+    $client = $listener.AcceptTcpClient()
+    try {
+        $stream = $client.GetStream()
+        $stream.ReadTimeout = 3000
+        $reader = New-Object System.IO.StreamReader($stream)
+        while (($line = $reader.ReadLine()) -and $line -ne '') { }  # drain request
+
+        $lines = @(
+            '# TYPE gpu_utilization_percent gauge'
+            '# TYPE gpu_memory_used_bytes gauge'
+            '# TYPE gpu_memory_total_bytes gauge'
+            '# TYPE gpu_temperature_celsius gauge'
+        )
+        $rows = & nvidia-smi --query-gpu=utilization.gpu,memory.used,memory.total,temperature.gpu --format=csv,noheader,nounits
+        $i = 0
+        foreach ($row in $rows) {
+            $f = $row -split ',' | ForEach-Object { $_.Trim() }
+            if ($f.Count -ge 4) {
+                $lines += "gpu_utilization_percent{gpu=`"$i`"} $($f[0])"
+                $lines += "gpu_memory_used_bytes{gpu=`"$i`"} $([long]$f[1] * 1048576)"
+                $lines += "gpu_memory_total_bytes{gpu=`"$i`"} $([long]$f[2] * 1048576)"
+                $lines += "gpu_temperature_celsius{gpu=`"$i`"} $($f[3])"
+            }
+            $i++
+        }
+        $body = [System.Text.Encoding]::UTF8.GetBytes(($lines -join "`n") + "`n")
+        $head = "HTTP/1.1 200 OK`r`nContent-Type: text/plain; version=0.0.4`r`nContent-Length: $($body.Length)`r`nConnection: close`r`n`r`n"
+        $headBytes = [System.Text.Encoding]::ASCII.GetBytes($head)
+        $stream.Write($headBytes, 0, $headBytes.Length)
+        $stream.Write($body, 0, $body.Length)
+        $stream.Flush()
+    } catch { } finally { $client.Close() }
+}


### PR DESCRIPTION
The workstation dual-boots Windows for flight simulator. New `scripts/gpu-exporter.ps1` (raw-TCP, :9106, logon task — already installed on the Windows boot) serves nvidia-smi; the Pi scrapes it as `gpu-windows` at the wired DHCP-by-MAC lease, which is identical under either OS. Since only one OS runs at a time, the kiosk GPU panels plot the two jobs as complementary series: **workstation** during work, **flight-sim rig** during play.

Deployed to the Pi and target registered; the gpu-windows series lights up on next Windows boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)