### PR TITLE
fix(evals): judge calibration — date context, full master, clean-bill filter

### DIFF
--- a/evals/judge.py
+++ b/evals/judge.py
@@ -11,6 +11,7 @@ provider resolved by ``lib.config.get_llm_client``.
 """
 from __future__ import annotations
 
+import datetime
 import json
 import re
 from dataclasses import dataclass, field
@@ -28,7 +29,10 @@ JUDGE_SYSTEM = (
     "Score honestly and critically."
 )
 
-JUDGE_USER_TEMPLATE = """JOB DESCRIPTION:
+JUDGE_USER_TEMPLATE = """TODAY'S DATE: {today}. Dates on or before today are NOT future-dated; \
+do not flag employment dates as hallucinations merely because they are recent.
+
+JOB DESCRIPTION:
 {job_description}
 
 MASTER RESUME EXCERPT:
@@ -37,7 +41,9 @@ MASTER RESUME EXCERPT:
 GENERATED OUTPUT:
 {generated_output}
 
-Score the output on each dimension 1-5. Return ONLY a JSON object, no other text:
+Score the output on each dimension 1-5. The "hallucinations" list must contain \
+ONLY claims from the output that cannot be traced to the master resume excerpt — \
+if there are none, return an empty list []. Return ONLY a JSON object, no other text:
 {{"keyword_coverage": N, "relevance": N, "accuracy": N, "impact_language": N,
  "ats_readiness": N, "rationale": "...", "hallucinations": ["..."],
  "verdict": "pass" or "fail"}}"""
@@ -66,16 +72,28 @@ class JudgeScore:
 
 
 def build_judge_messages(
-    job_description: str, master_resume_excerpt: str, generated_output: str
+    job_description: str,
+    master_resume_excerpt: str,
+    generated_output: str,
+    today: str = "",
 ) -> list[dict]:
+    if not today:
+        today = datetime.date.today().isoformat()
     return [
         {"role": "system", "content": JUDGE_SYSTEM},
         {"role": "user", "content": JUDGE_USER_TEMPLATE.format(
+            today=today,
             job_description=job_description,
             master_resume_excerpt=master_resume_excerpt,
             generated_output=generated_output,
         )},
     ]
+
+
+# Judges sometimes put a clean-bill NOTE into the hallucinations array
+# ("No hallucinations detected...") — counting those as hallucinations
+# inflated the rate to 60% on an entry with zero real findings.
+_CLEAN_BILL = re.compile(r"(?i)\bno hallucinations?\b|^none\b\.?$")
 
 
 def parse_judge_json(text: str) -> JudgeScore:
@@ -107,6 +125,7 @@ def parse_judge_json(text: str) -> JudgeScore:
     hallucinations = obj.get("hallucinations") or []
     if not isinstance(hallucinations, list):
         hallucinations = [str(hallucinations)]
+    hallucinations = [str(h) for h in hallucinations if not _CLEAN_BILL.search(str(h))]
     return JudgeScore(
         scores=scores,
         rationale=str(obj.get("rationale", "")),

--- a/evals/runner.py
+++ b/evals/runner.py
@@ -115,7 +115,10 @@ def default_generate(entry: GoldenEntry, jd_text: str) -> str:
     return (out_dir / f"{output_filename}.txt").read_text(encoding="utf-8")
 
 
-def _master_excerpt(max_chars: int = 6000) -> str:
+# qwen3-jobcontext runs a 40K-token context; the full ~30K-char master fits.
+# Truncating to 6K made 80% of the master invisible and the judge flagged
+# real (unseen) claims as hallucinations.
+def _master_excerpt(max_chars: int = 32000) -> str:
     from tools import resume  # noqa: PLC0415 — lazy: imports server config
 
     return resume.read_master_resume()[:max_chars]

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -165,6 +165,25 @@ def test_parse_judge_json_tolerates_think_blocks_and_fences():
     assert judge_mod.parse_judge_json(noisy).verdict == "pass"
 
 
+def test_judge_messages_include_todays_date():
+    msgs = judge_mod.build_judge_messages("JD", "M", "OUT", today="2026-07-29")
+    assert "TODAY'S DATE: 2026-07-29" in msgs[1]["content"]
+    # default fills in a real ISO date rather than leaving the slot empty
+    auto = judge_mod.build_judge_messages("JD", "M", "OUT")[1]["content"]
+    assert "TODAY'S DATE: 20" in auto
+
+
+def test_parse_judge_json_filters_clean_bill_notes():
+    payload = json.loads(_GOOD_JUDGE_JSON)
+    payload["hallucinations"] = [
+        "No hallucinations detected; claims are traceable.",
+        "None.",
+        "Invented award claim",
+    ]
+    score = judge_mod.parse_judge_json(json.dumps(payload))
+    assert score.hallucinations == ["Invented award claim"]
+
+
 def test_parse_judge_json_rejects_bad_output():
     with pytest.raises(ValueError):
         judge_mod.parse_judge_json("no json here")


### PR DESCRIPTION
The first n=5 variance run flagged hallucinations on all five golden entries — and on inspection, most were judge-harness artifacts, not generation defects:

1. **No date context**: real 2026 employment dates flagged as "future-dated" (one run assumed it was 2023). Prompt now states today's date.
2. **Master truncated at 6K of ~30K chars**: real claims past the cut looked untraceable. Cap now 32K (fits the 40K-token judge context).
3. **Clean-bill notes counted as hallucinations**: "No hallucinations detected" inside the hallucinations array inflated one entry to 60% with zero real findings. Filtered, and the prompt demands `[]` when clean.

39 eval tests green. Re-running the n=5 suite with the calibrated judge to establish the real variance baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)