### PR TITLE
fix(telemetry): instrument the chat agent loop's LLM calls

### DIFF
--- a/lib/metrics.py
+++ b/lib/metrics.py
@@ -11,7 +11,9 @@ What gets instrumented where:
                       http_requests_total / http_request_seconds{method,route,status}
   - Work items      → lib/work.py dispatcher
                       work_items_total / work_item_seconds{kind,status}
-  - LLM calls       → lib/openai_calls.create_chat_completion
+  - LLM calls       → lib/openai_calls.create_chat_completion, plus
+                      services/chat_service.py (chat bypasses the helper's
+                      rate gate and emits the same series with label="chat")
                       llm_calls_total{label,model,outcome}
                       llm_call_seconds{label,model}
                       llm_tokens_total{label,model,direction}

--- a/services/chat_service.py
+++ b/services/chat_service.py
@@ -23,11 +23,13 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from dataclasses import dataclass, field
 from typing import Any, AsyncGenerator
 
 import anyio
 
+from lib import metrics
 from lib.db import get_connection
 
 _log = logging.getLogger(__name__)
@@ -268,6 +270,56 @@ async def _execute_tool(mcp, name: str, arguments_json: str) -> str:
     return text
 
 
+# ── telemetry ──────────────────────────────────────────────────────────────────
+# Chat calls the provider directly instead of lib.openai_calls.create_chat_completion:
+# that helper's process-wide 12s rate-spacing gate would stall every tool hop of an
+# interactive conversation. The cost is that chat must emit the same llm_* series
+# itself — label values and outcome formats below must stay in lockstep with
+# lib/openai_calls.py so the Grafana LLM panels aggregate both paths.
+
+_METRICS_LABEL = "chat"
+
+
+def _estimate_tokens(text: str) -> int:
+    # ~4 chars/token: rough, but keeps the tokens panel non-empty for
+    # providers that omit usage.
+    return len(text) // 4 if text else 0
+
+
+def _record_llm_error(model: str, exc: Exception) -> None:
+    status_code = getattr(getattr(exc, "response", None), "status_code", None)
+    metrics.inc(
+        "llm_calls_total",
+        label=_METRICS_LABEL,
+        model=str(model),
+        outcome=f"error_{status_code or 'network'}",
+    )
+
+
+def _record_llm_success(model: str, started: float, response: Any, messages: list[dict]) -> None:
+    model = str(model)
+    metrics.inc("llm_calls_total", label=_METRICS_LABEL, model=model, outcome="ok")
+    metrics.observe(
+        "llm_call_seconds", time.monotonic() - started, label=_METRICS_LABEL, model=model)
+    usage = getattr(response, "usage", None)
+    prompt_tokens = getattr(usage, "prompt_tokens", None) if usage else None
+    completion_tokens = getattr(usage, "completion_tokens", None) if usage else None
+    if prompt_tokens is None:
+        prompt_tokens = _estimate_tokens(
+            "".join(str(m.get("content") or "") for m in messages))
+    if completion_tokens is None:
+        reply = response.choices[0].message
+        parts = [reply.content or ""]
+        parts.extend(tc.function.arguments or "" for tc in reply.tool_calls or ())
+        completion_tokens = _estimate_tokens("".join(parts))
+    if prompt_tokens:
+        metrics.inc("llm_tokens_total", float(prompt_tokens),
+                    label=_METRICS_LABEL, model=model, direction="prompt")
+    if completion_tokens:
+        metrics.inc("llm_tokens_total", float(completion_tokens),
+                    label=_METRICS_LABEL, model=model, direction="completion")
+
+
 # ── the agent loop ─────────────────────────────────────────────────────────────
 
 def _build_system_prompt() -> str:
@@ -315,6 +367,7 @@ async def run_chat_turn(
     _save_message(session_id, "user", user_message)
 
     for _hop in range(MAX_TOOL_HOPS):
+        started = time.monotonic()
         try:
             response = await anyio.to_thread.run_sync(
                 lambda: client.chat.completions.create(
@@ -322,10 +375,12 @@ async def run_chat_turn(
                 )
             )
         except Exception as exc:  # noqa: BLE001 — surface provider errors to the UI
+            _record_llm_error(model, exc)
             _log.warning("chat completion failed: %s", exc)
             yield ChatEvent("error", {"message": f"AI provider error: {exc}", "code": "provider"})
             return
 
+        _record_llm_success(model, started, response, messages)
         reply = response.choices[0].message
 
         if not reply.tool_calls:

--- a/tests/test_chat_service.py
+++ b/tests/test_chat_service.py
@@ -24,9 +24,17 @@ def _tool_call(call_id: str, name: str, arguments: dict) -> SimpleNamespace:
     )
 
 
-def _response(content: str | None = None, tool_calls=None) -> SimpleNamespace:
+def _response(
+    content: str | None = None, tool_calls=None, usage: dict | None = None
+) -> SimpleNamespace:
     message = SimpleNamespace(content=content, tool_calls=tool_calls or None)
-    return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+    response = SimpleNamespace(choices=[SimpleNamespace(message=message)])
+    if usage is not None:
+        response.usage = SimpleNamespace(
+            prompt_tokens=usage.get("prompt_tokens"),
+            completion_tokens=usage.get("completion_tokens"),
+        )
+    return response
 
 
 class FakeClient:
@@ -183,6 +191,117 @@ def test_provider_exception_surfaces_as_error(mcp_instance):
     events = _run_turn(mcp_instance, sid, "hi", ExplodingClient([]))
     assert events[-1].type == "error"
     assert events[-1].data["code"] == "provider"
+
+
+# ── telemetry ──────────────────────────────────────────────────────────────────
+# Chat bypasses lib.openai_calls (its 12s rate gate would stall tool hops), so
+# it must emit the llm_* series itself with the same label shapes.
+
+@pytest.fixture()
+def clean_metrics():
+    from lib import metrics
+    metrics.reset()
+    yield metrics
+    metrics.reset()
+
+
+def _series(snap: dict, kind: str, name: str, **labels):
+    """Value of the first counter/summary matching name + label subset."""
+    for entry in snap[kind]:
+        if entry["name"] == name and all(
+            entry["labels"].get(k) == v for k, v in labels.items()
+        ):
+            return entry
+    return None
+
+
+def test_chat_turn_records_llm_metrics_from_usage(mcp_instance, clean_metrics):
+    sid = chat_service.create_session()
+    client = FakeClient([
+        _response(content="Hi Frank!", usage={"prompt_tokens": 100, "completion_tokens": 20}),
+    ])
+
+    _run_turn(mcp_instance, sid, "hello", client)
+
+    snap = clean_metrics.snapshot()
+    calls = _series(snap, "counters", "llm_calls_total",
+                    label="chat", model="fake", outcome="ok")
+    assert calls["value"] == 1
+    seconds = _series(snap, "summaries", "llm_call_seconds", label="chat", model="fake")
+    assert seconds["count"] == 1
+    prompt = _series(snap, "counters", "llm_tokens_total",
+                     label="chat", model="fake", direction="prompt")
+    completion = _series(snap, "counters", "llm_tokens_total",
+                         label="chat", model="fake", direction="completion")
+    assert prompt["value"] == 100
+    assert completion["value"] == 20
+
+
+def test_chat_metrics_estimate_tokens_when_usage_missing(mcp_instance, clean_metrics):
+    sid = chat_service.create_session()
+    client = FakeClient([_response(content="A reply long enough to estimate.")])
+
+    _run_turn(mcp_instance, sid, "hello there, estimate me", client)
+
+    snap = clean_metrics.snapshot()
+    prompt = _series(snap, "counters", "llm_tokens_total",
+                     label="chat", model="fake", direction="prompt")
+    completion = _series(snap, "counters", "llm_tokens_total",
+                         label="chat", model="fake", direction="completion")
+    # Estimated (chars/4), so exact values are not pinned — just non-empty.
+    assert prompt["value"] > 0
+    assert completion["value"] > 0
+
+
+def test_chat_tool_hops_count_each_completion(mcp_instance, clean_metrics):
+    sid = chat_service.create_session()
+    client = FakeClient([
+        _response(tool_calls=[_tool_call("c1", "applications", {"action": "status"})]),
+        _response(content="Done."),
+    ])
+
+    _run_turn(mcp_instance, sid, "how's my pipeline?", client)
+
+    snap = clean_metrics.snapshot()
+    calls = _series(snap, "counters", "llm_calls_total",
+                    label="chat", model="fake", outcome="ok")
+    assert calls["value"] == 2
+    seconds = _series(snap, "summaries", "llm_call_seconds", label="chat", model="fake")
+    assert seconds["count"] == 2
+
+
+def test_chat_provider_error_records_error_outcome(mcp_instance, clean_metrics):
+    sid = chat_service.create_session()
+
+    class ExplodingClient(FakeClient):
+        def _create(self, **_kwargs):
+            exc = RuntimeError("rate limited")
+            exc.response = SimpleNamespace(status_code=429)
+            raise exc
+
+    _run_turn(mcp_instance, sid, "hi", ExplodingClient([]))
+
+    snap = clean_metrics.snapshot()
+    calls = _series(snap, "counters", "llm_calls_total",
+                    label="chat", model="fake", outcome="error_429")
+    assert calls["value"] == 1
+    # No success series and no duration for a failed call.
+    assert _series(snap, "counters", "llm_calls_total", outcome="ok") is None
+    assert _series(snap, "summaries", "llm_call_seconds", label="chat") is None
+
+
+def test_chat_error_without_status_is_network(mcp_instance, clean_metrics):
+    sid = chat_service.create_session()
+
+    class ExplodingClient(FakeClient):
+        def _create(self, **_kwargs):
+            raise RuntimeError("boom")
+
+    _run_turn(mcp_instance, sid, "hi", ExplodingClient([]))
+
+    calls = _series(clean_metrics.snapshot(), "counters", "llm_calls_total",
+                    label="chat", model="fake", outcome="error_network")
+    assert calls["value"] == 1
 
 
 def test_history_replays_into_next_turn(mcp_instance):


### PR DESCRIPTION
## Problem

`services/chat_service.py` calls `client.chat.completions.create` directly, bypassing `lib.openai_calls.create_chat_completion` — deliberately, since that helper's process-wide 12s rate-spacing gate would stall every tool hop of an interactive conversation. Side effect: chat emitted **no** `llm_calls_total` / `llm_call_seconds` / `llm_tokens_total` series, so the desktop wallboard's LLM panels (kiosk-ollama dashboard) sat empty whenever chat was the only LLM traffic.

## Fix

The agent loop now records the same series itself, around each completion call (one per tool hop):

- `llm_calls_total{label="chat",model,outcome}` — `outcome="ok"` on success, `error_{status|network}` on provider exceptions, matching `lib/openai_calls.py`'s format exactly so both paths aggregate in Grafana
- `llm_call_seconds{label="chat",model}` — success-only, same as the helper
- `llm_tokens_total{label="chat",model,direction=prompt|completion}` — from `response.usage` (the chat call is non-streaming, so usage is on the response); a chars/4 estimate keeps the tokens panel non-empty for providers that omit usage

A comment block in `chat_service.py` documents the bypass rationale and the lockstep requirement; `lib/metrics.py`'s instrumentation map is updated to list both emitters.

## Tests

Five new tests in `tests/test_chat_service.py` (usage-driven counts, estimate fallback, per-hop call counting, `error_429` and `error_network` outcomes, no success/duration series on failure). Full suite: 1606 passed, 17 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)