### PR TITLE
fix(dashboard): Windows-safe date in the Home daily digest

### DIFF
--- a/tests/test_dashboard_coverage.py
+++ b/tests/test_dashboard_coverage.py
@@ -540,6 +540,20 @@ class TestDashboardHomeApiCoverage:
         assert body["oura"] is None
         assert body["digest"]["items"]
 
+    def test_digest_date_line_is_windows_safe(self):
+        """'%-d' is glibc-only — strftime raises ValueError on Windows, which
+        500'd /api/dashboard/home for every Windows desktop user without a
+        ring (the digest builds unconditionally). The day must come from
+        today.day, and glibc-only '%-' flags must stay out of the module."""
+        import inspect
+        import re
+
+        digest = dashboard_api_routes._digest_payload(dict(self._SNAP))
+        today = dt.date.today()
+        assert digest["date"] == f"{today.strftime('%A, %B')} {today.day} · Morning briefing"
+        # Guard for Linux CI, where '%-d' silently works.
+        assert not re.search(r"strftime\([^)]*%-", inspect.getsource(dashboard_api_routes))
+
     def test_api_home_requires_auth(self, monkeypatch, isolated_server):
         """With auth enabled, an anonymous fetch is rejected (not a redirect)."""
         from fastapi.testclient import TestClient

--- a/transport/http/routes/dashboard/api.py
+++ b/transport/http/routes/dashboard/api.py
@@ -176,7 +176,8 @@ def _interview_today() -> "str | None":
 def _digest_payload(snap: dict) -> dict:
     """Build the daily-digest items shown when no Oura ring is connected."""
     today = datetime.date.today()
-    date_line = f"{today.strftime('%A, %B %-d')} \u00b7 Morning briefing"
+    # today.day instead of '%-d', which is Linux-only and raises on Windows.
+    date_line = f"{today.strftime('%A, %B')} {today.day} \u00b7 Morning briefing"
 
     # Stale = active, not waiting on them, untouched 14+ days.
     try:


### PR DESCRIPTION
## What

`GET /api/dashboard/home` 500s on Windows: `_digest_payload` builds its date line with `strftime('%A, %B %-d')`, and the no-padding `-` flag is glibc-only — Windows CPython raises `ValueError: Invalid format string`. The digest builds unconditionally, so every Windows desktop user without an Oura ring gets a 500, and the React Home screen silently falls back to its zeroed mock.

## Symptom

Home shows **0 active apps / 0 in-flight / 0 overdue** and "No Oura ring connected" on a fully synced Windows desktop — it presents exactly like a sync failure (which is how it was reported), but sync is healthy: the workspace data and 20 days of synced `oura_readiness` rows are all present locally. `_oura_via_sync()` would surface the readiness gauge too, if the endpoint survived long enough to reach it.

Not a beta27 regression — the module is identical in beta26. The new beta27 sidebar sync card just drew attention to the screen.

## Fix

Build the day from `today.day` instead — the same approach `tools/latex_export.py:362` already documents for exactly this pitfall.

## Test

- Renders the digest and asserts the exact date line (fails natively on Windows pre-fix).
- Greps the module source for glibc-only `%-` strftime flags, so Linux CI — where `%-d` silently works — also catches a reintroduction.

Verified on the affected machine: 122/122 in `tests/test_dashboard_coverage.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
