### PR TITLE
fix(certification): accept dict fields from MCP clients + enrichment failure logging

### DIFF
--- a/tests/test_certification.py
+++ b/tests/test_certification.py
@@ -442,6 +442,24 @@ class TestFacadeDispatch:
         )
         assert out.startswith("✓")
 
+    def test_override_fields_dict_through_facade(self, workspace):
+        # claude.ai / Claude Code harnesses auto-parse JSON-string args into
+        # objects — the facade schema must accept the dict form too.
+        from tools import consolidated
+        out = consolidated.certification(
+            action="employer_override", name="DictCo",
+            fields={"street": "1 Main St", "city": "Atlanta",
+                    "state": "GA", "zip": "30303"},
+        )
+        assert out.startswith("✓")
+
+    def test_override_fields_double_encoded_string(self, workspace):
+        payload = json.dumps(json.dumps({
+            "street": "1 Main St", "city": "Atlanta",
+            "state": "GA", "zip": "30303",
+        }))
+        assert cert.override_employer("DoubleCo", payload).startswith("✓")
+
     def test_activity_kinds_csv_becomes_list_not_characters(self, workspace):
         from tools import consolidated
         out = consolidated.certification(

--- a/tools/certification.py
+++ b/tools/certification.py
@@ -29,12 +29,15 @@ import datetime
 import hashlib
 import io
 import json
+import logging
 import re
 from typing import Literal
 
 from lib import config
 from lib.db import get_connection
 from lib.io import _load_json, _now, _save_json
+
+_log = logging.getLogger(__name__)
 
 # ── State profile ─────────────────────────────────────────────────────────────
 
@@ -566,7 +569,8 @@ def _web_search_address(company: str) -> "tuple[dict, str] | None":
         )
         resp.raise_for_status()
         payload = resp.json()
-    except Exception:  # noqa: BLE001 — enrichment is best-effort
+    except Exception as exc:  # noqa: BLE001 — enrichment is best-effort
+        _log.warning("serpapi search failed for %r: %s", company, exc)
         return None
     blobs: list[tuple[str, str]] = []
     kg = payload.get("knowledge_graph", {}) or {}
@@ -578,6 +582,8 @@ def _web_search_address(company: str) -> "tuple[dict, str] | None":
         match = _ADDRESS_RE.search(text)
         if match:
             return dict(match.groupdict()), source
+    _log.info("serpapi returned %d results for %r, none with a parseable address",
+              len(blobs), company)
     return None
 
 
@@ -595,7 +601,8 @@ def _ddg_search_address(company: str) -> "tuple[dict, str] | None":
            + quote_plus(f"{company} corporate office business address"))
     try:
         text = _fetch_page(url)
-    except Exception:  # noqa: BLE001 — enrichment is best-effort
+    except Exception as exc:  # noqa: BLE001 — enrichment is best-effort
+        _log.warning("ddg fallback fetch failed for %r: %s", company, exc)
         return None
     tokens = re.findall(r"[a-z0-9]+", company.lower())
     needle = next((t for t in tokens if len(t) >= 3), "")
@@ -607,6 +614,8 @@ def _ddg_search_address(company: str) -> "tuple[dict, str] | None":
         )
         if needle in window:
             return dict(match.groupdict()), url
+    _log.info("ddg fetched %d chars for %r, no company-adjacent address matched",
+              len(text), company)
     return None
 
 
@@ -659,7 +668,8 @@ def _scrape_address(website: str, company: str) -> "tuple[dict, str] | None":
         url = f"{base}{path}"
         try:
             text = _fetch_page(url)
-        except Exception:  # noqa: BLE001 — try the next page
+        except Exception as exc:  # noqa: BLE001 — try the next page
+            _log.warning("scrape fetch failed for %s: %s", url, exc)
             continue
         match = _ADDRESS_RE.search(text)
         if match:
@@ -667,6 +677,7 @@ def _scrape_address(website: str, company: str) -> "tuple[dict, str] | None":
         extracted = _llm_extract_address(text, company)
         if extracted:
             return extracted, url
+        _log.info("scraped %s (%d chars), no address matched", url, len(text))
     return None
 
 
@@ -766,7 +777,11 @@ def override_employer(name: str, fields: dict | str | None = None) -> str:
     enrichment pipeline will never overwrite it again."""
     if not str(name or "").strip():
         return "✗ employer name is required."
-    if isinstance(fields, str) and fields.strip():
+    # Up to two decode passes: MCP clients variously send the object itself,
+    # a JSON string, or a double-encoded JSON string (client re-serialized).
+    for _ in range(2):
+        if not (isinstance(fields, str) and fields.strip()):
+            break
         try:
             fields = json.loads(fields)
         except ValueError:

--- a/tools/consolidated.py
+++ b/tools/consolidated.py
@@ -577,7 +577,10 @@ def certification(
     out_entry: int | None = None,
     in_entry: str | None = None,
     name: str | None = None,
-    fields: str | None = None,
+    # str | dict, not just str: several MCP clients (claude.ai, Claude Code)
+    # auto-parse JSON-looking argument strings into objects before sending —
+    # a string-only schema hard-rejects those calls at validation.
+    fields: str | dict | None = None,
     mode: str | None = None,
     state: str | None = None,
     min_activities_per_week: int | None = None,


### PR DESCRIPTION
Follow-up to #172/#173, from live testing against prod.

## fields: str | dict — the revert was wrong
#172's review reverted the original patch's `fields: str | dict` facade line as schema pollution. Live testing proved the union is load-bearing: claude.ai and Claude Code harnesses auto-parse JSON-looking argument strings into objects before sending, so the string-only schema rejects every override from those clients at pydantic validation (`Input should be a valid string … input_type=dict`). Restored with a comment carrying the why. `override_employer` additionally tolerates double-encoded JSON strings (client re-serialization).

## Enrichment failure logging
All three network paths (`_web_search_address`, `_scrape_address` fetches, `_ddg_search_address`) swallowed failures as bare `return None` — AKS egress problems, Jina rate limits, and genuine no-match were indistinguishable. Now: WARNING on fetch/search failure with target + exception, INFO on fetched-but-no-address-matched. Diagnosis note: the jcmcp namespace has **no NetworkPolicy**, so if pod logs show fetch failures it's Jina rate-limiting / DDG datacenter-IP blocking, not cluster policy.

## Tests
Facade dispatch with dict `fields` (the auto-parsing-client shape) and double-encoded string round-trip. 73 pass on the touched suites, both with and without `LLM_PROVIDER=foundry`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)