### PR TITLE
Promote qa to main: dropdown visibility + enrichment observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/version-1.4.0-blue" alt="Version 1.4.0"/>
-  <img src="https://img.shields.io/badge/tests-1645%20passing-brightgreen" alt="1645 tests passing"/>
+  <img src="https://img.shields.io/badge/tests-1647%20passing-brightgreen" alt="1647 tests passing"/>
   <a href="https://sonarcloud.io/component_measures?id=JustLikeFrank3_jobContextMCP&metric=coverage"><img src="https://sonarcloud.io/api/project_badges/measure?project=JustLikeFrank3_jobContextMCP&metric=coverage" alt="Coverage"/></a>
   <img src="https://img.shields.io/badge/tools-12%20domains%20%C2%B7%2095%20actions-informational" alt="12 domain tools, 95 actions"/>
   <img src="https://img.shields.io/badge/license-MIT-lightgrey" alt="MIT License"/>
@@ -39,7 +39,7 @@ jobContext keeps your job-search context structured and persistent, and exposes 
 | | |
 |---|---|
 | 12 MCP tools | 95 domain actions behind them |
-| 1645 passing tests | Resume + cover letter generation with a deterministic truth gate |
+| 1647 passing tests | Resume + cover letter generation with a deterministic truth gate |
 | SQLite persistence + JSON audit trail | Job fitment analysis with persona lenses |
 | Local RAG semantic search | Interview prep + debrief logging |
 | Desktop app (macOS · Windows · Linux) | Outreach + relationship tracking |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/version-1.4.0-blue" alt="Version 1.4.0"/>
-  <img src="https://img.shields.io/badge/tests-1634%20passing-brightgreen" alt="1634 tests passing"/>
+  <img src="https://img.shields.io/badge/tests-1645%20passing-brightgreen" alt="1645 tests passing"/>
   <a href="https://sonarcloud.io/component_measures?id=JustLikeFrank3_jobContextMCP&metric=coverage"><img src="https://sonarcloud.io/api/project_badges/measure?project=JustLikeFrank3_jobContextMCP&metric=coverage" alt="Coverage"/></a>
   <img src="https://img.shields.io/badge/tools-12%20domains%20%C2%B7%2095%20actions-informational" alt="12 domain tools, 95 actions"/>
   <img src="https://img.shields.io/badge/license-MIT-lightgrey" alt="MIT License"/>
@@ -39,7 +39,7 @@ jobContext keeps your job-search context structured and persistent, and exposes 
 | | |
 |---|---|
 | 12 MCP tools | 95 domain actions behind them |
-| 1634 passing tests | Resume + cover letter generation with a deterministic truth gate |
+| 1645 passing tests | Resume + cover letter generation with a deterministic truth gate |
 | SQLite persistence + JSON audit trail | Job fitment analysis with persona lenses |
 | Local RAG semantic search | Interview prep + debrief logging |
 | Desktop app (macOS · Windows · Linux) | Outreach + relationship tracking |

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -18,6 +18,16 @@
   --text-strong: #ffffff;
   --muted: #9aa8bf;
   --font-display: 'Space Grotesk', ui-sans-serif, system-ui, sans-serif;
+  /* Native form-control popups (select option lists) are painted by the OS
+     in light mode unless told otherwise — light text becomes invisible. */
+  color-scheme: dark;
+}
+
+/* Fallback for engines that ignore color-scheme for popup surfaces: the
+   option list inherits the select's translucent background over white. */
+select option {
+  background-color: var(--surface, var(--ink-900));
+  color: var(--text, var(--text-strong));
 }
 
 html,

--- a/templates/latex_assets/sections/experience.tex
+++ b/templates/latex_assets/sections/experience.tex
@@ -5,7 +5,7 @@
 \subsection{{\textbf{Senior Software Engineer} \textit{\ \ Contoso Cloud, Remote} \hfill 20XX --- Present}}
 \begin{zitemize}
 \item Led design and delivery of a customer-facing service from architecture through production and on-call; quantify the impact here (latency, scale, revenue, or adoption).
-\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1645 passing tests at 80\%+ line coverage through disciplined TDD.
+\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1647 passing tests at 80\%+ line coverage through disciplined TDD.
 \item Drove a cross-team win — a migration, a shared API pattern others adopted, or an SLA target consistently met.
 \end{zitemize}
 %====================

--- a/templates/latex_assets/sections/experience.tex
+++ b/templates/latex_assets/sections/experience.tex
@@ -5,7 +5,7 @@
 \subsection{{\textbf{Senior Software Engineer} \textit{\ \ Contoso Cloud, Remote} \hfill 20XX --- Present}}
 \begin{zitemize}
 \item Led design and delivery of a customer-facing service from architecture through production and on-call; quantify the impact here (latency, scale, revenue, or adoption).
-\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1634 passing tests at 80\%+ line coverage through disciplined TDD.
+\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1645 passing tests at 80\%+ line coverage through disciplined TDD.
 \item Drove a cross-team win — a migration, a shared API pattern others adopted, or an SLA target consistently met.
 \end{zitemize}
 %====================

--- a/tests/test_certification.py
+++ b/tests/test_certification.py
@@ -442,6 +442,24 @@ class TestFacadeDispatch:
         )
         assert out.startswith("✓")
 
+    def test_override_fields_dict_through_facade(self, workspace):
+        # claude.ai / Claude Code harnesses auto-parse JSON-string args into
+        # objects — the facade schema must accept the dict form too.
+        from tools import consolidated
+        out = consolidated.certification(
+            action="employer_override", name="DictCo",
+            fields={"street": "1 Main St", "city": "Atlanta",
+                    "state": "GA", "zip": "30303"},
+        )
+        assert out.startswith("✓")
+
+    def test_override_fields_double_encoded_string(self, workspace):
+        payload = json.dumps(json.dumps({
+            "street": "1 Main St", "city": "Atlanta",
+            "state": "GA", "zip": "30303",
+        }))
+        assert cert.override_employer("DoubleCo", payload).startswith("✓")
+
     def test_activity_kinds_csv_becomes_list_not_characters(self, workspace):
         from tools import consolidated
         out = consolidated.certification(

--- a/tools/certification.py
+++ b/tools/certification.py
@@ -29,12 +29,15 @@ import datetime
 import hashlib
 import io
 import json
+import logging
 import re
 from typing import Literal
 
 from lib import config
 from lib.db import get_connection
 from lib.io import _load_json, _now, _save_json
+
+_log = logging.getLogger(__name__)
 
 # ── State profile ─────────────────────────────────────────────────────────────
 
@@ -566,7 +569,8 @@ def _web_search_address(company: str) -> "tuple[dict, str] | None":
         )
         resp.raise_for_status()
         payload = resp.json()
-    except Exception:  # noqa: BLE001 — enrichment is best-effort
+    except Exception as exc:  # noqa: BLE001 — enrichment is best-effort
+        _log.warning("serpapi search failed for %r: %s", company, exc)
         return None
     blobs: list[tuple[str, str]] = []
     kg = payload.get("knowledge_graph", {}) or {}
@@ -578,6 +582,8 @@ def _web_search_address(company: str) -> "tuple[dict, str] | None":
         match = _ADDRESS_RE.search(text)
         if match:
             return dict(match.groupdict()), source
+    _log.info("serpapi returned %d results for %r, none with a parseable address",
+              len(blobs), company)
     return None
 
 
@@ -595,7 +601,8 @@ def _ddg_search_address(company: str) -> "tuple[dict, str] | None":
            + quote_plus(f"{company} corporate office business address"))
     try:
         text = _fetch_page(url)
-    except Exception:  # noqa: BLE001 — enrichment is best-effort
+    except Exception as exc:  # noqa: BLE001 — enrichment is best-effort
+        _log.warning("ddg fallback fetch failed for %r: %s", company, exc)
         return None
     tokens = re.findall(r"[a-z0-9]+", company.lower())
     needle = next((t for t in tokens if len(t) >= 3), "")
@@ -607,6 +614,8 @@ def _ddg_search_address(company: str) -> "tuple[dict, str] | None":
         )
         if needle in window:
             return dict(match.groupdict()), url
+    _log.info("ddg fetched %d chars for %r, no company-adjacent address matched",
+              len(text), company)
     return None
 
 
@@ -659,7 +668,8 @@ def _scrape_address(website: str, company: str) -> "tuple[dict, str] | None":
         url = f"{base}{path}"
         try:
             text = _fetch_page(url)
-        except Exception:  # noqa: BLE001 — try the next page
+        except Exception as exc:  # noqa: BLE001 — try the next page
+            _log.warning("scrape fetch failed for %s: %s", url, exc)
             continue
         match = _ADDRESS_RE.search(text)
         if match:
@@ -667,6 +677,7 @@ def _scrape_address(website: str, company: str) -> "tuple[dict, str] | None":
         extracted = _llm_extract_address(text, company)
         if extracted:
             return extracted, url
+        _log.info("scraped %s (%d chars), no address matched", url, len(text))
     return None
 
 
@@ -766,7 +777,11 @@ def override_employer(name: str, fields: dict | str | None = None) -> str:
     enrichment pipeline will never overwrite it again."""
     if not str(name or "").strip():
         return "✗ employer name is required."
-    if isinstance(fields, str) and fields.strip():
+    # Up to two decode passes: MCP clients variously send the object itself,
+    # a JSON string, or a double-encoded JSON string (client re-serialized).
+    for _ in range(2):
+        if not (isinstance(fields, str) and fields.strip()):
+            break
         try:
             fields = json.loads(fields)
         except ValueError:

--- a/tools/consolidated.py
+++ b/tools/consolidated.py
@@ -577,7 +577,10 @@ def certification(
     out_entry: int | None = None,
     in_entry: str | None = None,
     name: str | None = None,
-    fields: str | None = None,
+    # str | dict, not just str: several MCP clients (claude.ai, Claude Code)
+    # auto-parse JSON-looking argument strings into objects before sending —
+    # a string-only schema hard-rejects those calls at validation.
+    fields: str | dict | None = None,
     mode: str | None = None,
     state: str | None = None,
     min_activities_per_week: int | None = None,


### PR DESCRIPTION
Promotes #174 (dark-mode select dropdowns rendered invisible options) and #175 (accept dict fields from MCP clients + enrichment failure logging) to main. qa deploy green on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)