### PR TITLE
fix(certification): never log the SerpAPI key

### DIFF
--- a/tools/certification.py
+++ b/tools/certification.py
@@ -570,7 +570,9 @@ def _web_search_address(company: str) -> "tuple[dict, str] | None":
         resp.raise_for_status()
         payload = resp.json()
     except Exception as exc:  # noqa: BLE001 — enrichment is best-effort
-        _log.warning("serpapi search failed for %r: %s", company, exc)
+        # httpx exception text embeds the full request URL — api_key included.
+        _log.warning("serpapi search failed for %r: %s", company,
+                     re.sub(r"api_key=[^&'\s]+", "api_key=***", str(exc)))
         return None
     blobs: list[tuple[str, str]] = []
     kg = payload.get("knowledge_graph", {}) or {}

--- a/transport/http/main.py
+++ b/transport/http/main.py
@@ -20,6 +20,9 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s %(levelname)-7s %(name)s: %(message)s",
 )
+# httpx logs every request line at INFO with the full URL — for SerpAPI that
+# is the api_key in a query param. Errors still surface via callers' logs.
+logging.getLogger("httpx").setLevel(logging.WARNING)
 
 
 app = create_app(mcp=_server.mcp)


### PR DESCRIPTION
The #175 enrichment logging did its diagnostic job immediately (found SerpAPI 401s in prod) but exposed a leak: httpx embeds the full request URL — api_key query param included — in both its INFO request lines and its exception text, so the key was landing in pod logs twice per failure.

- Scrub `api_key=…` from the exception string before logging in `_web_search_address`
- `httpx` logger → WARNING (its per-request INFO lines carry full URLs)

Note for ops: the current key is already in existing pod logs (and it's 401-invalid anyway) — rotating it on the SerpAPI dashboard when replacing it is the clean move.

73 tests green on touched suites + full http api suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)