### PR TITLE
Promote qa to main: SerpAPI key log scrubbing

### DIFF
--- a/tools/certification.py
+++ b/tools/certification.py
@@ -570,7 +570,9 @@ def _web_search_address(company: str) -> "tuple[dict, str] | None":
         resp.raise_for_status()
         payload = resp.json()
     except Exception as exc:  # noqa: BLE001 — enrichment is best-effort
-        _log.warning("serpapi search failed for %r: %s", company, exc)
+        # httpx exception text embeds the full request URL — api_key included.
+        _log.warning("serpapi search failed for %r: %s", company,
+                     re.sub(r"api_key=[^&'\s]+", "api_key=***", str(exc)))
         return None
     blobs: list[tuple[str, str]] = []
     kg = payload.get("knowledge_graph", {}) or {}

--- a/transport/http/main.py
+++ b/transport/http/main.py
@@ -20,6 +20,9 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s %(levelname)-7s %(name)s: %(message)s",
 )
+# httpx logs every request line at INFO with the full URL — for SerpAPI that
+# is the api_key in a query param. Errors still surface via callers' logs.
+logging.getLogger("httpx").setLevel(logging.WARNING)
 
 
 app = create_app(mcp=_server.mcp)


### PR DESCRIPTION
Promotes #177 (never log the SerpAPI key) to main — wants to be live in prod before the corrected key is installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)