### PR TITLE
fix(certification): accept Plaza/Square street suffixes in address regex

### DIFF
--- a/tests/test_certification.py
+++ b/tests/test_certification.py
@@ -374,6 +374,14 @@ class TestEnrichmentFixes:
         )
         assert match and match.group("street") == "One Mercedes-Benz Drive"
 
+    def test_address_regex_accepts_plaza(self):
+        # Real corporate HQs SerpAPI actually returns: State Farm's is a Plaza.
+        match = cert._ADDRESS_RE.search(
+            "Headquarters: One State Farm Plaza, Bloomington, IL 61710"
+        )
+        assert match and match.group("street") == "One State Farm Plaza"
+        assert match.group("zip") == "61710"
+
     def test_alias_activities_merge_into_one(self, workspace):
         _write_interviews([])
         _write_status([

--- a/tools/certification.py
+++ b/tools/certification.py
@@ -468,7 +468,8 @@ _AGENCY_RE = re.compile(
 _ADDRESS_RE = re.compile(
     r"(?P<street>(?:\d{1,6}|One|Two|Three|Four|Five|Ten)\s+[A-Za-z0-9 .'-]{3,60}"
     r"(?:Street|St|Avenue|Ave|Boulevard|Blvd|Drive|Dr|Road|Rd|Lane|Ln|Way|"
-    r"Court|Ct|Place|Pl|Parkway|Pkwy|Circle|Cir|Highway|Hwy|Suite [\w-]+)\.?)"
+    r"Court|Ct|Place|Pl|Plaza|Plz|Square|Sq|Parkway|Pkwy|Circle|Cir|Highway|Hwy|"
+    r"Suite [\w-]+)\.?)"
     r"[,\s]+(?P<city>[A-Za-z .'-]{2,40})[,\s]+"
     r"(?P<state>[A-Z]{2})[,\s]+(?P<zip>\d{5}(?:-\d{4})?)"
 )


### PR DESCRIPTION
Found live: with the (real) SerpAPI key working, Boeing and Roan Spargo auto-filled but State Farm gapped — the new INFO logging showed `serpapi returned 9 results for 'State Farm', none with a parseable address`. Their HQ is **One State Farm Plaza** and `Plaza` wasn't in `_ADDRESS_RE`'s street-suffix alternation.

Adds `Plaza|Plz|Square|Sq`; everything else stays deliberately strict. Test pins the exact State Farm HQ string. 75 green on touched suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)