### PR TITLE
Promote qa to main: Plaza/Square address suffixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/version-1.4.0-blue" alt="Version 1.4.0"/>
-  <img src="https://img.shields.io/badge/tests-1647%20passing-brightgreen" alt="1647 tests passing"/>
+  <img src="https://img.shields.io/badge/tests-1648%20passing-brightgreen" alt="1648 tests passing"/>
   <a href="https://sonarcloud.io/component_measures?id=JustLikeFrank3_jobContextMCP&metric=coverage"><img src="https://sonarcloud.io/api/project_badges/measure?project=JustLikeFrank3_jobContextMCP&metric=coverage" alt="Coverage"/></a>
   <img src="https://img.shields.io/badge/tools-12%20domains%20%C2%B7%2095%20actions-informational" alt="12 domain tools, 95 actions"/>
   <img src="https://img.shields.io/badge/license-MIT-lightgrey" alt="MIT License"/>
@@ -39,7 +39,7 @@ jobContext keeps your job-search context structured and persistent, and exposes 
 | | |
 |---|---|
 | 12 MCP tools | 95 domain actions behind them |
-| 1647 passing tests | Resume + cover letter generation with a deterministic truth gate |
+| 1648 passing tests | Resume + cover letter generation with a deterministic truth gate |
 | SQLite persistence + JSON audit trail | Job fitment analysis with persona lenses |
 | Local RAG semantic search | Interview prep + debrief logging |
 | Desktop app (macOS · Windows · Linux) | Outreach + relationship tracking |

--- a/templates/latex_assets/sections/experience.tex
+++ b/templates/latex_assets/sections/experience.tex
@@ -5,7 +5,7 @@
 \subsection{{\textbf{Senior Software Engineer} \textit{\ \ Contoso Cloud, Remote} \hfill 20XX --- Present}}
 \begin{zitemize}
 \item Led design and delivery of a customer-facing service from architecture through production and on-call; quantify the impact here (latency, scale, revenue, or adoption).
-\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1647 passing tests at 80\%+ line coverage through disciplined TDD.
+\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1648 passing tests at 80\%+ line coverage through disciplined TDD.
 \item Drove a cross-team win — a migration, a shared API pattern others adopted, or an SLA target consistently met.
 \end{zitemize}
 %====================

--- a/tests/test_certification.py
+++ b/tests/test_certification.py
@@ -374,6 +374,14 @@ class TestEnrichmentFixes:
         )
         assert match and match.group("street") == "One Mercedes-Benz Drive"
 
+    def test_address_regex_accepts_plaza(self):
+        # Real corporate HQs SerpAPI actually returns: State Farm's is a Plaza.
+        match = cert._ADDRESS_RE.search(
+            "Headquarters: One State Farm Plaza, Bloomington, IL 61710"
+        )
+        assert match and match.group("street") == "One State Farm Plaza"
+        assert match.group("zip") == "61710"
+
     def test_alias_activities_merge_into_one(self, workspace):
         _write_interviews([])
         _write_status([

--- a/tools/certification.py
+++ b/tools/certification.py
@@ -468,7 +468,8 @@ _AGENCY_RE = re.compile(
 _ADDRESS_RE = re.compile(
     r"(?P<street>(?:\d{1,6}|One|Two|Three|Four|Five|Ten)\s+[A-Za-z0-9 .'-]{3,60}"
     r"(?:Street|St|Avenue|Ave|Boulevard|Blvd|Drive|Dr|Road|Rd|Lane|Ln|Way|"
-    r"Court|Ct|Place|Pl|Parkway|Pkwy|Circle|Cir|Highway|Hwy|Suite [\w-]+)\.?)"
+    r"Court|Ct|Place|Pl|Plaza|Plz|Square|Sq|Parkway|Pkwy|Circle|Cir|Highway|Hwy|"
+    r"Suite [\w-]+)\.?)"
     r"[,\s]+(?P<city>[A-Za-z .'-]{2,40})[,\s]+"
     r"(?P<state>[A-Z]{2})[,\s]+(?P<zip>\d{5}(?:-\d{4})?)"
 )


### PR DESCRIPTION
Promotes #179 (accept Plaza/Square street suffixes in the certification address regex) to main. qa deploy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)