### PR TITLE
Promote qa to main: sync apply-lease recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/version-1.4.0-blue" alt="Version 1.4.0"/>
-  <img src="https://img.shields.io/badge/tests-1655%20passing-brightgreen" alt="1655 tests passing"/>
+  <img src="https://img.shields.io/badge/tests-1658%20passing-brightgreen" alt="1658 tests passing"/>
   <a href="https://sonarcloud.io/component_measures?id=JustLikeFrank3_jobContextMCP&metric=coverage"><img src="https://sonarcloud.io/api/project_badges/measure?project=JustLikeFrank3_jobContextMCP&metric=coverage" alt="Coverage"/></a>
   <img src="https://img.shields.io/badge/tools-12%20domains%20%C2%B7%2095%20actions-informational" alt="12 domain tools, 95 actions"/>
   <img src="https://img.shields.io/badge/license-MIT-lightgrey" alt="MIT License"/>
@@ -39,7 +39,7 @@ jobContext keeps your job-search context structured and persistent, and exposes 
 | | |
 |---|---|
 | 12 MCP tools | 95 domain actions behind them |
-| 1655 passing tests | Resume + cover letter generation with a deterministic truth gate |
+| 1658 passing tests | Resume + cover letter generation with a deterministic truth gate |
 | SQLite persistence + JSON audit trail | Job fitment analysis with persona lenses |
 | Local RAG semantic search | Interview prep + debrief logging |
 | Desktop app (macOS · Windows · Linux) | Outreach + relationship tracking |

--- a/lib/sync.py
+++ b/lib/sync.py
@@ -51,9 +51,27 @@ _LOG = logging.getLogger(__name__)
 
 _TS_FMT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
+# How long an apply may hold the journal-suppression flag before a later
+# process treats it as abandoned. Applies are one bounded transaction
+# (<= 2000 rows), so minutes is generous; the cost of guessing too low is a
+# few echoed journal entries that LWW/dedupe absorb, while guessing too high
+# leaves the partition silently unable to publish ANY change.
+_APPLY_LEASE_SECONDS = 300
+
 
 def _now_ts() -> str:
     return datetime.datetime.now(datetime.timezone.utc).strftime(_TS_FMT)
+
+
+def _ts_age_seconds(ts: str) -> "float | None":
+    """Seconds since a journal timestamp, or None if it can't be parsed."""
+    try:
+        when = datetime.datetime.strptime(ts, _TS_FMT).replace(
+            tzinfo=datetime.timezone.utc
+        )
+    except (TypeError, ValueError):
+        return None
+    return (datetime.datetime.now(datetime.timezone.utc) - when).total_seconds()
 
 
 @dataclass(frozen=True)
@@ -118,6 +136,9 @@ def ensure_sync_schema(con) -> None:
     con.execute("CREATE TABLE IF NOT EXISTS sync_state (id INTEGER PRIMARY KEY CHECK (id = 1), applying INTEGER NOT NULL DEFAULT 0)")
     con.execute("INSERT OR IGNORE INTO sync_state (id, applying) VALUES (1, 0)")
     con.execute("CREATE TABLE IF NOT EXISTS sync_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+    if "applying_since" not in {r[1] for r in con.execute("PRAGMA table_info(sync_state)")}:
+        con.execute("ALTER TABLE sync_state ADD COLUMN applying_since TEXT NOT NULL DEFAULT ''")
+    _release_stale_apply_lease(con)
 
     existing = {
         r[0] for r in con.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
@@ -144,6 +165,35 @@ def ensure_sync_schema(con) -> None:
                     END"""
             )
     _backfill_journal(con)
+
+
+def _release_stale_apply_lease(con) -> None:
+    """Clear ``applying`` when the process that set it never came back.
+
+    ``apply_changes`` restores the flag in a finally, which a SIGKILL skips —
+    a pod restart or crash mid-apply therefore leaves it set forever. Every
+    journal trigger is gated on ``applying = 0``, so a stuck flag silently
+    stops the partition from journaling ANY local write: exports go empty,
+    peers pull zero rows, and every status line still reads "ok". Recovering
+    on a lease expiry turns a permanent silent wedge into a bounded one.
+    """
+    row = con.execute("SELECT applying, applying_since FROM sync_state WHERE id = 1").fetchone()
+    if row is None or not row[0]:
+        return
+    age = _ts_age_seconds(row[1] or "")
+    if age is not None and age < _APPLY_LEASE_SECONDS:
+        return  # a real apply is in flight
+    con.execute("UPDATE sync_state SET applying = 0, applying_since = '' WHERE id = 1")
+    con.execute(
+        "INSERT INTO sync_meta (key, value) VALUES ('last_stale_apply_release', ?)"
+        " ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (_now_ts(),),
+    )
+    _LOG.warning(
+        "sync: cleared a stale apply lease (held %s) — an apply died mid-flight and "
+        "local writes since then were NOT journaled; peers may be missing them",
+        f"{int(age)}s" if age is not None else "since an unknown time",
+    )
 
 
 def _backfill_journal(con) -> None:
@@ -289,7 +339,11 @@ def apply_changes(con, changes: list[dict]) -> dict:
         (c for c in changes if c.get("tbl") in _SPECS_BY_NAME),
         key=lambda c: (order[c["tbl"]], c.get("ts") or ""),
     )
-    con.execute("UPDATE sync_state SET applying = 1 WHERE id = 1")
+    # Stamp the lease so a crash mid-apply is recoverable — without the
+    # timestamp a killed process leaves journaling off permanently.
+    con.execute(
+        "UPDATE sync_state SET applying = 1, applying_since = ? WHERE id = 1", (_now_ts(),)
+    )
     try:
         for change in batch:
             try:
@@ -298,7 +352,7 @@ def apply_changes(con, changes: list[dict]) -> dict:
                 stats.errors.append(f"{change.get('tbl')}/{change.get('nk')}: {exc}")
         con.commit()
     finally:
-        con.execute("UPDATE sync_state SET applying = 0 WHERE id = 1")
+        con.execute("UPDATE sync_state SET applying = 0, applying_since = '' WHERE id = 1")
         con.commit()
     return stats.as_dict()
 

--- a/templates/latex_assets/sections/experience.tex
+++ b/templates/latex_assets/sections/experience.tex
@@ -5,7 +5,7 @@
 \subsection{{\textbf{Senior Software Engineer} \textit{\ \ Contoso Cloud, Remote} \hfill 20XX --- Present}}
 \begin{zitemize}
 \item Led design and delivery of a customer-facing service from architecture through production and on-call; quantify the impact here (latency, scale, revenue, or adoption).
-\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1655 passing tests at 80\%+ line coverage through disciplined TDD.
+\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1658 passing tests at 80\%+ line coverage through disciplined TDD.
 \item Drove a cross-team win — a migration, a shared API pattern others adopted, or an SLA target consistently met.
 \end{zitemize}
 %====================

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -652,3 +652,62 @@ def test_manual_override_propagates_over_auto_row(replicas):
         )
         assert rows == [{"street": "75 5th St NW", "manual_override": 1}]
         assert stats["applied"] >= 1
+
+
+def _set_apply_flag(applying, since):
+    with db.get_connection() as con:
+        con.execute(
+            "UPDATE sync_state SET applying = ?, applying_since = ? WHERE id = 1",
+            (applying, since),
+        )
+
+
+def _flag():
+    with db.get_connection() as con:
+        return con.execute("SELECT applying FROM sync_state WHERE id = 1").fetchone()[0]
+
+
+def test_stale_apply_lease_is_released_and_journaling_resumes(replicas):
+    """A crash mid-apply (SIGKILL skips the finally) leaves `applying` set, and
+    every journal trigger is gated on it — so the partition silently stops
+    publishing ANY local write. The lease must expire and journaling resume."""
+    desktop, _ = replicas
+    with desktop:
+        _write_job(company="Before")
+        stale = "2020-01-01T00:00:00.000Z"
+        _set_apply_flag(1, stale)
+        # Opening a connection runs ensure_sync_schema, which reaps the lease.
+        assert _flag() == 0
+        _write_job(company="After")
+        journaled = _rows(
+            "SELECT nk FROM sync_log WHERE tbl = 'job_queue' AND origin = 'local'"
+        )
+        assert any("After" in r["nk"] for r in journaled), journaled
+        assert _rows("SELECT value FROM sync_meta WHERE key='last_stale_apply_release'")
+
+
+def test_live_apply_lease_is_not_stolen(replicas):
+    """A genuinely in-flight apply keeps the flag — clearing it would let the
+    applying peer's writes journal as local and echo back."""
+    desktop, _ = replicas
+    with desktop:
+        _write_job()
+        _set_apply_flag(1, sync._now_ts())
+        assert _flag() == 1
+        _write_job(company="DuringApply")
+        assert not any(
+            "DuringApply" in r["nk"]
+            for r in _rows("SELECT nk FROM sync_log WHERE origin = 'local'")
+        )
+        _set_apply_flag(0, "")
+
+
+def test_apply_changes_stamps_and_clears_the_lease(replicas):
+    desktop, cloud = replicas
+    with desktop:
+        _write_job(company="Leased")
+        batch = _export()
+    with cloud:
+        _apply(batch["changes"])
+        row = _rows("SELECT applying, applying_since FROM sync_state WHERE id = 1")
+        assert row == [{"applying": 0, "applying_since": ""}]


### PR DESCRIPTION
Promotes #183 (recover from a crashed apply that wedges journaling forever) to main. qa deploy green.

The cloud is where this bug bites — every deploy SIGKILLs the pod, which is how the flag got stuck in the first place. The restart that deploys this fix also heals any lease it leaves behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)