### PR TITLE
fix(certification): make every archived week openable, not just filed ones

### DIFF
--- a/frontend/src/screens/Certification.jsx
+++ b/frontend/src/screens/Certification.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import {
   useApi, Screen, SectionHead, StatGrid, Stat, Badge, List, Row, fmtDate,
 } from './_shared.jsx'
@@ -98,6 +98,14 @@ export default function Certification() {
   const selectedMeta = reports.find((r) => r.id === reportId)
   const weekStamp = archive.find((w) => w.weekEnding === report?.weekEnding)
 
+  // The archive sits below the report it drives, so a click there would
+  // otherwise change something off-screen and read as "nothing happened".
+  const reportRef = useRef(null)
+  const openWeek = (id) => {
+    setReportId(id)
+    reportRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
+
   const under = progress && progress.logged < progress.target
 
   return (
@@ -167,7 +175,7 @@ export default function Certification() {
       )}
 
       {report && (
-        <>
+        <div ref={reportRef}>
           <SectionHead
             title={`Week ending ${report.weekEnding} — v${report.version}`}
             right={`generated ${report.generatedAt}`}
@@ -253,7 +261,7 @@ export default function Certification() {
               </List>
             </>
           )}
-        </>
+        </div>
       )}
       {archive.length > 0 && (
         <>
@@ -266,14 +274,14 @@ export default function Certification() {
                 subtitle={
                   w.submittedVersion != null
                     ? `filed v${w.submittedVersion} · ${w.submittedAt?.slice(0, 16) || ''}${w.confirmation ? ` · confirmation ${w.confirmation}` : ''}`
-                    : `${w.versions} frozen version${w.versions === 1 ? '' : 's'} — none marked as filed`
+                    : `${w.versions} frozen version${w.versions === 1 ? '' : 's'} — none marked as filed · open v${w.openVersion} →`
                 }
                 right={
                   w.submittedVersion != null
                     ? <Badge tone="green">★ filed</Badge>
                     : <Badge tone="warn">not filed</Badge>
                 }
-                onClick={w.reportId != null ? () => setReportId(w.reportId) : undefined}
+                onClick={w.reportId != null ? () => openWeek(w.reportId) : undefined}
               />
             ))}
           </List>

--- a/tests/test_certification.py
+++ b/tests/test_certification.py
@@ -458,6 +458,35 @@ class TestSubmission:
         )
         assert out.startswith("✓") and "GA-42" in out
 
+    def test_archive_week_opens_without_a_stamp(self, http_client_noauth, monkeypatch):
+        """Reviewing a week is how you decide what to file, so an unfiled week
+        must still resolve to a report — it opens the NEWEST frozen version."""
+        _write_interviews([])
+        _write_status([_app("Acme", applied_date=_iso(IN_WEEK))])
+        first = _freeze_week(monkeypatch)
+        newest = _freeze_week(monkeypatch)
+        assert newest != first
+        data = http_client_noauth.get("/dashboard/certification/data").json()
+        week = next(w for w in data["archive"] if w["weekEnding"] == _iso(WEEK_END))
+        assert week["submittedVersion"] is None
+        assert week["reportId"] == newest
+        assert week["openVersion"] == 2
+        assert week["versions"] == 2
+
+    def test_archive_week_opens_the_filed_version_when_stamped(
+        self, http_client_noauth, monkeypatch
+    ):
+        """Once a week is filed, it opens the FILED version, not the newest —
+        the filed record is what matters after the fact."""
+        _write_interviews([])
+        _write_status([_app("Acme", applied_date=_iso(IN_WEEK))])
+        filed = _freeze_week(monkeypatch)
+        _freeze_week(monkeypatch)  # a later regeneration must not steal the link
+        cert.mark_certification_submitted(filed, "GA-9")
+        data = http_client_noauth.get("/dashboard/certification/data").json()
+        week = next(w for w in data["archive"] if w["weekEnding"] == _iso(WEEK_END))
+        assert week["reportId"] == filed and week["openVersion"] == 1
+
     def test_submit_endpoint_and_archive(self, http_client_noauth, monkeypatch):
         _write_interviews([])
         _write_status([_app("Acme", applied_date=_iso(IN_WEEK))])

--- a/transport/http/routes/dashboard/certification.py
+++ b/transport/http/routes/dashboard/certification.py
@@ -69,25 +69,28 @@ def _index_payload() -> dict:
             "generatedAt": row["generated_at"],
             "submitted": bool(stamp and stamp["version"] == row["version"]),
         })
-    # Archive: one line per week — what was (or wasn't) filed. The filed
-    # version is resolved back to a local report id when that row is present
-    # (sync peers may hold the stamp before the report row arrives).
+    # Archive: one line per week — what was (or wasn't) filed. Every week
+    # opens to a report: the filed version when one is stamped, otherwise the
+    # newest frozen version. Gating navigation on the stamp would mean a week
+    # could only be reviewed AFTER filing it, which is backwards — reviewing
+    # is how you decide what to file.
     weeks: dict[str, dict] = {}
-    for rep in reports:
+    for rep in reports:  # ordered week_ending DESC, version DESC
         wk = rep["weekEnding"]
         stamp = submitted.get(wk)
-        if wk not in weeks:
-            weeks[wk] = {
-                "weekEnding": wk,
-                "versions": 0,
-                "submittedVersion": stamp["version"] if stamp else None,
-                "submittedAt": stamp["submitted_at"] if stamp else "",
-                "confirmation": stamp["confirmation_number"] if stamp else "",
-                "reportId": None,
-            }
-        weeks[wk]["versions"] += 1
-        if stamp and rep["version"] == stamp["version"] and weeks[wk]["reportId"] is None:
-            weeks[wk]["reportId"] = rep["id"]
+        week = weeks.setdefault(wk, {
+            "weekEnding": wk,
+            "versions": 0,
+            "submittedVersion": stamp["version"] if stamp else None,
+            "submittedAt": stamp["submitted_at"] if stamp else "",
+            "confirmation": stamp["confirmation_number"] if stamp else "",
+            "reportId": rep["id"],       # newest version, until a stamp overrides
+            "openVersion": rep["version"],
+        })
+        week["versions"] += 1
+        if stamp and rep["version"] == stamp["version"]:
+            week["reportId"] = rep["id"]
+            week["openVersion"] = rep["version"]
     archive = sorted(weeks.values(), key=lambda w: w["weekEnding"], reverse=True)
     return {
         "configured": certification.is_configured(),


### PR DESCRIPTION
## The bug
The weekly archive only set `reportId` for weeks carrying a submission stamp, so with nothing filed yet **every archive row was inert** — Frank hit exactly this: two weeks listed, neither clickable. The logic was backwards: you could only open a week *after* filing it, when reviewing a week is how you decide what to file in the first place.

## Fix
- Every week resolves to a report — the **filed** version when stamped, otherwise the **newest** frozen version. A later regeneration can't steal the link away from a filed version.
- `openVersion` is surfaced so the row says which version it opens ("4 frozen versions — none marked as filed · open v4 →").
- Clicking an archive row now scrolls the report into view: the archive renders *below* the report it drives, so selection previously changed something off-screen and read as a no-op.

## Tests
2 new, both verified to fail without the fix: an unfiled week resolves to the newest version; a filed week resolves to the filed version even after a later regeneration. 45 green in the certification suite, frontend builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)