### PR TITLE
feat(certification): flag one employer counted twice in a week

### DIFF
--- a/tests/test_certification.py
+++ b/tests/test_certification.py
@@ -473,6 +473,60 @@ class TestSubmission:
         assert next(r for r in data["reports"] if r["id"] == rid)["submitted"] is True
 
 
+class TestDuplicateDetection:
+    """One employer, one activity kind, twice in a week — flag, never drop."""
+
+    def _iv(self, date, logged, role="AI Native Engineer", interviewer="Venky"):
+        return {
+            "timestamp": logged, "company": "Accenture", "role": role,
+            "interview_date": date, "interview_type": "hiring_manager",
+            "interview_format": "video", "interviewer": interviewer,
+        }
+
+    def test_same_event_logged_twice_is_flagged_with_the_tell(self, workspace, monkeypatch):
+        # The real shape: two records written an hour apart, different dates.
+        _write_interviews([
+            self._iv(_iso(IN_WEEK), "2026-07-23 18:57", role="AI Native Engineer / ATC"),
+            self._iv(_iso(IN_WEEK - datetime.timedelta(days=1)), "2026-07-23 19:57"),
+        ])
+        _write_status([])
+        monkeypatch.setattr(
+            cert, "enrich_employer",
+            lambda name, website_hint="": {"canonical_name": name, "aliases": []},
+        )
+        out = cert.weekly_certification_report(week_ending=_iso(WEEK_END))
+        assert "DUPLICATE?" in out and "Accenture" in out
+        assert "within 1h of each other" in out
+        # Flagged, never silently dropped — both entries still appear.
+        assert out.count("Accenture") >= 2
+
+    def test_distinct_rounds_logged_days_apart_get_no_tell(self, workspace, monkeypatch):
+        _write_interviews([
+            self._iv(_iso(IN_WEEK), "2026-07-21 10:00"),
+            self._iv(_iso(IN_WEEK - datetime.timedelta(days=2)), "2026-07-23 10:00"),
+        ])
+        _write_status([])
+        monkeypatch.setattr(
+            cert, "enrich_employer",
+            lambda name, website_hint="": {"canonical_name": name, "aliases": []},
+        )
+        out = cert.weekly_certification_report(week_ending=_iso(WEEK_END))
+        assert "DUPLICATE?" in out          # still worth a human look
+        assert "logged twice" not in out    # but no false accusation
+
+    def test_distinct_employers_are_never_flagged(self, workspace, monkeypatch):
+        _write_interviews([
+            self._iv(_iso(IN_WEEK), "2026-07-23 18:57"),
+            {**self._iv(_iso(IN_WEEK), "2026-07-23 18:58"), "company": "Globex"},
+        ])
+        _write_status([])
+        monkeypatch.setattr(
+            cert, "enrich_employer",
+            lambda name, website_hint="": {"canonical_name": name, "aliases": []},
+        )
+        assert "DUPLICATE?" not in cert.weekly_certification_report(week_ending=_iso(WEEK_END))
+
+
 class TestDdgFallback:
     """Keyless search fallback: company-adjacent addresses only, no network."""
 

--- a/tools/certification.py
+++ b/tools/certification.py
@@ -312,7 +312,7 @@ def derive_activities(start: datetime.date, end: datetime.date, profile: dict) -
 
     def add(kind: str, company: str, position: str, date: str, method: str,
             contact: str, result: str, source_ids: list[str],
-            website_hint: str = "") -> None:
+            website_hint: str = "", logged_at: str = "") -> None:
         if kind not in accepted or not company.strip():
             return
         primary = source_ids[0]
@@ -339,6 +339,9 @@ def derive_activities(start: datetime.date, end: datetime.date, profile: dict) -
                 return
         activities.append({
             "website_hint": website_hint,
+            # When the record was WRITTEN (not when the event happened) — two
+            # records of one event are usually logged minutes apart.
+            "logged_at": logged_at,
             "kind": kind,
             "strength": _KIND_STRENGTH.get(kind, 9),
             "employer": company.strip(),
@@ -377,6 +380,7 @@ def derive_activities(start: datetime.date, end: datetime.date, profile: dict) -
             str(iv.get("interviewer", "") or ""),
             "Interview completed",
             [_event_id("interview", iv.get("timestamp", ""), iv.get("company", ""), iv.get("role", ""))],
+            logged_at=str(iv.get("timestamp", "") or ""),
         )
 
     # 2. Application events.
@@ -836,6 +840,54 @@ def _entry_payload(activity: dict, directory_row: dict) -> dict:
     return entry
 
 
+def _logged_hours_apart(entries: list[dict]) -> "float | None":
+    """Hours between the earliest and latest *logging* time in a group."""
+    stamps = []
+    for e in entries:
+        raw = str(e.get("logged_at", "") or "").strip()[:16]
+        for fmt in ("%Y-%m-%d %H:%M", "%Y-%m-%dT%H:%M"):
+            try:
+                stamps.append(datetime.datetime.strptime(raw, fmt))
+                break
+            except ValueError:
+                continue
+    if len(stamps) < 2:
+        return None
+    return (max(stamps) - min(stamps)).total_seconds() / 3600
+
+
+def _duplicate_warnings(activities: list[dict]) -> list[str]:
+    """Flag one employer contributing the same activity kind twice in a week.
+
+    A second interview round is a real, countable activity; the same event
+    logged twice is not — and only a human knows which. So this never drops
+    an entry, it makes the collision impossible to file by accident. Two
+    records written minutes apart is the tell for a double-log, so say so.
+    """
+    groups: dict[tuple[str, str], list[dict]] = {}
+    for act in activities:
+        groups.setdefault((act["employer"].casefold(), act["kind"]), []).append(act)
+    warnings = []
+    for group in groups.values():
+        if len(group) < 2:
+            continue
+        dates = ", ".join(sorted(a["date"] for a in group))
+        apart = _logged_hours_apart(group)
+        tell = ""
+        if apart is not None and apart <= 24:
+            when = f"{int(apart)}h" if apart >= 1 else f"{int(apart * 60)}min"
+            tell = (
+                f" — and both records were written within {when} of each other,"
+                " which usually means one event logged twice"
+            )
+        warnings.append(
+            f"DUPLICATE? {group[0]['employer']}: {len(group)} × "
+            f"{group[0]['kind'].replace('_', ' ')} in one week ({dates}){tell}. "
+            "Confirm they are distinct events — a state may count them as one."
+        )
+    return warnings
+
+
 def _audit_append(record: dict) -> None:
     """Dual-write JSON audit trail beside the SQLite rows."""
     data = _load_json(config.CERTIFICATION_AUDIT_FILE, {"reports": []})
@@ -928,6 +980,7 @@ def weekly_certification_report(week_ending: str = "") -> str:
         {k: a[k] for k in ("kind", "employer", "position", "date", "method", "contact", "result", "source_event_ids")}
         for a in alternates
     ]
+    gaps.extend(_duplicate_warnings(picked))
     if len(entries) < target:
         gaps.insert(
             0,


### PR DESCRIPTION
## Why
Frank's week-ending 8/1 report listed the same Accenture hiring-manager interview **twice** and counted both toward 3/3. The underlying records: two interview entries written an hour apart on 7/29 (18:57 and 19:57), same company, same type, overlapping interviewer, near-identical role — but `interview_date` 7/26 on one and 7/29 on the other. The 7/26 date is a Sunday. One event, logged twice, one date mis-typed.

The existing alias dedupe can't catch this: it merges on same kind + **same date** + same position, and these differ by date. So the report overstated the week — the exact failure this tool exists to prevent.

## What
- Same employer + same activity kind, twice in one week → a `DUPLICATE?` warning in the report's gaps.
- **Never drops an entry.** A second interview round is a real countable activity, and only the person who was there knows which case it is. The warning makes the collision impossible to file by accident; the human decides.
- When both records were *written* within 24h of each other, the warning says so — that's the tell for a double-log versus two genuine rounds.
- Interview activities now carry `logged_at` (record write time, distinct from event date) to support that comparison.

## Tests
3 new, 2 verified to fail without the fix: the real double-log shape (1h apart, different dates) gets flagged *with* the tell; genuine rounds logged days apart get flagged *without* a false accusation; distinct employers are never flagged. 46 green in the certification suite, 36 in the facade suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)