### PR TITLE
docs(sync): interviews is an upsert table, not append

### DIFF
--- a/lib/sync.py
+++ b/lib/sync.py
@@ -14,10 +14,17 @@ Two table classes:
 - **upsert** tables (applications, job_queue, people, oura_readiness): identified
   by a natural key; conflicts resolve last-writer-wins by journal timestamp.
   Deletes travel as tombstone entries.
-- **append** tables (interviews, application_events, rejections, health_log,
+- **append** tables (application_events, rejections, health_log,
   linkedin_posts): rows are immutable observations; identity is the JSON of
   their identity columns and apply is insert-if-absent, so replays dedupe by
-  construction. Deletes are not synced.
+  construction. Deletes are not synced — and note the dedupe check runs
+  first, so an incoming delete for a row that still exists locally is
+  skipped as a duplicate rather than applied.
+
+``interviews`` is an **upsert** table despite reading like an append log:
+a debrief gets corrected and re-saved, and a mis-logged one has to be
+removable. TABLE_SPECS is the authority on a table's class — this list is
+prose and has been wrong before.
 
 Applying remote changes must not journal as *local* changes (echo loop): the
 apply transaction flips ``sync_state.applying`` which every trigger checks —


### PR DESCRIPTION
The `lib/sync.py` module docstring lists `interviews` among the **append** tables. `TABLE_SPECS` says `TableSpec("interviews", "upsert", ...)` — and has a comment right there explaining why (debriefs get enriched after the fact).

That stale prose cost real time today: diagnosing a mis-logged interview, I concluded from the docstring that deletes couldn't propagate and sent Frank a `kubectl exec` to delete the row cloud-side by hand. The delete would have synced on its own.

Doc-only. Also records the append-table subtlety that makes the distinction load-bearing: in `_apply_one` the dedupe check runs *before* the delete branch, so an incoming delete for a row that still exists locally is skipped as a duplicate rather than applied — which is exactly why the class of a table matters when reasoning about deletes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)