### PR TITLE
feat(cloud): SQLite is the sole datastore in AKS (SQLITE_ONLY=1)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -88,8 +88,13 @@ spec:
               value: "8"
             - name: USE_SQLITE
               value: "1"
+            # SQLite is the sole source of truth in the cloud. Reads already
+            # prefer it (lib/io._load_json); this stops the redundant JSON
+            # dual-write, which drifted from the tables and — because the
+            # data JSONs are ALSO file-synced — shipped that drift to peers
+            # as a second, competing channel. Desktop stays dual-write.
             - name: SQLITE_ONLY
-              value: "0"
+              value: "1"
             - name: ENABLE_REMOTE
               value: "true"
             # Required alongside ENABLE_REMOTE to disable the MCP SDK's

--- a/k8s/qa/deployment.yaml
+++ b/k8s/qa/deployment.yaml
@@ -69,8 +69,13 @@ spec:
               value: "http"
             - name: USE_SQLITE
               value: "1"
+            # SQLite is the sole source of truth in the cloud. Reads already
+            # prefer it (lib/io._load_json); this stops the redundant JSON
+            # dual-write, which drifted from the tables and — because the
+            # data JSONs are ALSO file-synced — shipped that drift to peers
+            # as a second, competing channel. Desktop stays dual-write.
             - name: SQLITE_ONLY
-              value: "0"
+              value: "1"
             - name: ENABLE_REMOTE
               value: "true"
             - name: SERVER_BASE_URL


### PR DESCRIPTION
## Why now
The JSON dual-write is a second copy that **nothing reads** — `lib/io._load_json` tries the SQLite handler first and only falls through for unmapped files. Worse, the data JSONs are also **file-synced**, so the same data travels two channels that can disagree. That's not theoretical: today we found an Accenture application whose four events existed in the desktop's `status.json` but not in its `application_events` table — they arrived via file sync, row sync never carried them, and every read ignored them.

## Safety audit
- **No direct readers.** Nothing outside `lib/io*` reads the nine mapped files (`status`, `job_queue`, `people`, `interviews`, `rejections`, `tone_samples`, `mental_health_log`, `linkedin_posts`, `personal_context`) — verified by grep. The flip only changes writes.
- **Already proven.** The desktop has run `SQLITE_ONLY=1` since the Tauri build (`desktop_main._apply_desktop_env`, pinned by `test_desktop_mode`) — the deployment doing the most writing has never dual-written.
- **No JSON→SQLite import path.** `provision_user_data` seeds example JSONs only `if not dest.exists()` and never imports them into tables, so a stale JSON can't overwrite newer rows.
- **Unmapped files unaffected** — the certification audit trail, eval results and config still get JSON.
- **Reversible** — existing JSONs stay on disk frozen; setting the value back to `"0"` resumes dual-writes.

Applied to prod (`k8s/deployment.yaml`) and qa (`k8s/qa/deployment.yaml`). Local and Pi manifests left alone.

## Follow-up, not in this PR
`tone_samples.json` and `personal_context.json` are mapped to SQLite but have **no row-sync table** in `TABLE_SPECS`, so they relied on file sync to travel — and since the desktop never imports a received JSON into its tables, they already don't sync in either direction. This PR doesn't change that; filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)