### PR TITLE
Promote qa to main: SQLite is the sole datastore in AKS

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -88,8 +88,13 @@ spec:
               value: "8"
             - name: USE_SQLITE
               value: "1"
+            # SQLite is the sole source of truth in the cloud. Reads already
+            # prefer it (lib/io._load_json); this stops the redundant JSON
+            # dual-write, which drifted from the tables and — because the
+            # data JSONs are ALSO file-synced — shipped that drift to peers
+            # as a second, competing channel. Desktop stays dual-write.
             - name: SQLITE_ONLY
-              value: "0"
+              value: "1"
             - name: ENABLE_REMOTE
               value: "true"
             # Required alongside ENABLE_REMOTE to disable the MCP SDK's

--- a/k8s/qa/deployment.yaml
+++ b/k8s/qa/deployment.yaml
@@ -69,8 +69,13 @@ spec:
               value: "http"
             - name: USE_SQLITE
               value: "1"
+            # SQLite is the sole source of truth in the cloud. Reads already
+            # prefer it (lib/io._load_json); this stops the redundant JSON
+            # dual-write, which drifted from the tables and — because the
+            # data JSONs are ALSO file-synced — shipped that drift to peers
+            # as a second, competing channel. Desktop stays dual-write.
             - name: SQLITE_ONLY
-              value: "0"
+              value: "1"
             - name: ENABLE_REMOTE
               value: "true"
             - name: SERVER_BASE_URL


### PR DESCRIPTION
Promotes #188 (SQLITE_ONLY=1 for prod and qa) to main.

qa verified before promoting:
- deploy green (test / build-and-deploy-qa / badges all success)
- `SQLITE_ONLY=1` confirmed in the live deployment spec
- pod Running, 0 restarts
- `GET /health` 200, no errors in pod logs

Post-merge check on prod: desktop Sync now still moves rows (the desktop is the peer, so this path can only be exercised against prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)