### PR TITLE
ci: stop concurrent badge jobs racing into a red build, and measure the suite once

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,8 +43,12 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements-dev.txt
 
+      # The whole suite, live_llm included — those tests bring their own mocked
+      # client (they only opt out of the autouse offline stub), so nothing here
+      # touches the network and the gate gets a few more tests for free. Running
+      # the same selection the badges want means it measures once, not twice.
       - name: Run tests
-        run: pytest -m "not live_llm" --cov --cov-report=xml
+        run: pytest --cov --cov-report=xml --junitxml=junit.xml
 
       # Layer 1 smoke gate (evals/): every non-network eval case runs against
       # an isolated throwaway workspace with fully verbose per-case logging
@@ -52,6 +56,16 @@ jobs:
       # <95% exits non-zero — this job fails and the deploy jobs never run.
       - name: Layer 1 smoke gate (verbose)
         run: python scripts/ci_smoke_gate.py
+
+      - name: Upload measurements for the badge job
+        uses: actions/upload-artifact@v4
+        with:
+          name: suite-measurements
+          path: |
+            junit.xml
+            coverage.xml
+          if-no-files-found: error
+          retention-days: 1
 
   badges:
     needs: test
@@ -72,11 +86,18 @@ jobs:
         with:
           python-version: '3.12'
 
+      # Runtime deps only — this job no longer runs pytest, it just needs to
+      # `import server` to count the MCP tools.
       - name: Install dependencies
-        run: pip install -r requirements-dev.txt
+        run: pip install -r requirements.txt
 
-      - name: Measure suite (full, including mocked live_llm)
-        run: pytest --cov --cov-report=xml --junitxml=junit.xml -q
+      # The suite already ran in `test`; re-running it here cost ~90s and, more
+      # to the point, widened the window in which concurrent badge jobs collide
+      # on the push below.
+      - name: Fetch measurements from the test job
+        uses: actions/download-artifact@v4
+        with:
+          name: suite-measurements
 
       - name: Regenerate README badges
         run: python scripts/update_readme_badges.py --junit junit.xml --coverage coverage.xml --readme README.md --resume-section templates/latex_assets/sections/experience.tex

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,18 +81,41 @@ jobs:
       - name: Regenerate README badges
         run: python scripts/update_readme_badges.py --junit junit.xml --coverage coverage.xml --readme README.md --resume-section templates/latex_assets/sections/experience.tex
 
+      # Several PRs merging to qa/main inside a couple of minutes put their
+      # badge jobs in a footrace for this push, and the losers used to die on
+      # "! [rejected] HEAD -> qa (fetch first)" — painting a run red whose
+      # tests and deploy both passed. So: regenerate on top of whoever won and
+      # try again. The regenerator is idempotent and rewrites only the stat
+      # fields in place, so replaying it after resetting to the new tip keeps
+      # any README prose that arrived on the winning push, and it recounts
+      # tools against that tip too. If the winner already published identical
+      # numbers there is nothing left to commit and we exit clean.
       - name: Commit badge changes if any
+        env:
+          BRANCH: ${{ github.ref_name }}
         run: |
           FILES="README.md templates/latex_assets/sections/experience.tex"
-          if git diff --quiet -- $FILES; then
-            echo "README badges & resume stats already current — nothing to commit."
-            exit 0
-          fi
+          REGEN="python scripts/update_readme_badges.py --junit junit.xml --coverage coverage.xml --readme README.md --resume-section templates/latex_assets/sections/experience.tex"
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add $FILES
-          git commit -m "docs: auto-update README badges & resume stats [skip ci]"
-          git push origin HEAD:${{ github.ref_name }}
+          for attempt in 1 2 3 4 5; do
+            if git diff --quiet -- $FILES; then
+              echo "README badges & resume stats already current — nothing to commit."
+              exit 0
+            fi
+            git add $FILES
+            git commit -m "docs: auto-update README badges & resume stats [skip ci]"
+            if git push origin HEAD:"$BRANCH"; then
+              echo "Pushed badge update on attempt $attempt."
+              exit 0
+            fi
+            echo "Push rejected — another badge job reached $BRANCH first. Rebuilding on the new tip (attempt $attempt)."
+            git fetch origin "$BRANCH"
+            git reset --hard FETCH_HEAD
+            $REGEN
+          done
+          echo "::error::Could not push the badge update after 5 attempts."
+          exit 1
 
   build-and-deploy:
     needs: test


### PR DESCRIPTION
## The noise

Three PRs merged to qa within 12 seconds on 2026-08-01:

| run | PR | `test` | deploy | `badges` |
|---|---|---|---|---|
| 30722926061 | #187 | ✅ | ✅ | ❌ |
| 30722929227 | #185 | ✅ | ✅ | ✅ |
| 30722932656 | #186 | ✅ | ✅ | ❌ |

All three deployed cleanly. Two went red anyway, because the three `badges` jobs raced for the same push and two lost:

```
! [rejected]        HEAD -> qa (fetch first)
```

A cosmetic README update marking a good deploy as failed is exactly the kind of red that teaches people to stop reading red.

## Commit 1 — retry the push instead of dying on it

On rejection: fetch, `reset --hard FETCH_HEAD`, **re-run the regenerator**, try again (5 attempts).

Replaying the generator rather than stashing and restoring the files is the part that matters. It edits only the stat fields in place, so README prose that arrived on the winning push survives — a save/restore approach would silently revert it — and the tool count is recounted against the tip that will actually carry the commit. The `git diff --quiet` check at the top of the loop means a rerun where the winner already published identical numbers exits clean with no commit at all.

Verified against a local bare-remote fixture with two clones checked out at the same tip:

- loser: attempt 1 rejected → rebuilt on new tip → `Pushed badge update on attempt 2.`
- prose edit pushed between the two badge jobs: preserved, badge applied on top
- identical numbers: `already current — nothing to commit`, no push
- history stays linear, one badge commit per job, all still `[skip ci]` — so the "never tag a badge commit with `desktop-v*`" rule is untouched

**Considered and rejected:** a `concurrency: badges-${{ github.ref }}` group. It serializes, but GitHub cancels an already-pending run when a third queues — with three rapid merges that trades a red run for a cancelled one. Still not green, so it fixes nothing here, and layering it on a working retry just adds a second failure mode.

## Commit 2 — stop measuring the same suite twice

`badges` re-ran the whole suite (~90s) to regenerate artifacts `test` had computed minutes earlier. Beyond the wasted minute, that long tail is *why* the race was likely: the wider the gap between "job starts" and "job pushes", the more merges land inside it. `test` now uploads `junit.xml` + `coverage.xml`; `badges` downloads them.

For the numbers to stay identical, `test` had to stop excluding `live_llm`. Per the marker's own docstring those tests opt out of the autouse offline `get_llm_client` stub and bring their own mocked client — nothing touches the network. `badges` has been running exactly this selection on every push and passing under the same workflow-level env, so **the deploy gate now covers five more tests than before, not fewer**.

`badges` also drops to `requirements.txt` — it no longer runs pytest, it only needs `import server` to count tools, which skips a pyinstaller install.

Verified locally: `pytest -m live_llm` → 5 passed; full-suite failures are identical under both selections (9 pre-existing Windows-local — POSIX crontab/plist, path semantics, weasyprint — none `live_llm`-marked, all green on ubuntu); and in a clean runtime-deps-only venv the generator parses both artifacts and rewrites both files, reporting 12 tools.

## Note: this PR cannot self-test

`deploy.yml` only triggers on push to qa/main, so the real exercise is the merge into qa. First qa merge after this lands is the proof; the race path itself only shows up when two merges land close together.

## Unrelated drift spotted, not fixed here

The generator emits `::warning::README badge updater found no match for: tools badge, tools badge alt` — the README's tools badge became `tools-12%20domains%20%C2%B7%2095%20actions` in a97f892 and the regex was never updated, so that badge has silently stopped being auto-maintained. It currently reads 12, which is correct by luck. Worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
