### PR TITLE
ci: fail the badge job on pattern drift; fix the rotted tools badge

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,6 +99,9 @@ jobs:
         with:
           name: suite-measurements
 
+      # Fails the job if any managed badge/stat string no longer matches its
+      # pattern — the generator's whole purpose is that these numbers cannot
+      # drift, so a skipped substitution must be loud, not a ::warning::.
       - name: Regenerate README badges
         run: python scripts/update_readme_badges.py --junit junit.xml --coverage coverage.xml --readme README.md --resume-section templates/latex_assets/sections/experience.tex
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Versions through 1.4.0 predate this note; their section headings vary slightly.
 
 ### CI
 
+- **The README badge updater can no longer skip silently** -- the tools badge became `tools-12 domains · 96 actions` in a97f892 and `update_readme_badges.py` still looked for `badge/tools-<n>-`, so both the badge and its alt text stopped being generated; every run printed `::warning::... no match for: tools, tools badge alt` and the job stayed green, which is why nobody noticed for weeks. The badge had drifted: the action count moved to 96 when `certification.mark_submitted` landed in #181, while the README still said 95. The patterns now match the current form (and the TL;DR row's action count, previously unmanaged, is generated too), an unmatched pattern raises and exits 1 with `::error::` instead of warning, and `tests/test_update_readme_badges.py` runs every pattern against the real README.md and experience.tex so the next format change fails a named test before it reaches the badge job.
 - **`mcp<2` pinned** -- mcp 2.0.0 removed `mcp.server.fastmcp`, breaking test collection.
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <img src="https://img.shields.io/badge/version-1.4.0-blue" alt="Version 1.4.0"/>
   <img src="https://img.shields.io/badge/tests-1688%20passing-brightgreen" alt="1688 tests passing"/>
   <a href="https://sonarcloud.io/component_measures?id=JustLikeFrank3_jobContextMCP&metric=coverage"><img src="https://sonarcloud.io/api/project_badges/measure?project=JustLikeFrank3_jobContextMCP&metric=coverage" alt="Coverage"/></a>
-  <img src="https://img.shields.io/badge/tools-12%20domains%20%C2%B7%2095%20actions-informational" alt="12 domain tools, 95 actions"/>
+  <img src="https://img.shields.io/badge/tools-12%20domains%20%C2%B7%2096%20actions-informational" alt="12 domain tools, 96 actions"/>
   <img src="https://img.shields.io/badge/license-MIT-lightgrey" alt="MIT License"/>
   <img src="https://img.shields.io/badge/Works%20with-Oura%20Ring-00B5C8" alt="Works with Oura Ring"/>
 </p>
@@ -38,7 +38,7 @@ jobContext keeps your job-search context structured and persistent, and exposes 
 
 | | |
 |---|---|
-| 12 MCP tools | 95 domain actions behind them |
+| 12 MCP tools | 96 domain actions behind them |
 | 1688 passing tests | Resume + cover letter generation with a deterministic truth gate |
 | SQLite persistence + JSON audit trail | Job fitment analysis with persona lenses |
 | Local RAG semantic search | Interview prep + debrief logging |

--- a/scripts/update_readme_badges.py
+++ b/scripts/update_readme_badges.py
@@ -9,14 +9,21 @@ Sources of truth:
   • tests    — passing count from a JUnit XML report (tests - failures - errors - skipped)
   • coverage — line-rate from coverage.xml (Cobertura format)
   • tools    — len(server.mcp._tool_manager.list_tools()) at runtime
+  • actions  — total dispatch actions across tools.consolidated.DOMAINS
 
 Usage:
     python scripts/update_readme_badges.py \
         --junit junit.xml --coverage coverage.xml --readme README.md \
         --resume-section templates/latex_assets/sections/experience.tex
 
-Exits 0 whether or not anything changed; prints a one-line summary. Designed to
-run in CI after the test job, with the result committed back via [skip ci].
+Exits 0 whether or not anything changed; prints a one-line summary. A managed
+pattern that no longer matches is a HARD FAILURE (exit 1, ``::error::``
+annotation) — a silently skipped badge is how the tools badge drifted for
+weeks after its format changed. If a README/resume edit intentionally reshapes
+a managed string, update the matching pattern here in the same change; the
+tests in tests/test_update_readme_badges.py pin every shape against the real
+files so the break surfaces before CI. Designed to run in CI after the test
+job, with the result committed back via [skip ci].
 """
 from __future__ import annotations
 
@@ -30,6 +37,33 @@ from pathlib import Path
 #: live test/tool counts. Kept in sync with the README badges from the same
 #: JUnit / runtime sources so the resume never quotes a stale number.
 RESUME_SECTION_DEFAULT = Path("templates/latex_assets/sections/experience.tex")
+
+
+class BadgePatternError(RuntimeError):
+    """A managed substitution pattern matched nothing.
+
+    Raised instead of warning: the point of the generator is that the quoted
+    numbers cannot drift, so an unmatched pattern must break the job loudly.
+    """
+
+    def __init__(self, target: str, missing: list[str]) -> None:
+        self.target = target
+        self.missing = list(missing)
+        super().__init__(
+            f"{target} updater found no match for: {', '.join(self.missing)}"
+        )
+
+
+def _apply(target: str, text: str, subs: list[tuple[str, str, str]]) -> str:
+    """Apply every substitution, raising if any pattern matched nothing."""
+    missing: list[str] = []
+    for label, pattern, repl in subs:
+        text, n = re.subn(pattern, repl, text)
+        if n == 0:
+            missing.append(label)
+    if missing:
+        raise BadgePatternError(target, missing)
+    return text
 
 
 def passing_tests(junit_path: Path) -> int:
@@ -50,21 +84,41 @@ def coverage_pct(coverage_path: Path) -> str:
     return f"{rate * 100:.2f}"
 
 
-def tool_count() -> int:
-    # Ensure the project root is importable regardless of CWD (the script lives
-    # in scripts/, which otherwise shadows the repo root on sys.path).
+def _add_repo_root_to_path() -> None:
+    """Make the project root importable regardless of CWD (the script lives in
+    scripts/, which otherwise shadows the repo root on sys.path)."""
     root = str(Path(__file__).resolve().parent.parent)
     if root not in sys.path:
         sys.path.insert(0, root)
+
+
+def tool_count() -> int:
+    _add_repo_root_to_path()
     import server  # imported lazily so the script is usable without a full env
 
     return len(server.mcp._tool_manager.list_tools())
 
 
-def update_readme(text: str, tests: int, tools: int) -> str:
-    """Apply anchored substitutions. Each pattern is specific enough that a miss
-    means the README format changed and the caller should be alerted."""
-    subs: list[tuple[str, str, str]] = [
+def action_count() -> int:
+    """Total dispatch actions behind the consolidated domain facades.
+
+    The tools badge quotes both numbers ("12 domains · 96 actions"), and the
+    action count moves whenever a row is added to a domain spec — exactly the
+    kind of number that goes stale by hand.
+    """
+    _add_repo_root_to_path()
+    from tools.consolidated import DOMAINS  # lazy, same reason as tool_count
+
+    return sum(len(actions) for actions in DOMAINS.values())
+
+
+def readme_substitutions(tests: int, tools: int, actions: int) -> list[tuple[str, str, str]]:
+    """The (label, pattern, replacement) triples the README updater applies.
+
+    Exposed so the test suite can pin every pattern against the real README —
+    a format change then fails a named test instead of going quiet.
+    """
+    return [
         # ── Badges (shields.io) ──────────────────────────────────────────────
         ("tests badge",
          r"badge/tests-\d+%20passing-",
@@ -74,16 +128,21 @@ def update_readme(text: str, tests: int, tools: int) -> str:
          f'alt="{tests} tests passing"'),
         # Coverage is shown via a live SonarCloud measure badge (see README),
         # so it is intentionally not managed here — no static badge to rewrite.
+        # The tools badge carries both counts: "tools-12 domains · 96 actions"
+        # (%C2%B7 is the URL-encoded middot).
         ("tools badge",
-         r"badge/tools-\d+-",
-         f"badge/tools-{tools}-"),
+         r"badge/tools-\d+%20domains%20%C2%B7%20\d+%20actions-",
+         f"badge/tools-{tools}%20domains%20%C2%B7%20{actions}%20actions-"),
         ("tools badge alt",
-         r'alt="\d+ MCP tools"',
-         f'alt="{tools} MCP tools"'),
+         r'alt="\d+ domain tools, \d+ actions"',
+         f'alt="{tools} domain tools, {actions} actions"'),
         # ── Inline current-state stats ───────────────────────────────────────
         ("TL;DR tools row",
          r"\| \d+ MCP tools \|",
          f"| {tools} MCP tools |"),
+        ("TL;DR actions cell",
+         r"\| \d+ domain actions behind them \|",
+         f"| {actions} domain actions behind them |"),
         ("TL;DR tests row",
          r"\| \d+ passing tests \|",
          f"| {tests} passing tests |"),
@@ -101,18 +160,20 @@ def update_readme(text: str, tests: int, tools: int) -> str:
          f"Discovered {tools} tools"),
     ]
 
-    missing: list[str] = []
-    for label, pattern, repl in subs:
-        text, n = re.subn(pattern, repl, text)
-        if n == 0:
-            missing.append(label)
 
-    if missing:
-        # Non-fatal: prose may legitimately be reworded. Warn so it's visible in
-        # CI logs without breaking the deploy.
-        print(f"::warning::README badge updater found no match for: {', '.join(missing)}",
-              file=sys.stderr)
-    return text
+def update_readme(text: str, tests: int, tools: int, actions: int) -> str:
+    """Apply anchored substitutions. Each pattern is specific enough that a miss
+    means the README format changed, so a miss raises BadgePatternError."""
+    return _apply("README badge", text, readme_substitutions(tests, tools, actions))
+
+
+def resume_substitutions(tests: int) -> list[tuple[str, str, str]]:
+    """The (label, pattern, replacement) triples the resume updater applies."""
+    return [
+        ("resume passing tests",
+         r"hold \d+ passing tests",
+         f"hold {tests} passing tests"),
+    ]
 
 
 def update_resume_section(text: str, tests: int) -> str:
@@ -122,23 +183,11 @@ def update_resume_section(text: str, tests: int) -> str:
     sample template never quotes a stale number. Coverage is deliberately left
     as evergreen prose (e.g. "80%+ line coverage") to avoid drift, and the tool
     count is a README-only concern (too product-specific for a generic resume).
+
+    Raises BadgePatternError if the bullet no longer matches — same contract as
+    update_readme.
     """
-    subs: list[tuple[str, str, str]] = [
-        ("resume passing tests",
-         r"hold \d+ passing tests",
-         f"hold {tests} passing tests"),
-    ]
-
-    missing: list[str] = []
-    for label, pattern, repl in subs:
-        text, n = re.subn(pattern, repl, text)
-        if n == 0:
-            missing.append(label)
-
-    if missing:
-        print(f"::warning::resume section updater found no match for: {', '.join(missing)}",
-              file=sys.stderr)
-    return text
+    return _apply("resume section", text, resume_substitutions(tests))
 
 
 def main() -> int:
@@ -153,26 +202,49 @@ def main() -> int:
     tests = passing_tests(args.junit)
     coverage = coverage_pct(args.coverage)
     tools = tool_count()
+    actions = action_count()
+
+    summary = (f"{tests} tests, {coverage}% coverage, "
+               f"{tools} tools, {actions} actions")
+
+    # Both targets are attempted even if the first drifts, so one run reports
+    # every stale pattern instead of trickling them out across CI runs.
+    failures: list[BadgePatternError] = []
 
     original = args.readme.read_text(encoding="utf-8")
-    updated = update_readme(original, tests, tools)
-
-    if updated == original:
-        print(f"README badges already current: {tests} tests, {coverage}% coverage, {tools} tools")
+    try:
+        updated = update_readme(original, tests, tools, actions)
+    except BadgePatternError as exc:
+        failures.append(exc)
     else:
-        args.readme.write_text(updated, encoding="utf-8")
-        print(f"README badges updated: {tests} tests, {coverage}% coverage, {tools} tools")
+        if updated == original:
+            print(f"README badges already current: {summary}")
+        else:
+            args.readme.write_text(updated, encoding="utf-8")
+            print(f"README badges updated: {summary}")
 
     # Keep the bundled sample resume bullet's test count in sync from JUnit.
     section_path = args.resume_section
     if section_path and Path(section_path).exists():
         section_orig = Path(section_path).read_text(encoding="utf-8")
-        section_new = update_resume_section(section_orig, tests)
-        if section_new == section_orig:
-            print(f"Resume section already current: {tests} tests")
+        try:
+            section_new = update_resume_section(section_orig, tests)
+        except BadgePatternError as exc:
+            failures.append(exc)
         else:
-            Path(section_path).write_text(section_new, encoding="utf-8")
-            print(f"Resume section updated: {tests} tests")
+            if section_new == section_orig:
+                print(f"Resume section already current: {tests} tests")
+            else:
+                Path(section_path).write_text(section_new, encoding="utf-8")
+                print(f"Resume section updated: {tests} tests")
+
+    if failures:
+        for exc in failures:
+            print(f"::error::{exc}", file=sys.stderr)
+        print("::error::Managed strings drifted from their patterns — update "
+              "scripts/update_readme_badges.py so the numbers stay generated.",
+              file=sys.stderr)
+        return 1
 
     return 0
 

--- a/tests/test_update_readme_badges.py
+++ b/tests/test_update_readme_badges.py
@@ -3,16 +3,47 @@
 Covers the JUnit test-count parser, the README badge rewriter, and the bundled
 LaTeX resume section updater that keeps the resume bullet's live test/tool
 counts in sync with the README badges.
+
+The tests in the "real files" section are the drift alarm: they run every
+managed pattern against the actual README.md and experience.tex. When a badge
+is reshaped by hand (as the tools badge was, silently, in a97f892) the matching
+test fails by name instead of the generator emitting a warning nobody reads.
 """
 import importlib.util
+import re
 import sys
 from pathlib import Path
 
-_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "update_readme_badges.py"
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "update_readme_badges.py"
+_README = _REPO_ROOT / "README.md"
+_RESUME_SECTION = _REPO_ROOT / "templates" / "latex_assets" / "sections" / "experience.tex"
+
 _spec = importlib.util.spec_from_file_location("update_readme_badges", _SCRIPT)
 assert _spec is not None and _spec.loader is not None
 badges = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(badges)
+
+
+def _readme_fixture(tests: int = 1, tools: int = 1, actions: int = 1) -> str:
+    """A synthetic README carrying every shape the updater manages.
+
+    Kept honest by test_fixture_covers_every_managed_readme_pattern — if a
+    pattern is added to the script, this fixture must grow with it.
+    """
+    return "\n".join([
+        f'<img src="https://img.shields.io/badge/tests-{tests}%20passing-brightgreen"'
+        f' alt="{tests} tests passing"/>',
+        f'<img src="https://img.shields.io/badge/tools-{tools}%20domains%20%C2%B7%20'
+        f'{actions}%20actions-informational" alt="{tools} domain tools, {actions} actions"/>',
+        f"| {tools} MCP tools | {actions} domain actions behind them |",
+        f"| {tests} passing tests | Resume + cover letter generation |",
+        f'        TOOLS["{tools} MCP / CLI tools"]',
+        f"# Expected: OK, {tools} tools",
+        f"the Output pane should show `Discovered {tools} tools`.",
+    ])
 
 
 # ---------------------------------------------------------------------------
@@ -52,6 +83,22 @@ def test_coverage_pct_formats_two_decimals(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# action_count
+# ---------------------------------------------------------------------------
+
+def test_action_count_sums_the_domain_specs():
+    """Pins the source of the badge's action number to the facade specs.
+
+    importorskip so the module stays runnable without the full app env; CI has
+    the deps, which is where the badge is actually generated.
+    """
+    consolidated = pytest.importorskip("tools.consolidated")
+    expected = sum(len(actions) for actions in consolidated.DOMAINS.values())
+    assert badges.action_count() == expected
+    assert expected > len(consolidated.DOMAINS)
+
+
+# ---------------------------------------------------------------------------
 # update_resume_section
 # ---------------------------------------------------------------------------
 
@@ -73,25 +120,108 @@ def test_update_resume_section_preserves_coverage_prose():
     assert r"80\%+ line coverage" in out
 
 
-def test_update_resume_section_no_match_returns_unchanged():
-    src = "nothing quantified here"
-    assert badges.update_resume_section(src, 1214) == src
+def test_update_resume_section_no_match_raises():
+    """A reworded bullet must fail the job, not silently skip the update."""
+    with pytest.raises(badges.BadgePatternError) as exc:
+        badges.update_resume_section("nothing quantified here", 1214)
+    assert exc.value.missing == ["resume passing tests"]
 
 
 # ---------------------------------------------------------------------------
 # update_readme
 # ---------------------------------------------------------------------------
 
-def test_update_readme_rewrites_test_and_tool_badges():
-    src = (
-        'badge/tests-1%20passing-brightgreen alt="1 tests passing" '
-        'badge/tools-1-informational alt="1 MCP tools"'
-    )
-    out = badges.update_readme(src, 1214, 85)
+def test_update_readme_rewrites_every_managed_number():
+    out = badges.update_readme(_readme_fixture(), 1214, 12, 96)
+
     assert "badge/tests-1214%20passing-" in out
     assert 'alt="1214 tests passing"' in out
-    assert "badge/tools-85-" in out
-    assert 'alt="85 MCP tools"' in out
+    assert "badge/tools-12%20domains%20%C2%B7%2096%20actions-" in out
+    assert 'alt="12 domain tools, 96 actions"' in out
+    assert "| 12 MCP tools | 96 domain actions behind them |" in out
+    assert "| 1214 passing tests |" in out
+    assert 'TOOLS["12 MCP / CLI tools"]' in out
+    assert "# Expected: OK, 12 tools" in out
+    assert "Discovered 12 tools" in out
+    # No placeholder survives anywhere.
+    assert "1 MCP tools" not in out
+
+
+def test_update_readme_raises_when_a_pattern_stops_matching():
+    """The tools badge reshaped by hand — the exact a97f892 regression."""
+    reshaped = _readme_fixture().replace(
+        "badge/tools-1%20domains%20%C2%B7%201%20actions-informational",
+        "badge/tools-1%20facades-informational",
+    )
+    with pytest.raises(badges.BadgePatternError) as exc:
+        badges.update_readme(reshaped, 1214, 12, 96)
+    assert exc.value.missing == ["tools badge"]
+    assert "tools badge" in str(exc.value)
+
+
+def test_update_readme_reports_every_missing_pattern_at_once():
+    with pytest.raises(badges.BadgePatternError) as exc:
+        badges.update_readme("no managed strings here", 1214, 12, 96)
+    labels = [label for label, _, _ in badges.readme_substitutions(1214, 12, 96)]
+    assert exc.value.missing == labels
+
+
+def test_fixture_covers_every_managed_readme_pattern():
+    """Guards the fixture itself: a new pattern must be represented here."""
+    src = _readme_fixture()
+    for label, pattern, _ in badges.readme_substitutions(1, 1, 1):
+        assert re.search(pattern, src), f"fixture is missing a case for: {label}"
+
+
+# ---------------------------------------------------------------------------
+# Real files — pins the shipped README / resume shapes
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "label,pattern",
+    [(label, pattern) for label, pattern, _ in badges.readme_substitutions(1, 1, 1)],
+)
+def test_real_readme_still_matches_pattern(label, pattern):
+    """Every managed README string is still in the shape the generator expects.
+
+    If this fails, README.md was reformatted: update the matching entry in
+    readme_substitutions() rather than leaving the number hand-maintained.
+    """
+    src = _README.read_text(encoding="utf-8")
+    assert re.search(pattern, src), f"README.md no longer matches the '{label}' pattern"
+
+
+@pytest.mark.parametrize(
+    "label,pattern",
+    [(label, pattern) for label, pattern, _ in badges.resume_substitutions(1)],
+)
+def test_real_resume_section_still_matches_pattern(label, pattern):
+    src = _RESUME_SECTION.read_text(encoding="utf-8")
+    assert re.search(pattern, src), f"experience.tex no longer matches the '{label}' pattern"
+
+
+def test_real_readme_round_trips_through_the_updater():
+    """End-to-end on the shipped README: no pattern misses, numbers land."""
+    src = _README.read_text(encoding="utf-8")
+    out = badges.update_readme(src, 4242, 7, 33)
+
+    assert "badge/tests-4242%20passing-" in out
+    assert "badge/tools-7%20domains%20%C2%B7%2033%20actions-" in out
+    assert 'alt="7 domain tools, 33 actions"' in out
+    assert "| 7 MCP tools | 33 domain actions behind them |" in out
+
+
+def test_real_readme_tools_badge_and_tldr_row_agree():
+    """The badge and the TL;DR row quote the same two numbers.
+
+    They are separate substitutions, so a half-applied rewrite would leave the
+    README internally inconsistent without any pattern missing.
+    """
+    src = _README.read_text(encoding="utf-8")
+    badge = re.search(r"badge/tools-(\d+)%20domains%20%C2%B7%20(\d+)%20actions-", src)
+    row = re.search(r"\| (\d+) MCP tools \| (\d+) domain actions behind them \|", src)
+    assert badge and row
+    assert badge.groups() == row.groups()
 
 
 # ---------------------------------------------------------------------------
@@ -108,18 +238,15 @@ def test_main_updates_both_readme_and_resume_section(tmp_path, monkeypatch):
     cov = tmp_path / "coverage.xml"
     cov.write_text('<coverage line-rate="0.823"></coverage>', encoding="utf-8")
     readme = tmp_path / "README.md"
-    readme.write_text(
-        'badge/tests-1%20passing-brightgreen alt="1 tests passing" '
-        'badge/tools-1-informational alt="1 MCP tools"',
-        encoding="utf-8",
-    )
+    readme.write_text(_readme_fixture(), encoding="utf-8")
     section = tmp_path / "experience.tex"
     section.write_text(
         r"hold 1 passing tests at 80\%+ line coverage through disciplined TDD.",
         encoding="utf-8",
     )
 
-    monkeypatch.setattr(badges, "tool_count", lambda: 85)
+    monkeypatch.setattr(badges, "tool_count", lambda: 12)
+    monkeypatch.setattr(badges, "action_count", lambda: 96)
     monkeypatch.setattr(
         sys, "argv",
         ["update_readme_badges.py", "--junit", str(junit), "--coverage", str(cov),
@@ -131,7 +258,7 @@ def test_main_updates_both_readme_and_resume_section(tmp_path, monkeypatch):
     assert rc == 0
     readme_out = readme.read_text(encoding="utf-8")
     assert "badge/tests-1214%20passing-" in readme_out
-    assert "badge/tools-85-" in readme_out
+    assert "badge/tools-12%20domains%20%C2%B7%2096%20actions-" in readme_out
     section_out = section.read_text(encoding="utf-8")
     assert "hold 1214 passing tests" in section_out
 
@@ -147,9 +274,10 @@ def test_main_skips_resume_section_when_missing(tmp_path, monkeypatch):
     cov = tmp_path / "coverage.xml"
     cov.write_text('<coverage line-rate="0.5"></coverage>', encoding="utf-8")
     readme = tmp_path / "README.md"
-    readme.write_text("badge/tests-1%20passing- badge/tools-1-", encoding="utf-8")
+    readme.write_text(_readme_fixture(), encoding="utf-8")
 
-    monkeypatch.setattr(badges, "tool_count", lambda: 85)
+    monkeypatch.setattr(badges, "tool_count", lambda: 12)
+    monkeypatch.setattr(badges, "action_count", lambda: 96)
     monkeypatch.setattr(
         sys, "argv",
         ["update_readme_badges.py", "--junit", str(junit), "--coverage", str(cov),
@@ -158,3 +286,56 @@ def test_main_skips_resume_section_when_missing(tmp_path, monkeypatch):
     )
 
     assert badges.main() == 0
+
+
+def _main_argv(tmp_path, readme, section=None):
+    junit = tmp_path / "junit.xml"
+    junit.write_text(
+        '<testsuites><testsuite tests="9" failures="0" errors="0" skipped="0"/>'
+        "</testsuites>",
+        encoding="utf-8",
+    )
+    cov = tmp_path / "coverage.xml"
+    cov.write_text('<coverage line-rate="0.9"></coverage>', encoding="utf-8")
+    argv = ["update_readme_badges.py", "--junit", str(junit), "--coverage", str(cov),
+            "--readme", str(readme)]
+    if section is not None:
+        argv += ["--resume-section", str(section)]
+    return argv
+
+
+def test_main_fails_the_job_when_a_readme_pattern_drifts(tmp_path, monkeypatch, capsys):
+    """A no-match must exit non-zero — a skipped badge is how drift hid before."""
+    readme = tmp_path / "README.md"
+    stale = _readme_fixture().replace(
+        "badge/tools-1%20domains%20%C2%B7%201%20actions-informational",
+        "badge/tools-1-informational",
+    )
+    readme.write_text(stale, encoding="utf-8")
+
+    monkeypatch.setattr(badges, "tool_count", lambda: 12)
+    monkeypatch.setattr(badges, "action_count", lambda: 96)
+    monkeypatch.setattr(sys, "argv", _main_argv(tmp_path, readme, tmp_path / "missing.tex"))
+
+    assert badges.main() == 1
+    err = capsys.readouterr().err
+    assert "::error::" in err
+    assert "tools badge" in err
+    # Nothing half-written: the drifted README is left exactly as found.
+    assert readme.read_text(encoding="utf-8") == stale
+
+
+def test_main_fails_when_the_resume_bullet_drifts(tmp_path, monkeypatch, capsys):
+    readme = tmp_path / "README.md"
+    readme.write_text(_readme_fixture(), encoding="utf-8")
+    section = tmp_path / "experience.tex"
+    section.write_text("no quantified bullet here", encoding="utf-8")
+
+    monkeypatch.setattr(badges, "tool_count", lambda: 12)
+    monkeypatch.setattr(badges, "action_count", lambda: 96)
+    monkeypatch.setattr(sys, "argv", _main_argv(tmp_path, readme, section))
+
+    assert badges.main() == 1
+    assert "resume passing tests" in capsys.readouterr().err
+    # The README half of the run still applied — only the drifted target failed.
+    assert "Discovered 12 tools" in readme.read_text(encoding="utf-8")


### PR DESCRIPTION
## What happened

The README tools badge changed shape in a97f892 (the docs overhaul) to
`tools-12%20domains%20%C2%B7%2095%20actions`. `scripts/update_readme_badges.py`
still looked for `badge/tools-\d+-`, so **two** managed strings — the badge URL
and its `alt` text — stopped being generated. The generator printed
`::warning::README badge updater found no match for: tools badge, tools badge alt`
and exited 0, so the `badges` job stayed green and nobody looked.

The number had in fact drifted: `certification.mark_submitted` (#181) took the
action count to **96**, while the README still read 95. That is exactly the
failure the generator exists to prevent.

## Audit of every managed pattern

| Label | Status before |
|---|---|
| tests badge / tests badge alt | matching |
| tools badge | **rotted** (`badge/tools-\d+-`) |
| tools badge alt | **rotted** (`alt="\d+ MCP tools"` vs `alt="12 domain tools, 95 actions"`) |
| TL;DR tools row | matching |
| TL;DR actions cell (`95 domain actions behind them`) | **never managed** — the second number in the same row was hand-maintained |
| TL;DR tests row, diagram label, smoke-test expected, `Discovered N tools` | matching |
| resume `hold N passing tests` | matching |

Coverage is a live SonarCloud measure badge; version/license/Oura are static.
Neither is generated, and that stays true.

## Changes

1. **Patterns fixed.** The tools badge and alt text match the current form, and
   the TL;DR actions cell is now generated. `action_count()` derives the number
   from `tools.consolidated.DOMAINS` — the same spec that defines the actions —
   alongside the existing runtime `tool_count()`.
2. **A no-match now fails the job.** `update_readme` / `update_resume_section`
   raise `BadgePatternError`; `main()` collects failures from both targets (so
   one run reports every drifted string), emits `::error::`, and returns 1. A
   drifted file is left untouched rather than half-rewritten.
3. **The shapes are pinned by tests.** `tests/test_update_readme_badges.py` runs
   every pattern against the real `README.md` and `experience.tex`, one
   parametrized case per label, plus a round-trip and a badge/TL;DR agreement
   check. A format change fails a **named** test instead of going quiet.

Verified by reshaping the tools badge locally: 3 tests fail by name, including
`test_real_readme_still_matches_pattern[tools badge-...]`.

README regenerated in this PR: **95 → 96 actions** (badge, alt text, TL;DR row).

## Coverage gap worth knowing about

`deploy.yml` runs on pushes to qa/main only (no `pull_request` trigger) and
`paths-ignore`s `**.md` / `docs/**`. So a **docs-only** push that reshapes a
badge runs neither the pinning tests nor the generator — the break surfaces on
the next push that touches code, loudly, instead of at the moment it is
introduced. Closing that would mean a small `pull_request`-triggered job (or
dropping `**.md` from paths-ignore for the test job); happy to add it if you
want it, but it is a separate change.

Branch prefixed `ci/` so the Desktop CI build matrix does not fire for a
workflow-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)