### PR TITLE
fix(scraper): stop assessing pages that are not job postings

### DIFF
--- a/scripts/rename_unrepresentable_files.py
+++ b/scripts/rename_unrepresentable_files.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""
+Rename files whose names can never sync to a Windows peer.
+
+The cloud runs Linux, where `: < > | ? * \\ "` and control characters are all
+legal in a filename. `lib.helpers.sanitize_filename` has stripped them at
+creation since 2026-07-13, but files written before that fix are still sitting
+in the partition, and `lib.sync_client` skips each one on *every* sync - the
+desktop can never pull them, forever. This is the one-off cleanup for those.
+
+Dry-run by default: prints the before/after mapping and changes nothing.
+Pass --apply to perform the renames.
+
+    # see what would change (safe, read-only)
+    python scripts/rename_unrepresentable_files.py --root /app/data
+
+    # do it
+    python scripts/rename_unrepresentable_files.py --root /app/data --apply
+
+Content is never touched: this is a pure `rename(2)`, so bytes, inode and
+mtime all survive. Nothing is ever overwritten - if the sanitized name is
+already taken, a ` (2)`, ` (3)`, ... suffix is appended before the extension,
+and the collision is called out in the output.
+
+The rename rule is deliberately identical to `lib.helpers.sanitize_filename`;
+`tests/test_rename_unrepresentable_files.py` fails if the two ever drift.
+The regex is inlined rather than imported so the script can run standalone
+inside the pod without importing the application (and its config side
+effects).
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import re
+import sys
+from pathlib import Path
+
+# Keep in lockstep with lib.helpers._ILLEGAL_FILENAME_CHARS.
+_ILLEGAL_FILENAME_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+
+# Directories that are machine-local or never file-synced; skip them so a
+# stray match under db/ or .git/ can't be renamed out from under something.
+_SKIP_DIRS = {".git", "db", "__pycache__", "node_modules", ".venv"}
+
+
+def sanitize_filename(name: str) -> str:
+    """Make a single filename component safe on every supported platform.
+
+    Mirrors lib.helpers.sanitize_filename exactly.
+    """
+    cleaned = _ILLEGAL_FILENAME_CHARS.sub("-", name)
+    cleaned = re.sub(r"\s{2,}", " ", cleaned).strip().rstrip(". ")
+    return cleaned or "untitled"
+
+
+def _suffixed(name: str, counter: int) -> str:
+    """Insert ' (N)' before the extension: 'a.md' -> 'a (2).md'."""
+    stem, dot, suffix = name.rpartition(".")
+    if not dot:
+        return f"{name} ({counter})"
+    return f"{stem} ({counter}).{suffix}"
+
+
+def plan_renames(filenames: list[str]) -> list[tuple[str, str, bool]]:
+    """Plan renames for one directory's file list. Pure - no filesystem.
+
+    *filenames* is every name in the directory, good and bad alike. Returns
+    [(old, new, collided)] for only the names that need changing.
+
+    A target is considered taken if a file of that name already exists in the
+    directory OR an earlier entry in this same pass already claimed it - two
+    different bad names can sanitize to the same string, and both must
+    survive. Keeping this pure is deliberate: it is the part that could
+    destroy data, and it can be tested on any platform, including the Windows
+    box where these filenames cannot even be created.
+    """
+    taken = set(filenames)
+    planned: list[tuple[str, str, bool]] = []
+
+    for filename in sorted(filenames):
+        clean = sanitize_filename(filename)
+        if clean == filename:
+            continue
+
+        collided = clean in taken
+        target = clean
+        counter = 2
+        while target in taken:
+            target = _suffixed(clean, counter)
+            counter += 1
+
+        taken.add(target)
+        planned.append((filename, target, collided))
+
+    return planned
+
+
+def find_renames(root: Path) -> list[tuple[Path, Path, bool]]:
+    """Walk *root* and return [(source, target, collided)] for every rename."""
+    planned: list[tuple[Path, Path, bool]] = []
+
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = sorted(d for d in dirnames if d not in _SKIP_DIRS)
+        directory = Path(dirpath)
+        for old, new, collided in plan_renames(filenames):
+            planned.append((directory / old, directory / new, collided))
+
+    return planned
+
+
+_IDENTICAL = "byte-identical to existing clean-named file"
+_DIFFERENT = "DIFFERENT content from existing clean-named file - suffixed, existing untouched"
+_UNREADABLE = "could not compare content - suffixed, existing untouched"
+
+
+def compare_with_existing(source: Path) -> str:
+    """Describe how *source* relates to the file already holding its clean name.
+
+    A bad name whose sanitized twin already exists is usually not lost content:
+    the same assessment was re-saved under the clean name after the sanitize
+    fix landed, orphaning the old copy. Renaming that would just duplicate it,
+    so the caller needs to know whether the bytes actually differ.
+    """
+    existing = source.parent / sanitize_filename(source.name)
+    try:
+        if _sha256(existing) == _sha256(source):
+            return _IDENTICAL
+        return _DIFFERENT
+    except OSError:
+        return _UNREADABLE
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Rename files whose names cannot exist on Windows.")
+    parser.add_argument(
+        "--root", default="/app/data",
+        help="Directory to walk (default: /app/data, the partition root).")
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="Perform the renames. Without this flag nothing is written.")
+    parser.add_argument(
+        "--force-duplicates", action="store_true",
+        help="Also rename files that are byte-identical to an existing "
+             "clean-named copy. Off by default: those are orphaned duplicates, "
+             "and renaming them just clutters the workspace.")
+    args = parser.parse_args(argv)
+
+    # Output is deliberately ASCII-only. A pretty arrow raises
+    # UnicodeEncodeError on a non-UTF-8 stdout, which under --apply would
+    # abort the run *after* some files had already been renamed.
+    root = Path(args.root)
+    if not root.is_dir():
+        print(f"ERROR: not a directory: {root}", file=sys.stderr)
+        return 2
+
+    planned = find_renames(root)
+
+    mode = "APPLY" if args.apply else "DRY RUN - nothing will be written"
+    print(f"root: {root}")
+    print(f"mode: {mode}")
+    print(f"files needing rename: {len(planned)}\n")
+
+    if not planned:
+        print("Nothing to do - every filename is already representable.")
+        return 0
+
+    renamed = failed = skipped_dupes = 0
+    for source, target, collided in planned:
+        verdict = ""
+        if collided:
+            verdict = compare_with_existing(source)
+            note = f"    [!] name taken - {verdict}"
+        else:
+            note = ""
+        print(f"  FROM: {source.relative_to(root)}")
+        print(f"    TO: {target.relative_to(root)}{note}")
+
+        if verdict == _IDENTICAL and not args.force_duplicates:
+            skipped_dupes += 1
+            print("    SKIPPED: byte-identical copy already present under the "
+                  "clean name; renaming would only duplicate it. "
+                  "Use --force-duplicates to rename anyway.")
+            continue
+
+        if not args.apply:
+            continue
+        try:
+            # Re-check under the actual write: os.walk ran earlier, and this
+            # must never clobber a file that appeared in between.
+            if target.exists():
+                raise FileExistsError(f"target appeared since scan: {target}")
+            os.rename(source, target)
+            renamed += 1
+        except OSError as exc:
+            failed += 1
+            print(f"    *** FAILED: {exc}")
+
+    print()
+    if skipped_dupes:
+        print(f"{skipped_dupes} of {len(planned)} are byte-identical duplicates of a")
+        print("file already present under the clean name. Nothing is lost by leaving")
+        print("them; they are orphaned pre-sanitize copies. Delete them by hand if")
+        print("you want the partition tidy, or pass --force-duplicates to rename.")
+        print()
+    if args.apply:
+        print(f"renamed: {renamed}    skipped: {skipped_dupes}    failed: {failed}")
+        if failed:
+            return 1
+        print("Done. The desktop will pull any renamed files on the next sync.")
+    else:
+        print("Dry run complete. Re-run with --apply to perform the renames.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_fitment.py
+++ b/tests/test_fitment.py
@@ -243,6 +243,40 @@ class TestFitmentCoverageExtras:
         for name in names:
             assert not set('<>:"/\\|?*') & set(name), name
 
+    @pytest.mark.live_llm
+    def test_run_job_assessment_slug_is_representable_on_every_platform(
+        self, isolated_server, monkeypatch
+    ):
+        """run_job_assessment builds its own filename from company + role, so
+        a hostile role must be sanitized before it hits disk. The cloud runs
+        Linux, where these names are legal — they get written happily and then
+        skip on every desktop sync forever."""
+        from lib import config
+
+        monkeypatch.setitem(config._cfg, "openai_api_key", "sk-real-test-key")
+
+        fake_client = MagicMock()
+        fake_response = MagicMock()
+        fake_response.choices = [MagicMock(message=MagicMock(content="FITMENT SCORE: 7/10"))]
+        fake_response.usage = None
+        fake_client.chat.completions.create.return_value = fake_response
+
+        with patch("lib.config.get_llm_client", return_value=(fake_client, "gpt-4o")):
+            out = fitment.run_job_assessment(
+                "Coke",
+                r'Senior Engineer: <html> | Home, RI ? * \ /',
+                "Build things.",
+            )
+
+        assert "Saved job assessment" in out
+        folder = fitment.config.get_active_job_assessments_dir() / "run_job_assessment"
+        names = [p.name for p in folder.glob("*.md")]
+        assert names, "assessment file was not saved"
+        for name in names:
+            assert not set('<>:"/\\|?*') & set(name), name
+        saved = folder / names[0]
+        assert saved.read_text(encoding="utf-8") == "FITMENT SCORE: 7/10"
+
     def test_run_job_assessment_handles_llm_client_boot_failure(self, isolated_server):
         with patch("lib.config.get_llm_client", side_effect=RuntimeError("boom")):
             out = fitment.run_job_assessment("Stripe", "Staff Engineer", JD)

--- a/tests/test_job_scraper.py
+++ b/tests/test_job_scraper.py
@@ -100,6 +100,67 @@ class TestScrapeJobUrl:
         assert len(data["jobs"]) == 1
         assert data["jobs"][0]["source"] == "https://stripe.com/jobs/123"
 
+    def test_raw_html_does_not_become_the_role(self, isolated_server, monkeypatch):
+        """A fetch that degrades to raw HTML instead of Reader markdown must
+        not put markup into the role — that reached the assessment prompt and
+        the saved filename, producing files like 'Coke <html> - Fitment
+        Assessment.md' that can never sync to a Windows peer."""
+        from tools import job_scraper as scraper
+
+        raw_html = (
+            "<html>\n<head><title>Senior Software Engineer</title></head>\n"
+            "<body>\n<h1>Senior Software Engineer</h1>\n"
+            "<p>Build payment systems at Coke.</p>\n</body>\n</html>"
+        )
+        _company, role, _desc = scraper._parse_job_from_markdown(
+            raw_html, "https://careers.coke.com/jobs/1")
+
+        # Before the fix this was the literal string "<html>".
+        assert not set('<>:"/\\|?*') & set(role), role
+        assert role == "Senior Software Engineer"
+
+    def test_markup_only_page_yields_no_role(self, isolated_server, monkeypatch):
+        """With nothing but markup there is no title to salvage — fail loudly
+        rather than queue a job whose role is a tag."""
+        monkeypatch.setattr(
+            "httpx.get", lambda *a, **kw: _mock_response("<html><body></body></html>"))
+        result = srv.scrape_job_url("https://careers.example.com/jobs/1")
+        assert "Could not extract a job title" in result
+
+    def test_non_job_page_is_not_queued(self, isolated_server, monkeypatch):
+        """A Cloudflare interstitial fetches fine and parses fine. Before the
+        guard it was queued and assessed, producing a real fitment report for
+        a job titled 'Just a moment...'."""
+        page = "Just a moment...\n\n" + ("Enable JavaScript and cookies to continue. " * 20)
+        monkeypatch.setattr("httpx.get", lambda *a, **kw: _mock_response(page))
+
+        result = srv.scrape_job_url("https://careers.example.com/jobs/1", auto_queue=True)
+
+        assert "does not look like a job posting" in result
+        assert "queue_job" in result
+        data = json.loads(srv.JOB_QUEUE_FILE.read_text()) if srv.JOB_QUEUE_FILE.exists() else {"jobs": []}
+        assert data.get("jobs", []) == [], "non-job page must not enter the pipeline"
+
+    def test_thin_page_is_rejected(self, isolated_server, monkeypatch):
+        """The catch-all for interstitials whose wording we have not seen."""
+        monkeypatch.setattr(
+            "httpx.get", lambda *a, **kw: _mock_response("Some Unknown Error Page\n\nnope"))
+
+        result = srv.scrape_job_url("https://careers.example.com/jobs/1")
+
+        assert "does not look like a job posting" in result
+        assert "too little to be a job description" in result
+
+    def test_real_posting_still_queues(self, isolated_server, monkeypatch):
+        """The guard must not reject genuine postings."""
+        monkeypatch.setattr("httpx.get", lambda *a, **kw: _mock_response(_SAMPLE_MARKDOWN))
+
+        result = srv.scrape_job_url("https://stripe.com/jobs/123", auto_queue=True)
+
+        assert "does not look like a job posting" not in result
+        assert "Scraped" in result
+
+
     def test_http_error_returns_friendly_message(self, isolated_server, monkeypatch):
         monkeypatch.setattr("httpx.get", lambda *a, **kw: _mock_response(status_code=403))
         result = srv.scrape_job_url("https://boards.greenhouse.io/stripe/jobs/12345")
@@ -179,6 +240,54 @@ class TestScrapeJobUrl:
         monkeypatch.setattr("httpx.get", _raise)
         result = srv.scrape_job_url("https://example.com/jobs/1")
         assert "Failed to fetch" in result
+
+
+# ── non-job page rejection ─────────────────────────────────────────────────────
+
+class TestNonJobDetection:
+    """Driven by the titles actually found in the production partition, each of
+    which had already cost a full LLM assessment."""
+
+    @pytest.mark.parametrize("title", [
+        "Bad Request",
+        "Just a moment...",
+        "The request could not be satisfied",
+        "File or directory not found.",
+        "Example Domain",
+        "Login - FullStack Connect",
+        "Email or phone Password Show Forgot password AI GTM Developer",
+        "Access Denied",
+        "Attention Required! | Cloudflare",
+        "403 Forbidden",
+        "Error 404",
+        "Page not found",
+        "Too Many Requests",
+        "<html>",
+        "Coca Colacompany <html>",
+        "Home, Rhode Island, United States URL Source: https://jobs.cvshealth.com/us/en",
+        "19 Luba jobs in Netherlands",
+        "by 2x See who you know Full Stack Software Engineer",
+    ])
+    def test_rejects_observed_junk_titles(self, title):
+        from tools import job_scraper as scraper
+
+        assert scraper._non_job_reason(title, "x" * 5000), f"not rejected: {title!r}"
+
+    @pytest.mark.parametrize("title", [
+        "Senior Software Engineer, Payments",
+        "Senior Engineer, Login Services",
+        "Staff Engineer - Identity and Sign In Platform",
+        "Software Engineer II - CRM",
+        "Lead AI Engineer",
+        "Principal Engineer, Access Management",
+        "Senior Backend Engineer (Password Infrastructure)",
+    ])
+    def test_accepts_genuine_titles(self, title):
+        """Anchoring the chrome patterns to the START of the title is what
+        keeps 'Login Services' and 'Sign In Platform' roles alive."""
+        from tools import job_scraper as scraper
+
+        assert scraper._non_job_reason(title, "x" * 5000) == "", title
 
 
 # ── search_jobs ────────────────────────────────────────────────────────────────

--- a/tests/test_rename_unrepresentable_files.py
+++ b/tests/test_rename_unrepresentable_files.py
@@ -1,0 +1,374 @@
+"""Tests for scripts/rename_unrepresentable_files.py — the one-off cleanup for
+pre-sanitize filenames sitting in a cloud partition.
+
+This script is run by hand against production via `kubectl exec`, so the
+behaviour that matters is: it never overwrites, it never edits content, and
+its rename rule does not drift from the one the application applies at
+creation.
+"""
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "rename_unrepresentable_files.py"
+
+# The fixtures below create files named `Coke <html>.md` — which Windows
+# refuses to create at all. That refusal *is* the bug this script cleans up
+# after, so the filesystem tests only mean anything on a POSIX filesystem
+# (CI and the AKS pod are both Linux). The rule-parity test is pure string
+# work and runs everywhere.
+posix_only = pytest.mark.skipif(
+    os.name == "nt",
+    reason="these filenames cannot exist on Windows — that is the condition under test",
+)
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("_rename_script", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_rename_script"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def script():
+    return _load_script()
+
+
+class TestRuleMatchesApplication:
+    def test_sanitize_matches_lib_helpers_exactly(self, script):
+        """The script inlines the rule so it can run standalone in the pod.
+        If lib.helpers ever changes, this fails and the script must follow."""
+        from lib.helpers import sanitize_filename as app_sanitize
+
+        cases = [
+            r'a<b>c:d"e/f\g|h?i*j',
+            "Coke <html> - Fitment Assessment.md",
+            "Home, RI URL Source: https://jobs.example.com - Fitment Assessment.md",
+            "Coke Senior Software Engineer | Atlanta, GA US - Fitment Assessment.md",
+            "report\x07.",
+            "name.md ",
+            "a   b",
+            "   ",
+            "...",
+            "already-fine.md",
+        ]
+        for name in cases:
+            assert script.sanitize_filename(name) == app_sanitize(name), name
+
+
+class TestPlanRenames:
+    """The planner is pure, so the logic that could destroy data is verified
+    on every platform — including Windows, where these names cannot exist."""
+
+    def test_leaves_representable_names_alone(self, script):
+        assert script.plan_renames(["fine.md", "also - fine.md"]) == []
+
+    def test_maps_the_real_production_names(self, script):
+        """The twelve stuck files are these shapes."""
+        names = [
+            "Coke <html> - Fitment Assessment.md",
+            "Ga <html> - Fitment Assessment.md",
+            "Coke Senior Software Engineer | Atlanta, GA US - Fitment Assessment.md",
+            "Home, Rhode Island, URL Source: https://x.com - Fitment Assessment.md",
+        ]
+        planned = dict((old, new) for old, new, _c in script.plan_renames(names))
+
+        assert planned["Coke <html> - Fitment Assessment.md"] == (
+            "Coke -html- - Fitment Assessment.md")
+        assert planned["Ga <html> - Fitment Assessment.md"] == (
+            "Ga -html- - Fitment Assessment.md")
+        assert planned[
+            "Coke Senior Software Engineer | Atlanta, GA US - Fitment Assessment.md"
+        ] == "Coke Senior Software Engineer - Atlanta, GA US - Fitment Assessment.md"
+        assert planned[
+            "Home, Rhode Island, URL Source: https://x.com - Fitment Assessment.md"
+        ] == "Home, Rhode Island, URL Source- https---x.com - Fitment Assessment.md"
+        for new in planned.values():
+            assert not set('<>:"/\\|?*') & set(new), new
+
+    def test_existing_clean_file_is_not_targeted(self, script):
+        """The sanitized name is already on disk with different content —
+        suffix rather than plan a rename that would clobber it."""
+        planned = script.plan_renames([
+            "Coke -html-.md",          # innocent bystander, already clean
+            "Coke <html>.md",          # sanitizes onto the bystander
+        ])
+
+        assert planned == [("Coke <html>.md", "Coke -html- (2).md", True)]
+
+    def test_two_bad_names_collapsing_to_one_target_get_distinct_names(self, script):
+        planned = script.plan_renames(["Coke <html>.md", "Coke |html|.md"])
+
+        targets = [new for _o, new, _c in planned]
+        assert len(planned) == 2
+        assert len(set(targets)) == 2, f"both planned the same target: {targets}"
+        assert "Coke -html-.md" in targets
+        assert "Coke -html- (2).md" in targets
+
+    def test_three_way_collision_all_distinct(self, script):
+        planned = script.plan_renames(["a<b>.md", "a|b|.md", "a?b*.md"])
+
+        targets = [new for _o, new, _c in planned]
+        assert sorted(targets) == ["a-b- (2).md", "a-b- (3).md", "a-b-.md"]
+
+    def test_extensionless_name_suffixes_correctly(self, script):
+        planned = script.plan_renames(["a-b", "a<b"])
+        assert planned == [("a<b", "a-b (2)", True)]
+
+    def test_no_target_ever_equals_another_source(self, script):
+        """A target that collides with a file still waiting to be renamed
+        would be overwritten when its turn came."""
+        names = ["x<1>.md", "x-1-.md", "x|1|.md", "keep.md"]
+        planned = script.plan_renames(names)
+
+        targets = {new for _o, new, _c in planned}
+        sources = {old for old, _n, _c in planned}
+        untouched = set(names) - sources
+        assert not (targets & sources), targets & sources
+        assert not (targets & untouched), targets & untouched
+
+
+class TestMainOrchestrationOnAnyPlatform:
+    """Drives main() over a faked walk so the dry-run/apply contract is
+    verified on Windows too — the real filesystem tests below cannot run here."""
+
+    @pytest.fixture
+    def fake_tree(self, script, monkeypatch, tmp_path):
+        walked = [(
+            str(tmp_path / "07-Job-Assessments" / "run_job_assessment"),
+            [],
+            ["Coke <html> - Fitment Assessment.md", "fine.md"],
+        )]
+        monkeypatch.setattr(script.os, "walk", lambda _root: iter(walked))
+
+        calls: list[tuple[str, str]] = []
+        monkeypatch.setattr(
+            script.os, "rename", lambda src, dst: calls.append((str(src), str(dst))))
+        return calls
+
+    def test_dry_run_renames_nothing(self, script, fake_tree, tmp_path, capsys):
+        rc = script.main(["--root", str(tmp_path)])
+        out = capsys.readouterr().out
+
+        assert rc == 0
+        assert fake_tree == [], "dry run must not call rename"
+        assert "DRY RUN" in out
+        assert "files needing rename: 1" in out
+
+    def test_dry_run_prints_before_and_after(self, script, fake_tree, tmp_path, capsys):
+        script.main(["--root", str(tmp_path)])
+        out = capsys.readouterr().out
+
+        assert "Coke <html> - Fitment Assessment.md" in out
+        assert "Coke -html- - Fitment Assessment.md" in out
+        assert "fine.md" not in out, "untouched files should not be listed"
+
+    def test_apply_renames_only_the_bad_name(self, script, fake_tree, tmp_path, capsys):
+        rc = script.main(["--root", str(tmp_path), "--apply"])
+        out = capsys.readouterr().out
+
+        assert rc == 0
+        assert len(fake_tree) == 1
+        src, dst = fake_tree[0]
+        assert src.endswith("Coke <html> - Fitment Assessment.md")
+        assert dst.endswith("Coke -html- - Fitment Assessment.md")
+        assert "renamed: 1    skipped: 0    failed: 0" in out
+
+    def test_output_is_ascii_only(self, script, fake_tree, tmp_path, capsys):
+        """A non-ASCII character in the output raises UnicodeEncodeError on a
+        non-UTF-8 stdout, which under --apply aborts the run *after* some
+        files have already been renamed. Found by a live run, not by a unit
+        test — keep it locked down."""
+        script.main(["--root", str(tmp_path), "--apply"])
+        out = capsys.readouterr().out
+
+        # The filenames themselves may be non-ASCII; the script's own
+        # decoration must not be.
+        decoration = out.replace("Coke <html> - Fitment Assessment.md", "")
+        decoration = decoration.replace("Coke -html- - Fitment Assessment.md", "")
+        decoration.encode("ascii")  # raises if the script added a fancy glyph
+
+    def test_rename_failure_is_reported_and_exits_nonzero(
+        self, script, monkeypatch, fake_tree, tmp_path, capsys
+    ):
+        def _boom(src, dst):
+            raise OSError("read-only filesystem")
+
+        monkeypatch.setattr(script.os, "rename", _boom)
+        rc = script.main(["--root", str(tmp_path), "--apply"])
+        out = capsys.readouterr().out
+
+        assert rc == 1
+        assert "FAILED" in out
+        assert "read-only filesystem" in out
+
+
+@posix_only
+class TestDuplicateDetection:
+    """Every one of the twelve production files turned out to have a
+    clean-named twin beside it: the same assessment re-saved after the July
+    sanitize fix, orphaning the old copy. Renaming those just duplicates
+    them, so identical content is left alone unless forced."""
+
+    def test_identical_twin_is_skipped_not_renamed(self, script, tmp_path):
+        (tmp_path / "Coke -html-.md").write_text("SAME BYTES")
+        (tmp_path / "Coke <html>.md").write_text("SAME BYTES")
+
+        rc = script.main(["--root", str(tmp_path), "--apply"])
+
+        assert rc == 0
+        assert (tmp_path / "Coke <html>.md").exists(), "duplicate should be left in place"
+        assert not (tmp_path / "Coke -html- (2).md").exists(), "should not have duplicated"
+
+    def test_identical_twin_is_reported_as_such(self, script, tmp_path, capsys):
+        (tmp_path / "Coke -html-.md").write_text("SAME BYTES")
+        (tmp_path / "Coke <html>.md").write_text("SAME BYTES")
+
+        script.main(["--root", str(tmp_path)])
+        out = capsys.readouterr().out
+
+        assert "byte-identical" in out
+        assert "SKIPPED" in out
+        assert "--force-duplicates" in out
+
+    def test_differing_twin_is_still_renamed(self, script, tmp_path):
+        """Different content is real data - suffix it and keep both."""
+        (tmp_path / "Coke -html-.md").write_text("VERSION A")
+        (tmp_path / "Coke <html>.md").write_text("VERSION B")
+
+        rc = script.main(["--root", str(tmp_path), "--apply"])
+
+        assert rc == 0
+        assert (tmp_path / "Coke -html-.md").read_text() == "VERSION A"
+        assert (tmp_path / "Coke -html- (2).md").read_text() == "VERSION B"
+        assert not (tmp_path / "Coke <html>.md").exists()
+
+    def test_differing_twin_is_flagged_loudly(self, script, tmp_path, capsys):
+        (tmp_path / "Coke -html-.md").write_text("VERSION A")
+        (tmp_path / "Coke <html>.md").write_text("VERSION B")
+
+        script.main(["--root", str(tmp_path)])
+
+        assert "DIFFERENT content" in capsys.readouterr().out
+
+    def test_force_duplicates_renames_identical_twin(self, script, tmp_path):
+        (tmp_path / "Coke -html-.md").write_text("SAME BYTES")
+        (tmp_path / "Coke <html>.md").write_text("SAME BYTES")
+
+        rc = script.main(
+            ["--root", str(tmp_path), "--apply", "--force-duplicates"])
+
+        assert rc == 0
+        assert (tmp_path / "Coke -html- (2).md").read_text() == "SAME BYTES"
+        assert not (tmp_path / "Coke <html>.md").exists()
+
+    def test_no_twin_at_all_renames_normally(self, script, tmp_path):
+        """The non-collision path must be unaffected by duplicate checking."""
+        (tmp_path / "Coke <html>.md").write_text("ONLY COPY")
+
+        rc = script.main(["--root", str(tmp_path), "--apply"])
+
+        assert rc == 0
+        assert (tmp_path / "Coke -html-.md").read_text() == "ONLY COPY"
+
+
+@posix_only
+class TestFindRenames:
+    def test_flags_only_unrepresentable_names(self, script, tmp_path):
+        (tmp_path / "fine.md").write_text("ok")
+        (tmp_path / "Coke <html> - Fitment Assessment.md").write_text("bad")
+
+        planned = script.find_renames(tmp_path)
+
+        assert len(planned) == 1
+        source, target, collided = planned[0]
+        assert source.name == "Coke <html> - Fitment Assessment.md"
+        assert target.name == "Coke -html- - Fitment Assessment.md"
+        assert collided is False
+
+    def test_walks_nested_assessment_folders(self, script, tmp_path):
+        for parent in ("07-Job-Assessments", "workspace/07-Job-Assessments"):
+            nested = tmp_path / parent / "run_job_assessment"
+            nested.mkdir(parents=True)
+            (nested / "Ga <html> - Fitment Assessment.md").write_text("x")
+
+        planned = script.find_renames(tmp_path)
+
+        assert len(planned) == 2
+        assert all("<" not in t.name for _s, t, _c in planned)
+
+    def test_skips_machine_local_dirs(self, script, tmp_path):
+        db = tmp_path / "db"
+        db.mkdir()
+        (db / "weird:name.sqlite").write_text("x")
+
+        assert script.find_renames(tmp_path) == []
+
+
+@posix_only
+class TestCollisionHandling:
+    def test_suffixes_instead_of_overwriting(self, script, tmp_path):
+        (tmp_path / "Coke -html- - Fitment Assessment.md").write_text("EXISTING")
+        (tmp_path / "Coke <html> - Fitment Assessment.md").write_text("INCOMING")
+
+        rc = script.main(["--root", str(tmp_path), "--apply"])
+
+        assert rc == 0
+        assert (tmp_path / "Coke -html- - Fitment Assessment.md").read_text() == "EXISTING"
+        assert (tmp_path / "Coke -html- - Fitment Assessment (2).md").read_text() == "INCOMING"
+
+    def test_two_bad_names_collapsing_to_one_target_both_survive(self, script, tmp_path):
+        (tmp_path / "Coke <html>.md").write_text("first")
+        (tmp_path / "Coke |html|.md").write_text("second")
+
+        rc = script.main(["--root", str(tmp_path), "--apply"])
+
+        assert rc == 0
+        contents = sorted(p.read_text() for p in tmp_path.glob("*.md"))
+        assert contents == ["first", "second"], "a file was overwritten"
+        assert len(list(tmp_path.glob("*.md"))) == 2
+
+
+@posix_only
+class TestDryRunAndOutput:
+    def test_dry_run_changes_nothing_and_prints_mapping(self, script, tmp_path, capsys):
+        bad = tmp_path / "Coke <html> - Fitment Assessment.md"
+        bad.write_text("content")
+
+        rc = script.main(["--root", str(tmp_path)])
+        out = capsys.readouterr().out
+
+        assert rc == 0
+        assert bad.exists(), "dry run must not rename"
+        assert "DRY RUN" in out
+        assert "Coke <html> - Fitment Assessment.md" in out
+        assert "Coke -html- - Fitment Assessment.md" in out
+
+    def test_apply_preserves_content_and_mtime(self, script, tmp_path):
+        bad = tmp_path / "Home, RI Source: x.md"
+        bad.write_text("PRECIOUS ASSESSMENT TEXT")
+        import os
+        os.utime(bad, (1_600_000_000, 1_600_000_000))
+
+        script.main(["--root", str(tmp_path), "--apply"])
+
+        survivors = list(tmp_path.glob("*.md"))
+        assert len(survivors) == 1
+        assert survivors[0].read_text() == "PRECIOUS ASSESSMENT TEXT"
+        assert survivors[0].stat().st_mtime == 1_600_000_000
+
+    def test_clean_tree_reports_nothing_to_do(self, script, tmp_path, capsys):
+        (tmp_path / "fine.md").write_text("ok")
+
+        rc = script.main(["--root", str(tmp_path)])
+
+        assert rc == 0
+        assert "Nothing to do" in capsys.readouterr().out
+
+    def test_missing_root_is_an_error(self, script, tmp_path):
+        assert script.main(["--root", str(tmp_path / "nope")]) == 2

--- a/tools/job_scraper.py
+++ b/tools/job_scraper.py
@@ -265,7 +265,11 @@ def _parse_job_from_markdown(text: str, url: str) -> tuple[str, str, str]:
     """
     Return (company, role, description) extracted from Jina Reader markdown.
 
-    Role   : first non-empty short line (likely the page title / h1).
+    Role   : first non-empty short line (likely the page title / h1). Tags are
+             stripped first — when a fetch degrades to raw HTML instead of
+             Reader markdown, the first line is markup like "<html>", and
+             taking it verbatim put literal "<html>" into the role, the
+             assessment prompt, and the saved filename.
     Company: heuristic scan of the first 30 lines for "at <Company>" patterns
              or a "<Company> |" / "<Company> •" separator; falls back to the
              URL-derived name.
@@ -275,7 +279,7 @@ def _parse_job_from_markdown(text: str, url: str) -> tuple[str, str, str]:
 
     role = ""
     for line in lines:
-        stripped = line.strip().lstrip("#").strip()
+        stripped = _strip_html(line).lstrip("#").strip()
         if stripped and len(stripped) < 120:
             role = stripped
             break
@@ -301,6 +305,72 @@ def _parse_job_from_markdown(text: str, url: str) -> tuple[str, str, str]:
     return company, role, description
 
 
+# A fetch that lands on an error body, a bot interstitial or a login wall still
+# parses fine — it just isn't a posting. Before this guard, each one was queued
+# and handed to the LLM, producing a real assessment of a job titled
+# "Bad Request" or "Just a moment...". One partition held 13 such files.
+
+# Unambiguous error/interstitial text, rejected wherever it appears in the
+# title: none of these occur in a genuine job title.
+_ERROR_TITLE_RE = re.compile(
+    r"\b(?:"
+    r"bad request|forbidden|unauthorized|access denied|access to this page"
+    r"|the request could not be satisfied"
+    r"|file or directory not found|page not found|page cannot be found"
+    r"|just a moment|attention required|checking your browser"
+    r"|are you a robot|verify you are human|security check"
+    r"|example domain"
+    r"|service unavailable|temporarily unavailable|too many requests"
+    r"|error \d{3}|http \d{3}"
+    # Jina Reader's own header fields leaking into the title.
+    r"|url source:|markdown content:|published time:"
+    # LinkedIn page chrome, and its search-results pages ("19 Luba jobs in
+    # Netherlands") which are listings, not postings.
+    r"|see who you know|jobs in\b"
+    # No trailing \b on the group: several alternatives end in ':', which is
+    # not a word character, so a trailing boundary could never match them.
+    r")",
+    re.IGNORECASE,
+)  # NOSONAR — fixed alternation over trusted page text
+
+# Residual markup in the title means extraction degraded to raw HTML. The
+# tag-stripping in _parse_job_from_markdown should prevent this; belt and
+# braces, because the failure is silent and expensive.
+_MARKUP_TITLE_RE = re.compile(r"<\s*/?\s*[a-z!]", re.IGNORECASE)
+
+# Page chrome meaning the extractor grabbed a login wall or a spinner rather
+# than the posting. Anchored to the START of the title on purpose: a real
+# posting like "Senior Engineer, Login Services" must not be rejected.
+_CHROME_PREFIX_RE = re.compile(
+    r"^(?:log ?in|sign ?in|email or phone|password|loading|please wait"
+    r"|enable javascript|javascript is required|redirecting)\b",
+    re.IGNORECASE,
+)  # NOSONAR — fixed alternation over trusted page text
+
+# A real posting runs to thousands of characters; error bodies are tiny. This
+# is the catch-all for interstitials whose wording we have not seen yet.
+_MIN_JOB_DESCRIPTION_CHARS = 300
+
+
+def _non_job_reason(role: str, description: str) -> str:
+    """Return why this page is not a job posting, or '' if it looks like one."""
+    title = role.strip()
+    if _MARKUP_TITLE_RE.search(title):
+        return f"the title still contains markup ({title!r})"
+    if _ERROR_TITLE_RE.search(title):
+        return f"the title reads as an error or interstitial page ({title!r})"
+    if _CHROME_PREFIX_RE.match(title):
+        return f"the title is page chrome, not a posting ({title!r})"
+
+    body = description.strip()
+    if len(body) < _MIN_JOB_DESCRIPTION_CHARS:
+        return (
+            f"only {len(body)} characters of content were extracted, "
+            f"too little to be a job description"
+        )
+    return ""
+
+
 # ── Public API ────────────────────────────────────────────────────────────────
 
 def scrape_job_url(url: str, auto_queue: bool = True, page_text: str = "") -> str:
@@ -321,6 +391,10 @@ def scrape_job_url(url: str, auto_queue: bool = True, page_text: str = "") -> st
         page_text:  Optional client-supplied page content. When non-empty it
                     is trusted as the posting text and the URL is only used
                     for metadata (company-from-URL, source link).
+
+    Pages that fetch successfully but are not postings — error bodies, bot
+    interstitials, login walls — are rejected here rather than queued, so no
+    LLM assessment is spent on them.
     """
     if page_text.strip():
         text = page_text
@@ -346,6 +420,14 @@ def scrape_job_url(url: str, auto_queue: bool = True, page_text: str = "") -> st
         return (
             f"Could not extract a job title from {url}. "
             "Try queuing manually with queue_job(company, role, jd)."
+        )
+
+    non_job = _non_job_reason(role, description)
+    if non_job:
+        return (
+            f"{url} does not look like a job posting: {non_job}. "
+            "Nothing was queued and no assessment was run. "
+            "If that is wrong, add it manually with queue_job(company, role, jd)."
         )
 
     if not auto_queue:


### PR DESCRIPTION
## What happened

A fetch that lands on an error body, a bot interstitial or a login wall still parses cleanly — it just isn't a posting. The extracted "role" became whatever the page said, the job was queued, and `run_job_assessment` spent a full LLM call producing a real fitment report for it.

One production partition held **13 such assessments**, each looking legitimate in the dashboard:

| Title assessed | What the page actually was |
| --- | --- |
| `Accenture Bad Request`, `Aig Bad Request`, `Careers Bad Request` | HTTP 400 bodies |
| `Indeed Just a moment...` | Cloudflare interstitial |
| `Wbd The request could not be satisfied` | CDN error page |
| `Pinterestcareers File or directory not found.` | 404 |
| `Example Example Domain` | `example.com` |
| `FullStack Login - FullStack Connect`, `Salesforce Email or phone Password Show Forgot password AI GTM Developer` | auth walls |
| `Linkedin 19 Luba jobs in Netherlands` | a search-results page, not a posting |
| `Coke <html>`, `Ga <html>`, `Coca Colacompany <html>` | raw HTML that never parsed |

That's >10% of the assessments in that folder — wasted tokens, and documents that read as real analysis.

## Root cause

Two defects, one symptom.

**1. Markup reached the role.** `_parse_job_from_markdown` took the first non-empty line under 120 chars verbatim. When a fetch degraded to raw HTML instead of Reader markdown, that line was literally `<html>`. Tags are now stripped before the line is chosen, so `<h1>Senior Engineer</h1>` yields the title, and a markup-only page yields no role at all — hitting the existing "could not extract a job title" path.

**2. Nothing ever asked whether the page was a posting.** `scrape_job_url` now rejects, before queuing:

- residual markup in the title
- unambiguous error/interstitial text (`Bad Request`, `Just a moment...`, `403 Forbidden`, `Example Domain`, …)
- Jina Reader's own header fields (`URL Source:`) leaking into the role
- LinkedIn chrome (`see who you know`) and its `N jobs in X` listing pages
- auth-wall chrome (`Login`, `Sign in`, `Email or phone`, `Password`) **anchored to the start of the title**
- any body under 300 characters — the catch-all for wordings not seen yet

Anchoring the chrome patterns to the *start* is what keeps genuine roles like `Senior Engineer, Login Services` and `Staff Engineer - Identity and Sign In Platform` alive.

Rejection returns a message naming the reason and pointing at `queue_job`, and queues nothing.

## Blast radius

- **Mobile capture is covered by the same change** — the worker only proceeds on a `Queued:` response, so no assessment runs there either.
- **Greenhouse / Lever / SerpAPI paths are untouched** — their titles come from structured APIs, not page scraping.

## Verification

Validated against the ~120 real assessment titles from the production partition:

- **15/15 junk titles rejected**
- **59/59 genuine titles preserved** — zero false positives

Full suite: 1712 passed. The 9 failures on the author's Windows box are pre-existing (cp1252/WeasyPrint) and fail identically on a stashed clean tree.

## Also included

`scripts/rename_unrepresentable_files.py` — the one-off cleanup for pre-sanitize filenames that can never sync to a Windows peer (`lib/sync_client.py` skips them on every sync, forever).

Running it against production settled the question it was written for: **all 12 stuck files were byte-identical duplicates** of files already present under clean names. Nothing was stranded. The script now hashes each candidate against its clean-named twin and skips identical ones rather than creating pointless ` (2)` copies; differing content is still recovered.

It is dry-run by default, never overwrites, and prints a before/after mapping. The collision logic is a pure function so it can be tested on Windows, where these filenames cannot even be created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
