### PR TITLE
fix(scraper): reject thin pages that carry no job-posting vocabulary

### DIFF
--- a/tests/test_job_scraper.py
+++ b/tests/test_job_scraper.py
@@ -200,7 +200,12 @@ class TestScrapeJobUrl:
         guest_html = (
             '<h2 class="top-card-layout__title">Senior Platform Engineer</h2>'
             '<h4>at Cox Automotive</h4>'
-            '<div class="description__text">' + "Build the dealer platform. " * 20 + "</div>"
+            # Reads like an actual posting: the thin-page guard asks for the
+            # vocabulary every real job description carries, and filler text
+            # repeated 20 times is not a realistic stand-in for one.
+            '<div class="description__text">'
+            + "Build the dealer platform. You will need experience with distributed systems. " * 20
+            + "</div>"
         )
 
         def fake_get(url, *a, **kw):
@@ -288,6 +293,46 @@ class TestNonJobDetection:
         from tools import job_scraper as scraper
 
         assert scraper._non_job_reason(title, "x" * 5000) == "", title
+
+    def test_thin_page_without_job_vocabulary_is_rejected(self):
+        """Regression from qa: r.jina.ai served a cached snapshot of
+        example.com titled 'Test Document' with 320 characters of body. No
+        error phrase to match and past the length floor, so it queued —
+        exactly the class of page that produced junk assessments in prod."""
+        from tools import job_scraper as scraper
+
+        body = (
+            "## Test Article\n\nThis is a test article with some content for "
+            "Jina to extract.\n\nIt contains multiple paragraphs to test the "
+            "HTML parsing functionality.\n" * 2
+        )
+        assert len(body.strip()) > scraper._MIN_JOB_DESCRIPTION_CHARS
+        reason = scraper._non_job_reason("Test Document", body)
+        assert reason, "thin non-job page should be rejected"
+        assert "vocabulary" in reason
+
+    def test_short_but_genuine_posting_survives(self):
+        """A terse real posting is shorter than the thin-page threshold, so
+        the vocabulary check is what keeps it from being rejected."""
+        from tools import job_scraper as scraper
+
+        body = (
+            "Senior Backend Engineer\n\nWe are looking for an engineer to "
+            "join the platform team.\n\nRequirements: 5+ years of experience "
+            "with distributed systems, strong Python, and a track record of "
+            "owning services end to end. You will design APIs, run them in "
+            "production, and mentor other engineers.\n\nApply online today."
+        )
+        assert scraper._MIN_JOB_DESCRIPTION_CHARS < len(body.strip()) < scraper._THIN_BODY_CHARS
+        assert scraper._non_job_reason("Senior Backend Engineer", body) == ""
+
+    def test_long_page_without_vocabulary_is_left_alone(self):
+        """Above the thin threshold we stop guessing: an unusual posting is
+        likelier than an error body that verbose, and a false reject costs
+        more than a false accept."""
+        from tools import job_scraper as scraper
+
+        assert scraper._non_job_reason("Some Unusual Title", "lorem ipsum " * 300) == ""
 
 
 # ── search_jobs ────────────────────────────────────────────────────────────────

--- a/tools/job_scraper.py
+++ b/tools/job_scraper.py
@@ -347,9 +347,27 @@ _CHROME_PREFIX_RE = re.compile(
     re.IGNORECASE,
 )  # NOSONAR — fixed alternation over trusted page text
 
-# A real posting runs to thousands of characters; error bodies are tiny. This
-# is the catch-all for interstitials whose wording we have not seen yet.
+# A real posting runs to thousands of characters; error bodies are tiny.
 _MIN_JOB_DESCRIPTION_CHARS = 300
+
+# Matching only known error wordings catches only what we have already seen.
+# qa proved the gap: r.jina.ai served a cached snapshot of example.com titled
+# "Test Document" with 320 characters of body — past the length floor, and no
+# error phrase to match, so it queued. The generalisable signal is the
+# absence of job-posting vocabulary, not the presence of error vocabulary.
+#
+# Applied only to thin pages: a long page without these words is more likely
+# a posting written in a way we did not anticipate than an error body, and
+# rejecting it would cost more than letting it through.
+_THIN_BODY_CHARS = 1500
+_JOB_VOCAB_RE = re.compile(
+    r"\b(?:responsibilit|qualificat|requirement|experience|skill"
+    r"|you will|we are looking|who you are|what you.ll do"
+    r"|apply|salary|compensation|benefit|equal opportunity"
+    r"|role|position|candidate|hiring|employment|full[- ]time"
+    r")",
+    re.IGNORECASE,
+)  # NOSONAR — fixed alternation over trusted page text
 
 
 def _non_job_reason(role: str, description: str) -> str:
@@ -367,6 +385,11 @@ def _non_job_reason(role: str, description: str) -> str:
         return (
             f"only {len(body)} characters of content were extracted, "
             f"too little to be a job description"
+        )
+    if len(body) < _THIN_BODY_CHARS and not _JOB_VOCAB_RE.search(body):
+        return (
+            f"{len(body)} characters of content with none of the vocabulary a "
+            f"job posting always carries (requirements, experience, apply, ...)"
         )
     return ""
 


### PR DESCRIPTION
Follow-up to #200, found **in qa** rather than by the unit tests — which is the point of deploying there.

## What qa showed

I pointed the freshly deployed qa pod at `https://example.com`, the page that produced `Example Example Domain - Fitment Assessment.md` in production. It was still accepted:

```
Title: Test Document
URL Source: https://example.com/
Warning: This is a cached snapshot of the original page, consider retry with caching opt-out.
Markdown Content:
## Test Article
This is a test article with some content for Jina to extract.
```

- `r.jina.ai` now serves a **cached snapshot titled "Test Document"** — no error phrase to match
- body is **320 characters** — past the 300-char floor

So it queued, and would have cost another assessment.

## Why the first fix was not enough

Matching known error wordings only ever catches what has already been seen. `Bad Request` and `Just a moment...` were in the list because they had already burned tokens.

The generalisable signal is the **absence of job-posting vocabulary**, not the presence of error vocabulary. A page under 1500 characters containing none of `requirements / experience / apply / responsibilities / salary / candidate / …` is not a posting, whatever its title claims.

Deliberately scoped to thin pages: above that threshold, an unusually-worded posting is likelier than an error body that verbose, and a false reject costs more than a false accept.

## One test fixture changed, and why

`test_linkedin_guest_fallback_rescues_blocked_direct` began failing. Its body was `"Build the dealer platform. "` repeated 20 times — 629 characters carrying no job vocabulary whatsoever, which no real job description does.

I made the fixture realistic rather than lowering the threshold to accommodate it. Tuning the guard to fit synthetic filler would have fitted it to a test artifact instead of to production data. Flagging it explicitly since editing an existing test to make a change pass deserves scrutiny.

## Verification

- Re-validated against the real assessment titles from the production partition: **11/11 junk rejected, 25/25 genuine preserved**
- New tests cover the qa regression, a short-but-genuine posting surviving on vocabulary alone, and a long unusual page being left alone
- Full suite: 1792 passed (9 pre-existing Windows-local failures unchanged)

I will re-run the same live qa check after this deploys, and only promote to main once `example.com` actually comes back rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
