### PR TITLE
docs(config): add side_project_repos and github_metrics to config.example.json

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -5,6 +5,11 @@
     "/path/to/your/primary-side-project",
     "/path/to/another-project"
   ],
+  "_comment_side_project_repos": "Remote repos for the skills scan when no local checkout exists — each is shallow-cloned to a temp dir and scanned. Entries are either a plain clone URL string or {\"url\": ..., \"branch\": ...}.",
+  "side_project_repos": [
+    "https://github.com/you/your-project.git",
+    {"url": "https://github.com/you/another-project.git", "branch": "main"}
+  ],
   "data_folder": "/path/to/job-search-mcp/data",
   "fb_friends_folder": "/path/to/facebook-export/friends",
 
@@ -26,6 +31,12 @@
   "openai_api_key": "sk-...your-key-here",
   "openai_model": "gpt-4o-mini",
   "serpapi_key": "",
+
+  "_comment_github_metrics": "Repos tracked by refresh_portfolio_metrics (traffic snapshots). Repo entries may be bare names (combined with username) or full owner/name slugs. Auth comes from env GITHUB_TOKEN or the gh CLI keyring — never stored here; the traffic API needs push access to each repo.",
+  "github_metrics": {
+    "username": "your-github-username",
+    "repos": ["your-project", "someone-else/shared-repo"]
+  },
 
   "_comment_llm_provider": "Set llm_provider to 'openai' (default), 'ollama' (local, no key), 'anthropic' (Claude BYOK), or 'foundry' (Azure AI Foundry). The LLM_PROVIDER env var overrides this.",
   "llm_provider": "openai",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,6 +97,7 @@ Every knob the code actually reads, derived from source. Two layers: **environme
 | `generation_budgets` | see [generation.md](generation.md) | Token budgets for context packing |
 | `github_metrics` | — | `{username, repos}` for portfolio tracking |
 | `side_project_folders` | `[]` | Array of folders for the skill scanner |
+| `side_project_repos` | `[]` | Remote repos for the skill scanner (URL string or `{url, branch}`); shallow-cloned to a temp dir when no local checkout exists |
 | `latex_resume_dir` / `resume_pdfs_dir` | — / `03-Resume-PDFs` | Owner-only LaTeX assets; PDF output dir |
 
 Provider selection notes:


### PR DESCRIPTION
Frank noticed config.example.json has no line for GitHub repos to be scanned. Two keys the code reads were missing from the example:

- `side_project_repos` — remote repos the skills scan (`scan_project_for_skills`, tools/project_scanner.py) shallow-clones to a temp dir when no local checkout exists. Plain clone-URL string or `{url, branch}` object.
- `github_metrics` — `{username, repos}` tracked by `refresh_portfolio_metrics` (tools/github.py). Bare repo names combine with username; full owner/name slugs also accepted. Comment notes auth comes from env `GITHUB_TOKEN` / gh CLI keyring, never the config file.

Also adds the missing `side_project_repos` row to the docs/configuration.md key table (`github_metrics` was already there).

Docs/example-only, no code change. JSON validated. Branched off qa, independent of #202.

Do not merge — Frank merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>