### PR TITLE
fix(llm): key learned quirks by endpoint and call site, not model name

### DIFF
--- a/lib/openai_calls.py
+++ b/lib/openai_calls.py
@@ -61,31 +61,58 @@ def _retry_after_seconds(exc: Exception, fallback: float) -> float:
 # default sampling is what the provider wants us to use anyway.
 _DROPPABLE_PARAMS = ("temperature", "top_p", "presence_penalty", "frequency_penalty")
 
-# Per-model quirks learned at runtime, kept for the life of the process so
-# the discovery cost (a rejected 400 or an empty-at-cap response) is paid
-# once, not on every call — the calibration run paid 3 requests per judge
-# call rediscovering the same two claude-sonnet-5 quirks 25 times.
+# Quirks learned at runtime, kept for the life of the process so the
+# discovery cost (a rejected 400 or an empty-at-cap response) is paid once,
+# not on every call — the calibration run paid 3 requests per judge call
+# rediscovering the same two claude-sonnet-5 quirks 25 times.
+#
+# Keyed by endpoint AND model, never model alone: the judge split routinely
+# puts the same model name behind two different providers (generator on
+# foundry, judge on openai or anthropic), and those endpoints do not accept
+# the same params. A quirk observed at one is not evidence about the other,
+# so a model-only key would let the judge's discovery silently reshape every
+# generator request — the wrong direction for a param the generator needs.
 _MODEL_REJECTED_PARAMS: "dict[str, set[str]]" = {}
-_MODEL_MIN_CAP: "dict[str, int]" = {}
+# Additionally keyed by label. The empty-at-cap floor is a property of the
+# prompt as much as the model: an eval_judge call reasons its way through a
+# 30KB master resume and needs 8000, while a short summarize call is fine at
+# 2000. Keying by model alone let one big call site raise the floor for every
+# small one, quietly multiplying their budgets.
+_MODEL_MIN_CAP: "dict[tuple[str, str], int]" = {}
 _RENAME_MAX_TOKENS = "max_tokens→max_completion_tokens"
 
 
-def _apply_model_memory(kwargs: dict) -> None:
-    """Preemptively apply quirks previously learned for this model."""
+def _memory_key(client: Any, kwargs: dict) -> str:
+    """Endpoint-qualified model identity for the quirk caches.
+
+    Returns "" when the model is unknown, which disables memory entirely
+    rather than lumping every unnamed call under one shared key.
+    """
     model = str(kwargs.get("model") or "")
     if not model:
+        return ""
+    try:
+        endpoint = str(getattr(client, "base_url", "") or "")
+    except Exception:  # a client whose base_url property raises is not fatal
+        endpoint = ""
+    return f"{endpoint}|{model}"
+
+
+def _apply_model_memory(kwargs: dict, key: str, label: str) -> None:
+    """Preemptively apply quirks previously learned for this endpoint+model."""
+    if not key:
         return
-    for param in _MODEL_REJECTED_PARAMS.get(model, ()):
+    for param in _MODEL_REJECTED_PARAMS.get(key, ()):
         if param == _RENAME_MAX_TOKENS:
             if "max_tokens" in kwargs:
                 kwargs["max_completion_tokens"] = kwargs.pop("max_tokens")
         else:
             kwargs.pop(param, None)
-    floor = _MODEL_MIN_CAP.get(model, 0)
+    floor = _MODEL_MIN_CAP.get((key, label), 0)
     if floor:
-        for key in ("max_tokens", "max_completion_tokens"):
-            if kwargs.get(key) and kwargs[key] < floor:
-                kwargs[key] = floor
+        for cap_key in ("max_tokens", "max_completion_tokens"):
+            if kwargs.get(cap_key) and kwargs[cap_key] < floor:
+                kwargs[cap_key] = floor
 
 
 def _drop_rejected_param(kwargs: dict, payload: str) -> "str | None":
@@ -112,8 +139,8 @@ def create_chat_completion(client: Any, *, label: str = "chat", max_attempts: in
     do not burst into the same rolling TPM/RPM window.
     """
     global _LAST_CHAT_CALL
-    _apply_model_memory(kwargs)
-    model_name = str(kwargs.get("model") or "")
+    memory_key = _memory_key(client, kwargs)
+    _apply_model_memory(kwargs, memory_key, label)
     # Collected locally and committed to the shared per-model memory only on
     # eventual success — a 400 whose retry then ALSO fails (wrong diagnosis,
     # or a second unrelated problem) must not permanently poison every future
@@ -223,8 +250,9 @@ def create_chat_completion(client: Any, *, label: str = "chat", max_attempts: in
                 completion_tokens,
                 total_tokens,
             )
-            if learned_rejected and model_name:
-                _MODEL_REJECTED_PARAMS.setdefault(model_name, set()).update(learned_rejected)
-            if learned_cap and model_name:
-                _MODEL_MIN_CAP[model_name] = max(_MODEL_MIN_CAP.get(model_name, 0), learned_cap)
+            if learned_rejected and memory_key:
+                _MODEL_REJECTED_PARAMS.setdefault(memory_key, set()).update(learned_rejected)
+            if learned_cap and memory_key:
+                cap_key = (memory_key, label)
+                _MODEL_MIN_CAP[cap_key] = max(_MODEL_MIN_CAP.get(cap_key, 0), learned_cap)
             return response

--- a/tests/test_openai_calls.py
+++ b/tests/test_openai_calls.py
@@ -290,7 +290,9 @@ def test_rejected_param_not_remembered_when_retry_never_succeeds(monkeypatch):
             messages=[{"role": "user", "content": "hi"}],
             temperature=0.0, max_tokens=5, max_attempts=3,
         )
-    assert oc._MODEL_REJECTED_PARAMS.get("claude-sonnet-5", set()) == set()
+    assert oc._MODEL_REJECTED_PARAMS.get(
+        oc._memory_key(client, {"model": "claude-sonnet-5"}), set()
+    ) == set()
 
     # A later call to the SAME model still sends temperature — nothing was
     # learned from the failed attempt.
@@ -301,3 +303,94 @@ def test_rejected_param_not_remembered_when_retry_never_succeeds(monkeypatch):
         temperature=0.0, max_tokens=5,
     )
     assert "temperature" in client2.calls[0]
+
+
+class _EmptyBelowFloor:
+    """Returns an empty message that consumed the whole cap whenever the cap
+    is under 4000 and not yet seen — so a bumped retry succeeds."""
+
+    def __init__(self):
+        self.calls = []
+        self.chat = self
+        self.completions = self
+        self._seen: set[int] = set()
+
+    def create(self, **kwargs):
+        self.calls.append(dict(kwargs))
+        cap = kwargs.get("max_tokens") or kwargs.get("max_completion_tokens")
+        empty = cap not in self._seen and cap is not None and cap < 4000
+        self._seen.add(cap)
+        content = None if empty else "ok"
+        return type("R", (), {
+            "choices": [type("C", (), {"message": type("M", (), {"content": content})()})()],
+            "usage": type("U", (), {
+                "prompt_tokens": 1, "completion_tokens": cap, "total_tokens": cap + 1})(),
+        })()
+
+
+def _client_at(url):
+    c = _Rejecting400()
+    c.base_url = url
+    return c
+
+
+def test_quirk_memory_is_not_shared_across_endpoints(monkeypatch):
+    """The same model name behind two providers must not share learned
+    quirks -- the judge split routinely does exactly this, and the two
+    endpoints do not accept the same params. A model-only cache key let one
+    provider's 400 silently strip a param from the other's requests."""
+    import lib.openai_calls as oc
+
+    monkeypatch.setattr(oc, "_MIN_CHAT_INTERVAL_SECONDS", 0.0)
+    first = _client_at("https://api.anthropic.com/v1/")
+    oc.create_chat_completion(
+        first, label="test", model="shared-name",
+        messages=[{"role": "user", "content": "hi"}], temperature=0.0, max_tokens=5,
+    )
+    # Learned there, and applied there: a second call skips the discovery 400.
+    oc.create_chat_completion(
+        first, label="test", model="shared-name",
+        messages=[{"role": "user", "content": "hi"}], temperature=0.0, max_tokens=5,
+    )
+    assert "temperature" not in first.calls[-1]
+
+    # Same model name, different endpoint: nothing inherited, so it still
+    # sends temperature and pays its own discovery cost.
+    other = _client_at("https://other.example/v1/")
+    oc.create_chat_completion(
+        other, label="test", model="shared-name",
+        messages=[{"role": "user", "content": "hi"}], temperature=0.0, max_tokens=5,
+    )
+    assert "temperature" in other.calls[0]
+
+
+def test_min_cap_floor_is_per_label(monkeypatch):
+    """The empty-at-cap floor is a property of the prompt as much as the
+    model: a judge call reasoning over a 30KB master needs a big budget, a
+    short call does not. Keying the floor by model alone let one call site
+    quietly multiply every other call site's token budget."""
+    import lib.openai_calls as oc
+
+    monkeypatch.setattr(oc, "_MIN_CHAT_INTERVAL_SECONDS", 0.0)
+    client = _EmptyBelowFloor()
+    client.base_url = "https://api.example/v1/"
+    oc.create_chat_completion(
+        client, label="eval_judge", model="thinky",
+        messages=[{"role": "user", "content": "hi"}], max_tokens=2000,
+    )
+    assert client.calls[-1]["max_tokens"] == 8000  # discovered the floor
+
+    # Same label reuses it without re-discovering.
+    oc.create_chat_completion(
+        client, label="eval_judge", model="thinky",
+        messages=[{"role": "user", "content": "hi"}], max_tokens=2000,
+    )
+    assert client.calls[-1]["max_tokens"] == 8000
+    judge_calls = len(client.calls)
+
+    # A different call site is unaffected -- it asks for what it asked for.
+    oc.create_chat_completion(
+        client, label="summarize", model="thinky",
+        messages=[{"role": "user", "content": "hi"}], max_tokens=6000,
+    )
+    assert client.calls[judge_calls]["max_tokens"] == 6000


### PR DESCRIPTION
Two cache keys in the runtime quirk memory (`lib/openai_calls.py`) were too coarse. Neither has misfired in production. Both are reachable from the judge split that is about to land, which is why they are worth closing now rather than after they bite.

## `_MODEL_REJECTED_PARAMS` — keyed by model name alone

The same model name served by two providers shared learned quirks. The judge split routinely creates exactly that shape: generator on foundry, judge on anthropic or openai, potentially the same model name behind both. Those endpoints do not accept the same params.

The failure direction is the bad one. A 400 observed at the judge's endpoint would silently strip a param from every subsequent *generator* request — and the generator needs what it sends. Now keyed by `base_url` + model.

## `_MODEL_MIN_CAP` — keyed by model alone

The empty-at-cap floor is a property of the prompt as much as of the model. An `eval_judge` call reasoning over a 30KB master resume discovers it needs 8000; a short call is fine at 2000. Sharing one floor across call sites let a single large caller quietly multiply every small caller's token budget — a cost and behavior change with no signal that it happened. Now keyed by `(endpoint+model, label)`.

`_memory_key` returns `""` for an unnamed model, which disables memory rather than lumping every unnamed call under one shared key.

## Does this cost back the win it was built for?

No. The `claude-sonnet-5` calibration run confirmed the memory working as intended — the `temperature` 400 fired once on call 1 of 25 and never again, against 3 requests per judge call before it existed. All 25 calls in that run share one endpoint, one model, and one label, so they still share one cache entry under the new keys.

## Tests

Two new cases, one per key:

- `test_quirk_memory_is_not_shared_across_endpoints` — a second endpoint inherits nothing and pays its own discovery 400, while the first endpoint's second call skips it.
- `test_min_cap_floor_is_per_label` — a second call site keeps the budget it asked for after another site discovered a higher floor.

The existing negative assertion that a failed retry does not poison the cache now checks the real key instead of a bare model name that is no longer one, so it stays meaningful rather than becoming vacuously true.

A name collision was caught before running: the new empty-at-cap fake would have shadowed the existing module-level `_EmptyAtCap` and broken `test_create_chat_completion_retries_empty_content_at_cap`, since Python resolves the class from module globals at call time. Renamed to `_EmptyBelowFloor`.

Full suite: **1868 passed, 17 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJAD4fQzurAG6zf1hcrg8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJAD4fQzurAG6zf1hcrg8P)_