### PR TITLE
fix(gpu-exporter): a dead client can no longer wedge the accept loop

### DIFF
--- a/scripts/gpu-exporter-install.txt
+++ b/scripts/gpu-exporter-install.txt
@@ -1,0 +1,43 @@
+# gpu-exporter install/update block (Windows, ELEVATED PowerShell).
+#
+# This file is referenced by scripts/gpu-exporter.ps1 but lived only in a
+# terminal scrollback until 2026-08-11 — the day the exporter wedged and the
+# task/firewall names had to be reverse-engineered from the live machine.
+# Names below match what is actually registered on the rig:
+#   scheduled task : jobcontext-gpu-exporter
+#   firewall rule  : jobcontext gpu exporter
+#   install path   : C:\ProgramData\jobcontext\gpu-exporter.ps1
+#
+# Idempotent: safe to re-run for UPDATES too — copies the current script over
+# the installed one and restarts the task. Run from the repo root.
+#
+# The task runs the ProgramData COPY, not the repo checkout. Pulling a fixed
+# script into the repo does nothing until this block is re-run.
+
+$dst = 'C:\ProgramData\jobcontext'
+New-Item -ItemType Directory -Force -Path $dst | Out-Null
+Copy-Item .\scripts\gpu-exporter.ps1 (Join-Path $dst 'gpu-exporter.ps1') -Force
+
+if (-not (Get-NetFirewallRule -DisplayName 'jobcontext gpu exporter' -ErrorAction SilentlyContinue)) {
+    # -Profile Any on purpose: Windows re-classifies networks (Private/Public)
+    # after updates, and a Private-scoped rule silently drops the Pi's scrapes.
+    New-NetFirewallRule -DisplayName 'jobcontext gpu exporter' -Direction Inbound `
+        -Action Allow -Protocol TCP -LocalPort 9106 -Profile Any | Out-Null
+}
+
+$action  = New-ScheduledTaskAction -Execute 'powershell.exe' `
+    -Argument '-NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File C:\ProgramData\jobcontext\gpu-exporter.ps1'
+$trigger = New-ScheduledTaskTrigger -AtLogOn
+Register-ScheduledTask -TaskName 'jobcontext-gpu-exporter' -Action $action -Trigger $trigger -Force | Out-Null
+
+# Restart so an update takes effect (and so a wedged instance dies). A wedged
+# PowerShell can survive Stop-ScheduledTask; the CIM sweep catches it.
+Stop-ScheduledTask -TaskName 'jobcontext-gpu-exporter' -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -Filter "Name='powershell.exe'" |
+    Where-Object CommandLine -match 'gpu-exporter' |
+    ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+Start-ScheduledTask -TaskName 'jobcontext-gpu-exporter'
+
+Start-Sleep 2
+curl.exe -s --max-time 3 http://localhost:9106/metrics | Select-Object -First 1
+# Expected: "# TYPE gpu_utilization_percent gauge". Anything else = not serving.

--- a/scripts/gpu-exporter.ps1
+++ b/scripts/gpu-exporter.ps1
@@ -17,8 +17,17 @@ $listener.Start()
 while ($true) {
     $client = $listener.AcceptTcpClient()
     try {
+        # BOTH directions get timeouts. The read timeout was here from day
+        # one; the missing WRITE timeout wedged the exporter on 2026-08-11: a
+        # scrape connection went half-dead during a LAN renumbering, Write()
+        # blocked forever on a full send buffer, and — this loop being
+        # single-threaded — every later connection (including localhost)
+        # timed out in the backlog while the task still showed "Running".
+        $client.ReceiveTimeout = 3000
+        $client.SendTimeout = 3000
         $stream = $client.GetStream()
         $stream.ReadTimeout = 3000
+        $stream.WriteTimeout = 3000
         $reader = New-Object System.IO.StreamReader($stream)
         while (($line = $reader.ReadLine()) -and $line -ne '') { }  # drain request
 


### PR DESCRIPTION
## The wedge (2026-08-11, diagnosed live)

`gpu-exporter.ps1` is deliberately a single-threaded `TcpListener` accept loop. It set a **read** timeout on the stream but no **write** timeout — so when a scrape connection went half-dead during today's RockMesh renumbering (asymmetric return path: the Pi reached the rig on-link, the rig replied via a gateway that only intermittently routed the legacy subnet), `Write()` blocked forever on a full send buffer. Single thread ⇒ the loop never returned to `AcceptTcpClient`, and every subsequent connection — **including `curl localhost:9106` on the rig itself** — timed out in the backlog. The scheduled task showed `Running` throughout, because the process was alive, just wedged.

The diagnostic chain that found it: board down → exporter verified fine locally → target IP drifted (`68.50` → `71.50`, fixed in #227) → still down → Pi host could reach the rig but intermittently → pod couldn't → finally *nothing* could, including localhost. That last step is what separates "network problem" from "exporter problem" — a localhost timeout has no network in the path.

## The fix

Timeouts in both directions: `ReceiveTimeout`/`SendTimeout` on the client socket, `WriteTimeout` alongside the existing `ReadTimeout` on the stream. A dead client now costs one 3-second exception — caught by the existing handler, connection closed, loop continues — instead of a permanent wedge.

## The install block finally exists

`gpu-exporter.ps1` has referenced `scripts/gpu-exporter-install.txt` since it was written; the file was never committed and lived only in terminal scrollback — today the task and firewall names had to be reverse-engineered from the live machine mid-incident. Now committed, with:

- the real names (`jobcontext-gpu-exporter` task, `jobcontext gpu exporter` rule, `C:\ProgramData\jobcontext\` path)
- idempotent re-run for **updates** — the task runs the ProgramData *copy*, so pulling a fixed script into the repo does nothing until this block is re-run; the block says so in bold
- a kill-sweep for exactly today's failure mode, because a wedged instance can survive `Stop-ScheduledTask`
- `-Profile Any` on the firewall rule, with the reason stated (Windows re-classifies networks after updates)

## Deployment note

Merging this changes nothing on the rig by itself. The fix lands when the install block is re-run on the Windows machine (elevated PowerShell, from the repo root, after pulling). No server/AKS impact — `deploy.yml` will run tests and deploy as usual but the diff is two script files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJAD4fQzurAG6zf1hcrg8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJAD4fQzurAG6zf1hcrg8P)_