### PR TITLE
feat(dashboards): header link buttons for touch screens

### DIFF
--- a/k8s/monitoring/grafana-dashboards.yaml
+++ b/k8s/monitoring/grafana-dashboards.yaml
@@ -10,6 +10,10 @@ data:
     {
      "uid": "jobcontext-overview",
      "title": "jobContext Overview",
+     "links": [
+      {"type": "link", "title": "⚙ Work stats — tokens, durations, quota", "icon": "external link",
+       "url": "https://jobcontext.ai/api/work/stats", "targetBlank": true}
+     ],
      "schemaVersion": 39,
      "refresh": "30s",
      "time": {
@@ -247,6 +251,12 @@ data:
     {
      "uid": "jobcontext-evals",
      "title": "jobContext Evals — resume quality",
+     "links": [
+      {"type": "link", "title": "📋 Run detail — alerts, flips, flagged claims", "icon": "external link",
+       "url": "https://jobcontext.ai/api/evals/results", "targetBlank": true},
+      {"type": "link", "title": "⚙ Work stats — tokens, durations, quota", "icon": "external link",
+       "url": "https://jobcontext.ai/api/work/stats", "targetBlank": true}
+     ],
      "schemaVersion": 39,
      "refresh": "1m",
      "time": {"from": "now-7d", "to": "now"},

--- a/k8s/monitoring/pi/grafana-pi.yaml
+++ b/k8s/monitoring/pi/grafana-pi.yaml
@@ -723,6 +723,10 @@ data:
   kiosk-evals.json: |
     {
       "uid": "kiosk-evals", "title": "Evals — resume quality (LLM-as-judge)", "tags": ["kiosk"],
+      "links": [
+        {"type": "link", "title": "📋 Run detail — alerts, flips, flagged claims", "icon": "external link",
+         "url": "https://jobcontext.ai/api/evals/results", "targetBlank": true}
+      ],
       "timezone": "browser", "refresh": "1m", "schemaVersion": 39,
       "time": {"from": "now-7d", "to": "now"},
       "panels": [


### PR DESCRIPTION
The drill-down links shipped in #227 are *data links* — hover a value, click. The wallboard is a touchscreen; there is no hover. Tapping a stat value does fire its single data link, but nothing tells a finger that's possible, and hitting a timeseries datapoint by touch is misery.

Dashboard-level `links` render as always-visible buttons in the header bar — one tap, no hover affordance needed:

- **jobContext Evals** (AKS): 📋 Run detail + ⚙ Work stats
- **jobContext Overview** (AKS): ⚙ Work stats
- **kiosk-evals** (Pi): 📋 Run detail

Data links stay for mouse users; both mechanisms point at the same authenticated endpoints (`/api/evals/results`, `/api/work/stats`, same-origin dashboard cookie).

All 9 embedded dashboard JSONs re-validated after the edit.

Same operational note as #227: `deploy.yml` doesn't apply `k8s/monitoring/` — AKS needs a `kubectl apply -f k8s/monitoring/grafana-dashboards.yaml`, the Pi needs `grafana-pi.yaml` + `grafana-dashboards.yaml` scp'd and applied, then a Grafana restart on each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJAD4fQzurAG6zf1hcrg8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJAD4fQzurAG6zf1hcrg8P)_