### PR TITLE
Promote qa → main: gpu-exporter wedge fix + touch-friendly dashboard links

### DIFF
--- a/k8s/monitoring/grafana-dashboards.yaml
+++ b/k8s/monitoring/grafana-dashboards.yaml
@@ -10,6 +10,10 @@ data:
     {
      "uid": "jobcontext-overview",
      "title": "jobContext Overview",
+     "links": [
+      {"type": "link", "title": "⚙ Work stats — tokens, durations, quota", "icon": "external link",
+       "url": "https://jobcontext.ai/api/work/stats", "targetBlank": true}
+     ],
      "schemaVersion": 39,
      "refresh": "30s",
      "time": {
@@ -247,6 +251,12 @@ data:
     {
      "uid": "jobcontext-evals",
      "title": "jobContext Evals — resume quality",
+     "links": [
+      {"type": "link", "title": "📋 Run detail — alerts, flips, flagged claims", "icon": "external link",
+       "url": "https://jobcontext.ai/api/evals/results", "targetBlank": true},
+      {"type": "link", "title": "⚙ Work stats — tokens, durations, quota", "icon": "external link",
+       "url": "https://jobcontext.ai/api/work/stats", "targetBlank": true}
+     ],
      "schemaVersion": 39,
      "refresh": "1m",
      "time": {"from": "now-7d", "to": "now"},

--- a/k8s/monitoring/pi/grafana-pi.yaml
+++ b/k8s/monitoring/pi/grafana-pi.yaml
@@ -723,6 +723,10 @@ data:
   kiosk-evals.json: |
     {
       "uid": "kiosk-evals", "title": "Evals — resume quality (LLM-as-judge)", "tags": ["kiosk"],
+      "links": [
+        {"type": "link", "title": "📋 Run detail — alerts, flips, flagged claims", "icon": "external link",
+         "url": "https://jobcontext.ai/api/evals/results", "targetBlank": true}
+      ],
       "timezone": "browser", "refresh": "1m", "schemaVersion": 39,
       "time": {"from": "now-7d", "to": "now"},
       "panels": [

--- a/scripts/gpu-exporter-install.txt
+++ b/scripts/gpu-exporter-install.txt
@@ -1,0 +1,43 @@
+# gpu-exporter install/update block (Windows, ELEVATED PowerShell).
+#
+# This file is referenced by scripts/gpu-exporter.ps1 but lived only in a
+# terminal scrollback until 2026-08-11 — the day the exporter wedged and the
+# task/firewall names had to be reverse-engineered from the live machine.
+# Names below match what is actually registered on the rig:
+#   scheduled task : jobcontext-gpu-exporter
+#   firewall rule  : jobcontext gpu exporter
+#   install path   : C:\ProgramData\jobcontext\gpu-exporter.ps1
+#
+# Idempotent: safe to re-run for UPDATES too — copies the current script over
+# the installed one and restarts the task. Run from the repo root.
+#
+# The task runs the ProgramData COPY, not the repo checkout. Pulling a fixed
+# script into the repo does nothing until this block is re-run.
+
+$dst = 'C:\ProgramData\jobcontext'
+New-Item -ItemType Directory -Force -Path $dst | Out-Null
+Copy-Item .\scripts\gpu-exporter.ps1 (Join-Path $dst 'gpu-exporter.ps1') -Force
+
+if (-not (Get-NetFirewallRule -DisplayName 'jobcontext gpu exporter' -ErrorAction SilentlyContinue)) {
+    # -Profile Any on purpose: Windows re-classifies networks (Private/Public)
+    # after updates, and a Private-scoped rule silently drops the Pi's scrapes.
+    New-NetFirewallRule -DisplayName 'jobcontext gpu exporter' -Direction Inbound `
+        -Action Allow -Protocol TCP -LocalPort 9106 -Profile Any | Out-Null
+}
+
+$action  = New-ScheduledTaskAction -Execute 'powershell.exe' `
+    -Argument '-NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File C:\ProgramData\jobcontext\gpu-exporter.ps1'
+$trigger = New-ScheduledTaskTrigger -AtLogOn
+Register-ScheduledTask -TaskName 'jobcontext-gpu-exporter' -Action $action -Trigger $trigger -Force | Out-Null
+
+# Restart so an update takes effect (and so a wedged instance dies). A wedged
+# PowerShell can survive Stop-ScheduledTask; the CIM sweep catches it.
+Stop-ScheduledTask -TaskName 'jobcontext-gpu-exporter' -ErrorAction SilentlyContinue
+Get-CimInstance Win32_Process -Filter "Name='powershell.exe'" |
+    Where-Object CommandLine -match 'gpu-exporter' |
+    ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+Start-ScheduledTask -TaskName 'jobcontext-gpu-exporter'
+
+Start-Sleep 2
+curl.exe -s --max-time 3 http://localhost:9106/metrics | Select-Object -First 1
+# Expected: "# TYPE gpu_utilization_percent gauge". Anything else = not serving.

--- a/scripts/gpu-exporter.ps1
+++ b/scripts/gpu-exporter.ps1
@@ -17,8 +17,17 @@ $listener.Start()
 while ($true) {
     $client = $listener.AcceptTcpClient()
     try {
+        # BOTH directions get timeouts. The read timeout was here from day
+        # one; the missing WRITE timeout wedged the exporter on 2026-08-11: a
+        # scrape connection went half-dead during a LAN renumbering, Write()
+        # blocked forever on a full send buffer, and — this loop being
+        # single-threaded — every later connection (including localhost)
+        # timed out in the backlog while the task still showed "Running".
+        $client.ReceiveTimeout = 3000
+        $client.SendTimeout = 3000
         $stream = $client.GetStream()
         $stream.ReadTimeout = 3000
+        $stream.WriteTimeout = 3000
         $reader = New-Object System.IO.StreamReader($stream)
         while (($line = $reader.ReadLine()) -and $line -ne '') { }  # drain request
 


### PR DESCRIPTION
Promotion of #229 and #230, both green through qa deploys (`0730fd3`, `7302e8d`).

- **#229** — the gpu-exporter's single-threaded accept loop gains send/write timeouts, so a half-dead scrape connection costs 3 seconds instead of wedging the exporter forever (today's incident: `Write()` blocked on a full send buffer during the LAN renumbering; everything after — including localhost — timed out while the task showed "Running"). Also commits the long-referenced-but-never-committed `scripts/gpu-exporter-install.txt`, with the real task/firewall names and a kill-sweep for the wedged state.
- **#230** — dashboard-header link buttons (📋 Run detail, ⚙ Work stats) on the eval and overview boards, because the wallboard is a touchscreen and data links require hover.

Post-merge, on the operator's side: re-run the install block on the rig (the task runs the ProgramData copy, not the repo), and `kubectl apply` the monitoring ConfigMaps to AKS + Pi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJAD4fQzurAG6zf1hcrg8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJAD4fQzurAG6zf1hcrg8P)_