### PR TITLE
Promote qa → main: numeric-integrity generation prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/version-1.4.0-blue" alt="Version 1.4.0"/>
-  <img src="https://img.shields.io/badge/tests-1968%20passing-brightgreen" alt="1968 tests passing"/>
+  <img src="https://img.shields.io/badge/tests-1970%20passing-brightgreen" alt="1970 tests passing"/>
   <a href="https://sonarcloud.io/component_measures?id=JustLikeFrank3_jobContextMCP&metric=coverage"><img src="https://sonarcloud.io/api/project_badges/measure?project=JustLikeFrank3_jobContextMCP&metric=coverage" alt="Coverage"/></a>
   <img src="https://img.shields.io/badge/tools-12%20domains%20%C2%B7%2096%20actions-informational" alt="12 domain tools, 96 actions"/>
   <img src="https://img.shields.io/badge/license-MIT-lightgrey" alt="MIT License"/>
@@ -39,7 +39,7 @@ jobContext keeps your job-search context structured and persistent, and exposes 
 | | |
 |---|---|
 | 12 MCP tools | 96 domain actions behind them |
-| 1968 passing tests | Resume + cover letter generation with a deterministic truth gate |
+| 1970 passing tests | Resume + cover letter generation with a deterministic truth gate |
 | SQLite persistence + JSON audit trail | Job fitment analysis with persona lenses |
 | Local RAG semantic search | Interview prep + debrief logging |
 | Desktop app (macOS · Windows · Linux) | Outreach + relationship tracking |

--- a/templates/latex_assets/sections/experience.tex
+++ b/templates/latex_assets/sections/experience.tex
@@ -5,7 +5,7 @@
 \subsection{{\textbf{Senior Software Engineer} \textit{\ \ Contoso Cloud, Remote} \hfill 20XX --- Present}}
 \begin{zitemize}
 \item Led design and delivery of a customer-facing service from architecture through production and on-call; quantify the impact here (latency, scale, revenue, or adoption).
-\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1968 passing tests at 80\%+ line coverage through disciplined TDD.
+\item Built and maintained a CI pipeline that runs the full suite on every deploy; hold 1970 passing tests at 80\%+ line coverage through disciplined TDD.
 \item Drove a cross-team win — a migration, a shared API pattern others adopted, or an SLA target consistently met.
 \end{zitemize}
 %====================

--- a/tests/test_generate_coverage.py
+++ b/tests/test_generate_coverage.py
@@ -337,3 +337,27 @@ def test_generate_resume_corrects_before_saving(isolated_server, monkeypatch):
     assert saved["content"] == "Cut latency 34%.", "the fabricated draft was saved"
     assert "99.99%" not in out
     assert "Provenance: ✓ PASS" in out
+
+
+class TestNumericIntegrityRules:
+    """The 2026-08-12 nightly flagged hallucinations in every run AFTER the
+    correction loop -- all in classes the regex gate cannot see (scope-shifted
+    numbers, double-counted metrics, reconstructed figures). These rules are
+    the prompt-side countermeasure; pin them so a later prompt edit doesn't
+    silently drop the constraints the eval trend depends on."""
+
+    def test_resume_prompt_carries_the_three_rules(self):
+        from tools.generate_prompts import RESUME_SYSTEM
+
+        assert "NUMERIC INTEGRITY" in RESUME_SYSTEM
+        assert "never migrate to a different claim" in RESUME_SYSTEM   # scope-shift
+        assert "WITHOUT a\n   number" in RESUME_SYSTEM.replace("    ", "   ") or \
+               "WITHOUT a" in RESUME_SYSTEM                            # verbatim-or-omit
+        assert "EXACTLY ONE place" in RESUME_SYSTEM                    # anti-double-count
+
+    def test_cover_letter_prompt_carries_the_rules(self):
+        from tools.generate_prompts import COVER_LETTER_SYSTEM
+
+        assert "NUMERIC INTEGRITY" in COVER_LETTER_SYSTEM
+        assert "never moved onto a different claim" in COVER_LETTER_SYSTEM
+        assert "at most once" in COVER_LETTER_SYSTEM

--- a/tools/generate_prompts.py
+++ b/tools/generate_prompts.py
@@ -238,6 +238,20 @@ RESUME_SYSTEM = textwrap.dedent("""\
     achievements, and company names must come verbatim from the master resume —
     do not invent or embellish anything.
 
+    NUMERIC INTEGRITY — these rules override brevity, style, and completeness:
+    1. Copy every number VERBATIM from the sources, keeping its unit AND the noun
+       it measures. A number may never migrate to a different claim: if a source
+       says a corpus indexes for under $0.10 in total, that figure cannot become
+       a per-query cost. If a source says 1,481 tests, the resume says 1,481 —
+       never a rounded, recalled, or recomputed variant.
+    2. If the exact number is not in your sources, write the claim WITHOUT a
+       number. Never estimate, combine two figures, or reconstruct one from
+       memory. A bullet with no metric is acceptable; a bullet with an invented
+       metric is the single worst failure this document can have.
+    3. Each metric appears in EXACTLY ONE place. One body of work is listed once,
+       in one section — never as both an employment bullet and a separate project
+       entry, and never with its headline numbers restated in a summary line.
+
     The PROJECTS section is REQUIRED — do not omit it. Include 2–3 side projects
     from the master resume that are most relevant to the target role. Select based
     on what the JD emphasizes — all project names and metrics must come verbatim
@@ -275,6 +289,12 @@ COVER_LETTER_SYSTEM = textwrap.dedent("""\
     - Metrics live in the ownership paragraphs; every claim there is specific and
       uses numbers verbatim from the master resume. Do not stuff a metric into
       every sentence, and do not pad to hit a length.
+    - NUMERIC INTEGRITY overrides everything above: a number is copied verbatim
+      with its unit and the noun it measures, never moved onto a different claim,
+      never estimated or reconstructed. If the exact figure is not in your
+      sources, make the point without a number — a sentence with no metric is
+      fine; a sentence with an invented one is disqualifying. Each metric
+      appears at most once in the letter.
     - Conversational but not casual; no filler phrases, no corporate speak.
     - A side project earns a place only when it is the strongest match to the job
       description, not as a mandatory section. Use metrics verbatim from the


### PR DESCRIPTION
Promotion of #241 — the three numeric-integrity rules (noun-locked numbers, verbatim-or-omit, each-metric-once) in both generation prompts. Full qa pipeline green on `675a5ba`: tests (1,970), smoke gate, badges, qa deploy.

Measurement follows the deploy: targeted eval run on GD-01 + GD-04 against the 08-12 baseline, with `prompt_version` making the comparison attributable per document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJAD4fQzurAG6zf1hcrg8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJAD4fQzurAG6zf1hcrg8P)_