### PR TITLE
fix: bundle stories trim must use the same token estimator as the ceiling

### DIFF
--- a/lib/io.py
+++ b/lib/io.py
@@ -123,12 +123,19 @@ def _format_personal_stories(stories_token_budget: int | None = None) -> str:
             blocks.append("\n".join(lines))
 
     if stories_token_budget is not None:
-        # ~4 chars/token, matching lib.story_retrieval.estimate_tokens. Whole-
+        # Same estimator the prompt builders use to measure headroom (tiktoken
+        # when installed, chars/4 otherwise). Mixing estimators here — chars/4
+        # trim vs tiktoken headroom — let a "fitting" stories section overshoot
+        # the ceiling, and the last-resort ceiling guard truncates the prompt
+        # TAIL, i.e. the format spec, not the stories (caught by CI, where
+        # tiktoken is installed, on the first qa run of this feature). Whole-
         # story granularity: a half-story invites the model to complete it.
+        from lib.story_retrieval import estimate_tokens  # noqa: PLC0415 — lazy: story_retrieval imports lib.io
+
         kept: list[str] = []
         used = 0
         for block in blocks:
-            cost = max(1, len(block) // 4)
+            cost = estimate_tokens(block) + 2  # +2 ≈ the "\n\n" join
             if used + cost > stories_token_budget:
                 break
             kept.append(block)
@@ -199,13 +206,21 @@ def _load_master_context(stories_token_budget: int | None = None) -> str:
     # used in generated documents exactly as written. This section is LAST so a
     # token-budgeted trim only ever shortens the stories tail — the sections
     # above stay byte-identical for every consumer of the bundle.
-    stories_text = _format_personal_stories(stories_token_budget)
+    stories_header = (
+        "──── STORIES (first-person stories — part of the source of truth) ────\n"
+        "(Facts, numbers, names, and dates below are citable exactly as written; "
+        "adapt wording to the target role but never alter a number, name, or date)\n"
+    )
+    if stories_token_budget is None:
+        effective_budget = None
+    else:
+        # The header spends from the same budget the caller measured headroom
+        # for — an uncounted header is a small, silent ceiling overshoot.
+        from lib.story_retrieval import estimate_tokens  # noqa: PLC0415 — lazy: story_retrieval imports lib.io
+
+        effective_budget = max(0, stories_token_budget - estimate_tokens(stories_header))
+    stories_text = _format_personal_stories(effective_budget)
     if stories_text:
-        parts.append(
-            "──── STORIES (first-person stories — part of the source of truth) ────\n"
-            "(Facts, numbers, names, and dates below are citable exactly as written; "
-            "adapt wording to the target role but never alter a number, name, or date)\n"
-            + stories_text
-        )
+        parts.append(stories_header + stories_text)
 
     return "\n\n".join(parts)

--- a/tests/test_generate_coverage.py
+++ b/tests/test_generate_coverage.py
@@ -94,9 +94,18 @@ def test_build_resume_user_message_trims_stories_not_the_format_spec(isolated_se
     captured: list = []
 
     def fake_bundle(stories_token_budget=None):
+        # Fill the granted budget exactly as production does: measured with the
+        # SAME estimator the builder uses (tiktoken in CI, chars/4 without it).
+        # A chars-imply-tokens shortcut here failed on CI's tiktoken while
+        # passing on the fallback estimator — the bug it caught was real and
+        # is now fixed in _format_personal_stories, which shares the estimator.
         captured.append(stories_token_budget)
-        stories = "S" * (4 * (stories_token_budget or 0))
-        return "MASTER\n" + stories
+        if not stories_token_budget:
+            return "MASTER"
+        words: list = []
+        while generate.estimate_tokens(" ".join([*words, "story"])) <= stories_token_budget:
+            words.append("story")
+        return "MASTER\n" + " ".join(words)
 
     monkeypatch.setattr(generate.config, "get_generation_budgets", lambda: {
         "resume_max_tokens": 2000,

--- a/tests/test_master_bundle.py
+++ b/tests/test_master_bundle.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import json
 
 from lib import config
-from lib.io import _format_personal_stories, _load_master_context
+from lib.io import _load_master_context
 
 
 def _seed_stories() -> None:
@@ -65,10 +65,17 @@ def test_budgeted_bundle_is_a_prefix_of_the_full_bundle(isolated_server):
     every generator-visible fact is judge-visible."""
     _seed_stories()
     full = _load_master_context()
-    first_story_cost = max(1, len(_format_personal_stories().split("\n\n")[0]) // 4)
-    trimmed = _load_master_context(stories_token_budget=first_story_cost)
+    # Find the smallest budget that admits the first story, by scanning rather
+    # than reimplementing the estimator (tiktoken vs chars/4 varies by env).
+    # At that exact boundary the second story cannot also fit, so this pins
+    # whole-story granularity too.
+    trimmed = next(
+        (t for b in range(1, 500)
+         if "1,491" in (t := _load_master_context(stories_token_budget=b))),
+        None,
+    )
+    assert trimmed is not None
     assert full.startswith(trimmed)
-    assert "1,491" in trimmed          # first story fit
     assert "Miami Beach" not in trimmed  # tail trimmed, whole-story granularity
 
 


### PR DESCRIPTION
Fixes the CI failure on #243's qa merge (`test_build_resume_user_message_trims_stories_not_the_format_spec`).

**Root cause**: the STORIES trim in `_format_personal_stories` counted chars/4, but the prompt builder measures headroom with `lib.story_retrieval.estimate_tokens` — which is **tiktoken wherever the package is installed** (CI, prod) and chars/4 only as an import-failure fallback (which is why the full suite passed in my sandbox but failed on the runner). A stories section that "fit" its budget under one estimator could overshoot the ceiling under the other, and the last-resort ceiling guard truncates the prompt **tail** — the format spec and final instruction — not the stories. The failing test was doing its job: that's the exact catastrophe it pins.

**Fix**: one estimator everywhere.
- `_format_personal_stories` trims with `estimate_tokens` (+2/block for the `\n\n` join), lazily imported since `story_retrieval` imports `lib.io`.
- The STORIES section header now spends from the same budget the caller measured — an uncounted header was a small, silent overshoot on top.
- The trim test sizes its fake bundle with the same estimator instead of assuming chars imply tokens; the prefix test scans for the boundary budget instead of reimplementing estimator arithmetic.

Full suite: 1978 passed, 17 skipped (fallback estimator — the sandbox proxy blocks tiktoken's BPE download, so CI's tiktoken run is the real confirmation for the other leg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJAD4fQzurAG6zf1hcrg8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJAD4fQzurAG6zf1hcrg8P)_